### PR TITLE
docs: Update README with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/anelson-labs/cgx/actions/workflows/ci.yml/badge.svg)](https://github.com/anelson-labs/cgx/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cgx?link=https%3A%2F%2Fcrates.io%2Fcrates%2Fcgx)](https://crates.io/crates/cgx)
-![Deps.rs Crate Dependencies (latest)](https://img.shields.io/deps-rs/cgx/latest)
+![license](https://img.shields.io/crates/l/cgx.svg)
 
 Execute Rust crates easily and quickly. Like `uvx` or `npx` for Rust.
 


### PR DESCRIPTION
My intention was to make specialized installation scripts as part of
this task, but it turns out that the ones generated by `cargo-dist` are
actually quite robust and probably sufficient for now.  So instead the
changes are to the README with revised installation instructions.

Whilst I had the hood up I also added more vanity shields to the README.

Closes #49