### PR TITLE
docs(claude): forbid the Claude co-author trailer in commits

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit:*)",
+            "command": "cmd=$(jq -r '.tool_input.command'); printf '%s' \"$cmd\" | grep -qE '(^|[[:space:]&|;])git[[:space:]]+commit([[:space:]]|$)' || exit 0; printf '%s' \"$cmd\" | grep -qiE 'co-authored-by.*anthropic\\.com' && printf '%s\\n' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"This commit message contains a Co-Authored-By trailer referencing anthropic.com. This repository forbids the Claude/Anthropic co-author trailer (see CLAUDE.md). Remove the trailer line from the commit message and retry.\"}}' || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ It also offers `ensure!` macros, which are like `assert!` but return an error in
 
 You can assume that the `gh` CLI is available to you to interact with Github. You can use the `git` CLI as needed, however you are strictly prohibited from staging, unstaging, committing, or revering any files under source control unless you have been explicitly asked to do so.
 
+**Never** add a `Co-Authored-By: Claude ...` or any `Co-Authored-By: ... @anthropic.com` trailer to commit messages or PR descriptions in this repository. This applies to commits you author directly, squash-merge commit bodies, and PR descriptions. Do not include the trailer even if a default workflow or template suggests it. The repo's contributors graph is polluted by these trailers, so they are forbidden here. A `PreToolUse` hook in `.claude/settings.json` will block any `git commit` invocation that includes the trailer; the hook is a backstop, not a license to attempt the commit.
+
 ## Instructions
 
 ### Build & Run Commands


### PR DESCRIPTION
Pollution from Claude co-author trailers (the ones referencing the Anthropic noreply address) was registering a "claude" account on the repo's contributors graph.  This is shitty growth-hacking clout-chasing behavior that I despise.  Just because I told the agent to draft an AI slop commit message for me or to baby-sit dependabot PRs to make sure that they land doesn't make the agent a "contributor".

This wouldn't be so bad except that the "claude" contributor on GH projects may as well be an "AI slop" badge.  I myself nope out of projects I see posted on HN as soon as I see the claude contributor, since I've been conditioned that it means the repo owner is some clueless performer who doesn't care enough about their project to even clean up the AI slop.  That's not what is happening here, but I would not be at all surprised if random passersby see the "claude" contributor and jump to the conclusion that this is yet another AI slop project.

This adds layered defenses to keep claude out of future commits:

- `CLAUDE.md`: new paragraph in the Git instructions section explicitly forbidding the trailer in commit bodies and PR descriptions, regardless of any default workflow that might otherwise add it.  Of course we know that agents will often ignore this, so it's just the first layer of defense.
- `.claude/settings.json`: set `attribution.commit` and `attribution.pr` to empty so the harness never injects the trailer in the first place. Add a `PreToolUse` hook on `Bash` that intercepts `git commit` invocations and denies any whose command contains the forbidden trailer line, serving as a backstop if the attribution setting is bypassed or overridden.

The three previously-merged commits on `master` that carried the trailer (#148, #150, #159) were rewritten in a separate force-push; this commit only addresses prevention going forward.