### PR TITLE
ci: Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,35 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
+    # Defense against supply chain attacks: wait until a release has been public
+    # for 7 days before proposing an update. Malicious releases tend to be
+    # discovered and yanked relatively quickly, so a short delay lets the
+    # ecosystem catch most of them before we pull them in.
+    cooldown:
+      default-days: 7
+    # Batch routine minor/patch bumps into a single PR per ecosystem to cut PR
+    # and CI volume. Majors are left ungrouped so each gets its own PR to review.
+    groups:
+      cargo-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
     exclude-paths:
       # This is managed by `cargo-dist`; if it gets modified by dependabot then
       #cargo-dist detects that and fails

--- a/cgx-core/src/lib.rs
+++ b/cgx-core/src/lib.rs
@@ -30,6 +30,9 @@ use error::Result;
 use http::HttpClient;
 use std::sync::Arc;
 
+// Re-export this third-party crate type that is nonetheless part of this crate's public API
+pub use cargo_metadata::Target;
+
 /// Instance of the engine that powers the `cgx` tool.
 ///
 /// This is packaged this way so that our `main.rs` is as minimal as possible.  That's useful for a
@@ -155,12 +158,7 @@ impl Cgx {
         &self,
         crate_spec: &CrateSpec,
         build_options: &BuildOptions,
-    ) -> Result<(
-        String,
-        Option<cargo_metadata::Target>,
-        Vec<cargo_metadata::Target>,
-        Vec<cargo_metadata::Target>,
-    )> {
+    ) -> Result<(String, Option<Target>, Vec<Target>, Vec<Target>)> {
         let resolved_crate = self.resolver.resolve(crate_spec)?;
         let crate_name = resolved_crate.name.clone();
         let downloaded_crate = self.downloader.download(resolved_crate)?;

--- a/cgx/src/lib.rs
+++ b/cgx/src/lib.rs
@@ -1,15 +1,15 @@
 pub mod logging;
+mod reporter;
 
 use cgx_core::{
+    Target,
     builder::BuildOptions,
     cli::{CliArgs, MessageFormat},
     config::Config,
     cratespec::CrateSpec,
     error,
-    messages::{Message, MessageReporter},
 };
-use std::io::Write;
-use tracing::*;
+use std::ffi::OsString;
 
 // Re-export key types from cgx-core for convenience
 pub use cgx_core::{
@@ -68,63 +68,104 @@ pub fn cgx_main() -> Result<()> {
     let crate_spec = CrateSpec::load(&config, &args)?;
     let build_options = BuildOptions::load(&config, &args.build_options, args.verbose)?;
 
-    const MESSAGE_CHANNEL_SIZE: usize = 100;
-
-    // Set up a channel reporter to run in a separate thread.
-    // This thread handles:
-    // 1. CargoStderrChunk messages: echoed to stderr
-    // 2. All messages in JSON mode: serialized to stdout
+    // Spawn a separate thread that will handle messages from the cgx core and report them to the user
+    // in the appropriate way.
     let json_mode = matches!(args.message_format, Some(MessageFormat::Json));
-    let (tx, rx) = std::sync::mpsc::sync_channel(MESSAGE_CHANNEL_SIZE);
-    let reporter_thread = std::thread::spawn(move || {
-        debug!("Starting message reporter thread");
-        for msg in rx {
-            // Handle CargoStderrChunk by echoing to stderr
-            if let Message::Build(messages::BuildMessage::CargoStderr { ref bytes }) = msg {
-                let _ = std::io::stderr().write_all(bytes);
-                let _ = std::io::stderr().flush();
-            }
+    let reporter_thread = reporter::ReporterThread::spawn(json_mode);
 
-            // In JSON mode, serialize all messages to stdout
-            if json_mode {
-                match serde_json::to_string(&msg) {
-                    Ok(json) => println!("{}", json),
-                    Err(e) => eprintln!("Failed to serialize message: {}", e),
-                }
-            }
+    // Decode and prepare the command that the user wants to execute based on the args and env.
+    // This is where the heavy lifting happens.
+    let result = prepare_command(&reporter_thread, config, crate_spec, build_options, args);
+
+    // Success or failure, there will be no more messages produced after this point, so join the
+    // reporter thread to make sure we've processed any that were emitted before we proceed
+    reporter_thread.join();
+
+    match result? {
+        Command::NoExec { bin_path } => {
+            // Print path to stdout for scripting (e.g., binary=$(cgx --no-exec tool))
+            println!("{}", bin_path.display());
+            return Ok(());
         }
-        debug!("Message reporter thread exiting");
-    });
-    let reporter = MessageReporter::channel(tx);
+        Command::Execute {
+            bin_path,
+            binary_args,
+        } => {
+            // Run the binary - this function never returns on success
+            // It either replaces the process (Unix) or exits with the child's code (Windows)
+            cgx_core::runner::run(&bin_path, &binary_args)
+        }
+        Command::ListTargets {
+            crate_name,
+            default,
+            bins,
+            examples,
+        } => {
+            // Ensure there are executable targets
+            if bins.is_empty() && examples.is_empty() {
+                return error::NoPackageBinariesSnafu { krate: crate_name }.fail();
+            }
 
-    let cgx = cgx_core::Cgx::new(config, reporter.clone())?;
+            println!(
+                "default_run: {}",
+                default
+                    .map(|target| target.name)
+                    .as_deref()
+                    .unwrap_or("<not set>")
+            );
+            // Print bins with default indication
+            for bin in bins {
+                println!("bin: {}", bin.name);
+            }
+
+            // Print examples
+            for example in examples {
+                println!("example: {}", example.name);
+            }
+
+            return Ok(());
+        }
+    }
+}
+
+/// Possible successful results of [`prepare_command`]
+enum Command {
+    /// Binary is ready to go but user requested `--no-exec` so just print the path we'd execute
+    NoExec { bin_path: std::path::PathBuf },
+    /// Binary has been prepared and we're ready to execute it with a given args
+    Execute {
+        bin_path: std::path::PathBuf,
+        binary_args: Vec<OsString>,
+    },
+    /// User just asked to list available targets of the crate
+    ListTargets {
+        crate_name: String,
+        default: Option<Target>,
+        bins: Vec<Target>,
+        examples: Vec<Target>,
+    },
+}
+
+/// Internal implementation that does the actual work of decoding the args, determinine that
+/// command the user wants performed, and preparing the environment as needed.
+fn prepare_command(
+    reporter_thread: &reporter::ReporterThread,
+    config: Config,
+    crate_spec: CrateSpec,
+    build_options: BuildOptions,
+    args: CliArgs,
+) -> Result<Command> {
+    let cgx = cgx_core::Cgx::new(config, reporter_thread.message_reporter().clone())?;
 
     if args.list_targets {
         let (crate_name, default, bins, examples) = cgx.list_targets(&crate_spec, &build_options)?;
 
-        // Ensure there are executable targets
-        if bins.is_empty() && examples.is_empty() {
-            return error::NoPackageBinariesSnafu { krate: crate_name }.fail();
-        }
-
-        println!(
-            "default_run: {}",
-            default
-                .map(|target| target.name)
-                .as_deref()
-                .unwrap_or("<not set>")
-        );
-        // Print bins with default indication
-        for bin in bins {
-            println!("bin: {}", bin.name);
-        }
-
-        // Print examples
-        for example in examples {
-            println!("example: {}", example.name);
-        }
-
-        return Ok(());
+        return Ok(Command::ListTargets {
+            crate_name,
+            default,
+            bins,
+            examples,
+        });
     }
 
     let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
@@ -133,24 +174,16 @@ pub fn cgx_main() -> Result<()> {
     let binary_args = CrateSpec::get_binary_args(&args);
 
     // Report the execution plan
-    reporter.report(|| messages::RunnerMessage::execution_plan(&bin_path, &binary_args, args.no_exec));
-
-    // Drop everything that can report messages, once all senders are dropped then the reporter
-    // thread will exit cleanly.
-    drop(reporter);
-    drop(cgx);
-
-    // Wait for reporter thread to finish
-    debug!("Waiting for reporter thread to finish");
-    let _ = reporter_thread.join();
+    reporter_thread
+        .message_reporter()
+        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &binary_args, args.no_exec));
 
     if args.no_exec {
-        // Print path to stdout for scripting (e.g., binary=$(cgx --no-exec tool))
-        println!("{}", bin_path.display());
-        return Ok(());
+        Ok(Command::NoExec { bin_path })
+    } else {
+        Ok(Command::Execute {
+            bin_path,
+            binary_args,
+        })
     }
-
-    // Run the binary - this function never returns on success
-    // It either replaces the process (Unix) or exits with the child's code (Windows)
-    cgx_core::runner::run(&bin_path, &binary_args)
 }

--- a/cgx/src/reporter.rs
+++ b/cgx/src/reporter.rs
@@ -1,0 +1,69 @@
+//! Reporter logic that takes messages from the cgx core impl and pushes them out to the user in
+//! the appropriate way.
+use std::io::Write;
+
+use cgx_core::messages;
+use tracing::*;
+
+const MESSAGE_CHANNEL_SIZE: usize = 100;
+
+/// Handle to the thread that is responsible for reporting messages to the user.
+///
+/// This thread pulls messages from the [`messages::MessageReporter`] passed to the cgx core,
+/// and processes them for display to the user.
+pub(crate) struct ReporterThread {
+    reporter_thread: std::thread::JoinHandle<()>,
+    message_reporter: messages::MessageReporter,
+}
+
+impl ReporterThread {
+    /// Set up a channel reporter to run in a separate spawned thread.
+    /// This thread handles:
+    /// 1. `CargoStderrChunk` messages: echoed to stderr
+    /// 2. All messages in JSON mode: serialized to stdout
+    pub(crate) fn spawn(json_mode: bool) -> Self {
+        let (tx, rx) = std::sync::mpsc::sync_channel(MESSAGE_CHANNEL_SIZE);
+        let reporter_thread = std::thread::spawn(move || {
+            debug!("Starting message reporter thread");
+            for msg in rx {
+                // Handle CargoStderrChunk by echoing to stderr
+                if let messages::Message::Build(messages::BuildMessage::CargoStderr { ref bytes }) = msg {
+                    let _ = std::io::stderr().write_all(bytes);
+                    let _ = std::io::stderr().flush();
+                }
+
+                // In JSON mode, serialize all messages to stdout
+                if json_mode {
+                    match serde_json::to_string(&msg) {
+                        Ok(json) => println!("{}", json),
+                        Err(e) => eprintln!("Failed to serialize message: {}", e),
+                    }
+                }
+            }
+            debug!("Message reporter thread exiting");
+        });
+        let message_reporter = messages::MessageReporter::channel(tx);
+        Self {
+            reporter_thread,
+            message_reporter,
+        }
+    }
+
+    /// Get the instance of `MessageReporter` that can be used to pass messages to this
+    /// reporter's thread.
+    ///
+    /// This is cheap to clone.
+    pub(crate) fn message_reporter(&self) -> &messages::MessageReporter {
+        &self.message_reporter
+    }
+
+    /// Block until the reporter thread exits.
+    ///
+    /// That wont' happen until every clone of the `MessageReporter` has been dropped.
+    /// Make sure not to call this from code that still holds a clone of the `MessageReporter` or it
+    /// will deadlock.
+    pub(crate) fn join(self) {
+        drop(self.message_reporter);
+        let _ = self.reporter_thread.join();
+    }
+}


### PR DESCRIPTION
- Add a `cooldown` of 7 days to all updates to give the ecosystem time to catch malicious releases before we pull them in.
- Use the new `groups` feature to batch routine minor/patch bumps into a single PR per ecosystem to cut PR and CI volume.
- Raise the number of open PRs limit to 20 to give dependabot more room to work with

Closes #187 

Somewhat sloppily, this also includes an unrelated commit that fixes some flaky tests, the flakiness of which is preventing the checks from passing on this PR.  It takes SO LONG to run these checks that it's not worth it to do this the Right Way, that is making a separate PR to land the fix, then rebasing this one, running all the checks again, just to land them.