### PR TITLE
chore: release v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.3] - 2025-10-05
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrate repository to anelson-labs
+- (Hopefully) get dist working on aarch64
+- Try to fix release-plz PR creation using correct token
 
 ## [0.0.2] - 2025-10-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "cgx"
-version = "0.0.2"
+version = "0.0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name         = "cgx"
 readme       = "README.md"
 repository   = "https://github.com/anelson-labs/cgx"
 rust-version = "1.85.1"
-version      = "0.0.2"
+version      = "0.0.3"
 
 [lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION



## 🤖 New release

* `cgx`: 0.0.2 -> 0.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.3] - 2025-10-05

### ⚙️ Miscellaneous Tasks

- Migrate repository to anelson-labs
- (Hopefully) get dist working on aarch64
- Try to fix release-plz PR creation using correct token
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).