### PR TITLE
feat: Add `--refresh` flag to bypass cache

### DIFF
--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -225,6 +225,15 @@ pub struct CliArgs {
     #[arg(long)]
     pub no_exec: bool,
 
+    /// Force refresh of all cached data for this crate.
+    ///
+    /// When set, cgx will bypass all cache lookups and perform fresh resolution, download, and
+    /// build operations. This also disables the fallback to stale cache entries on network errors,
+    /// so cgx will fail if a network error occurs rather than using potentially outdated cached
+    /// data.
+    #[arg(long)]
+    pub refresh: bool,
+
     /// List the crate's executable targets (bins and examples) without building or executing.
     ///
     /// Performs resolve and download operations, then inspects the crate's Cargo.toml

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -151,6 +151,8 @@ pub struct Config {
 
     pub locked: bool,
 
+    pub refresh: bool,
+
     /// Rust toolchain to use for building (e.g., "nightly", "1.70.0", "stable")
     pub toolchain: Option<String>,
 
@@ -189,6 +191,7 @@ impl Default for Config {
             resolve_cache_timeout: Duration::from_secs(3600),
             offline: false,
             locked: true,
+            refresh: false,
             toolchain: None,
             log_level: None,
             default_registry: None,
@@ -303,6 +306,7 @@ impl Config {
                 .unwrap_or_else(|| Duration::from_secs(60 * 60)),
             offline: config_file.offline.unwrap_or(false),
             locked: config_file.locked.unwrap_or(true),
+            refresh: args.refresh,
             toolchain: config_file.toolchain,
             log_level: config_file.log_level,
             default_registry: config_file.default_registry,


### PR DESCRIPTION
Users can now pass `--refresh` to force cgx to bypass all cache lookups and perform fresh resolution, download, and build operations. This is useful when users want to ensure they are working with the latest data and not stale cached entries, and may also be helpful in certain cases for troubleshooting.

Closes #52