### PR TITLE
ci: Configure cargo-dist to exclude cargo-cgx from release text

### DIFF
--- a/cargo-cgx/dist.toml
+++ b/cargo-cgx/dist.toml
@@ -1,0 +1,6 @@
+# Customize cargo-dist handling of this package specifically
+
+[dist]
+# Generate release binaries for this package, and include them in the Github release, but do not mention this package or
+# its install instructions or change log in the Github release text.
+display = false

--- a/deny.toml
+++ b/deny.toml
@@ -63,7 +63,7 @@ skip = [
   { name = "windows-strings", version = "0.4" },
 ]
 skip-tree = [
-  # vergen-gix (build dep) uses gix 0.71, we use 0.73
+  # vergen-gix (build dep) uses older gix 0.71
   # Can't upgrade vergen-gix to 2.x (requires Rust 1.88, we're on 1.85)
   # Can't use [patch] to force version (patch requires different source)
   { name = "gix", version = "0.71" },


### PR DESCRIPTION
I still want `cargo-cgx` binaries to be in the release, but I don't want to see install instructions and changelog.  `cargo-cgx` is literally just `cgx` but re-packaged as `cargo-cgx` for convenience for users who prefer to run it that way.  It's distracting and confusing to have it listed in the release text.