### PR TITLE
chore: release v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.10] - 2026-05-28
+
+### 💼 Other
+
+- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson-labs/cgx/pull/150))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+
+### 🛡️ Security
+
+- *(deps)* Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson-labs/cgx/pull/148))
 ## [0.0.9] - 2026-03-14
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-cgx"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "assert_cmd",
  "cgx",
@@ -476,7 +476,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgx"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "assert-json-diff",
  "assert_cmd",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "cgx-core"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "assert-json-diff",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ build-context      = "0.1.4"
 bytes              = "1"
 bzip2              = "0.6.1"
 cargo_metadata     = "0.20.0"
-cgx                = { version = "0.0.9", path = "cgx" }
-cgx-core           = { version = "0.0.9", path = "cgx-core" }
+cgx                = { version = "0.0.10", path = "cgx" }
+cgx-core           = { version = "0.0.10", path = "cgx-core" }
 chrono             = { version = "0.4.44", features = ["serde"] }
 clap               = { version = "4.6.1", features = ["derive", "env", "string", "unicode"] }
 ctrlc              = "3.5"

--- a/cargo-cgx/Cargo.toml
+++ b/cargo-cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cargo-cgx"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.9"
+version                = "0.0.10"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cgx-core/Cargo.toml
+++ b/cgx-core/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx-core"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.9"
+version                = "0.0.10"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/cgx/Cargo.toml
+++ b/cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.9"
+version                = "0.0.10"
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION



## 🤖 New release

* `cgx-core`: 0.0.9 -> 0.0.10 (✓ API compatible changes)
* `cgx`: 0.0.9 -> 0.0.10 (✓ API compatible changes)
* `cargo-cgx`: 0.0.9 -> 0.0.10

<details><summary><i><b>Changelog</b></i></summary><p>


## `cgx`

<blockquote>

## [0.0.10] - 2026-05-28

### 💼 Other

- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson-labs/cgx/pull/150))

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies

### 🛡️ Security

- *(deps)* Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson-labs/cgx/pull/148))
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).