### PR TITLE
Move from `anelson-labs/cgx` to `anelson/cgx`

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-    if: ${{ github.repository_owner == 'anelson-labs' }}
+    if: ${{ github.repository_owner == 'anelson' }}
     steps:
       - &checkout
         name: Checkout repository
@@ -44,7 +44,7 @@ jobs:
     concurrency:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
-    if: ${{ github.repository_owner == 'anelson-labs' }}
+    if: ${{ github.repository_owner == 'anelson' }}
     steps:
       - *checkout
       - *install-rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 💼 Other
 
-- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson-labs/cgx/pull/150))
+- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson/cgx/pull/150))
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -18,14 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🛡️ Security
 
-- *(deps)* Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson-labs/cgx/pull/148))
+- *(deps)* Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson/cgx/pull/148))
 ## [0.0.9] - 2026-03-14
 
 ### 🚀 Features
 
-- Add ability to resolve pre-built binaries for crates  ([#93](https://github.com/anelson-labs/cgx/pull/93))
-- *(http)* Centralize HTTP client with retry, proxy, and timeout support ([#114](https://github.com/anelson-labs/cgx/pull/114))
-- *(git)* Align gix HTTP behavior with cgx HTTP config and document curl runtime deps ([#128](https://github.com/anelson-labs/cgx/pull/128))
+- Add ability to resolve pre-built binaries for crates  ([#93](https://github.com/anelson/cgx/pull/93))
+- *(http)* Centralize HTTP client with retry, proxy, and timeout support ([#114](https://github.com/anelson/cgx/pull/114))
+- *(git)* Align gix HTTP behavior with cgx HTTP config and document curl runtime deps ([#128](https://github.com/anelson/cgx/pull/128))
 
 ### 📚 Documentation
 
@@ -38,25 +38,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Features
 
-- Add structured message format for detailed operation reporting ([#68](https://github.com/anelson-labs/cgx/pull/68))
+- Add structured message format for detailed operation reporting ([#68](https://github.com/anelson/cgx/pull/68))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Configure cargo-dist to exclude cargo-cgx from release text ([#65](https://github.com/anelson-labs/cgx/pull/65))
+- Configure cargo-dist to exclude cargo-cgx from release text ([#65](https://github.com/anelson/cgx/pull/65))
 ## [0.0.7] - 2025-11-07
 
 ### 🚀 Features
 
-- Add `--refresh` flag to bypass cache ([#64](https://github.com/anelson-labs/cgx/pull/64))
+- Add `--refresh` flag to bypass cache ([#64](https://github.com/anelson/cgx/pull/64))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Do not try to use `cargo-auditable` when building `cgx` release bins ([#62](https://github.com/anelson-labs/cgx/pull/62))
+- Do not try to use `cargo-auditable` when building `cgx` release bins ([#62](https://github.com/anelson/cgx/pull/62))
 ## [0.0.6] - 2025-11-06
 
 ### 🚀 Features
 
-- Add an --unlocked flag, make --locked the default ([#59](https://github.com/anelson-labs/cgx/pull/59))
+- Add an --unlocked flag, make --locked the default ([#59](https://github.com/anelson/cgx/pull/59))
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -74,8 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Features
 
-- Add `cargo-cgx` binary crate for cargo subcommand integration ([#51](https://github.com/anelson-labs/cgx/pull/51))
-- Honor tool versions in config when resolving crates ([#46](https://github.com/anelson-labs/cgx/pull/46))
+- Add `cargo-cgx` binary crate for cargo subcommand integration ([#51](https://github.com/anelson/cgx/pull/51))
+- Honor tool versions in config when resolving crates ([#46](https://github.com/anelson/cgx/pull/46))
 
 ### 🐛 Bug Fixes
 
@@ -84,21 +84,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚜 Refactor
 
-- Factor most logic out into cgx-core library crate ([#41](https://github.com/anelson-labs/cgx/pull/41))
+- Factor most logic out into cgx-core library crate ([#41](https://github.com/anelson/cgx/pull/41))
 
 ### 📚 Documentation
 
 - Add text in README about instability
-- Update README with installation instructions ([#50](https://github.com/anelson-labs/cgx/pull/50))
+- Update README with installation instructions ([#50](https://github.com/anelson/cgx/pull/50))
 
 ### 🧪 Testing
 
-- Add integration tests that actually drive the CLI and verify behavior ([#34](https://github.com/anelson-labs/cgx/pull/34))
+- Add integration tests that actually drive the CLI and verify behavior ([#34](https://github.com/anelson/cgx/pull/34))
 ## [0.0.3] - 2025-10-05
 
 ### ⚙️ Miscellaneous Tasks
 
-- Migrate repository to anelson-labs
+- Migrate repository namespace
 - (Hopefully) get dist working on aarch64
 - Try to fix release-plz PR creation using correct token
 - Fix release-plz workflow issues
@@ -125,8 +125,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🛡️ Security
 
-- _(deps)_ Bump actions/checkout from 4 to 5 ([#5](https://github.com/anelson-labs/cgx/pull/5))
-- _(deps)_ Bump extractions/setup-just from 2 to 3 ([#3](https://github.com/anelson-labs/cgx/pull/3))
+- _(deps)_ Bump actions/checkout from 4 to 5 ([#5](https://github.com/anelson/cgx/pull/5))
+- _(deps)_ Bump extractions/setup-just from 2 to 3 ([#3](https://github.com/anelson/cgx/pull/3))
 
 ## [0.0.1] - 2025-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### 💼 Other
+
+- _(refactor)_ Move from `anelson-labs/cgx` to `anelson/cgx` ([#191](https://github.com/anelson/cgx/pull/191))
+
 ## [0.0.10] - 2026-05-28
 
 ### 💼 Other
 
-- *(deps)* Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson/cgx/pull/150))
+- _(deps)_ Bump sha2 from 0.10.9 to 0.11.0 ([#150](https://github.com/anelson/cgx/pull/150))
 
 ### ⚙️ Miscellaneous Tasks
 
@@ -18,14 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🛡️ Security
 
-- *(deps)* Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson/cgx/pull/148))
+- _(deps)_ Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson/cgx/pull/148))
+
 ## [0.0.9] - 2026-03-14
 
 ### 🚀 Features
 
-- Add ability to resolve pre-built binaries for crates  ([#93](https://github.com/anelson/cgx/pull/93))
-- *(http)* Centralize HTTP client with retry, proxy, and timeout support ([#114](https://github.com/anelson/cgx/pull/114))
-- *(git)* Align gix HTTP behavior with cgx HTTP config and document curl runtime deps ([#128](https://github.com/anelson/cgx/pull/128))
+- Add ability to resolve pre-built binaries for crates ([#93](https://github.com/anelson/cgx/pull/93))
+- _(http)_ Centralize HTTP client with retry, proxy, and timeout support ([#114](https://github.com/anelson/cgx/pull/114))
+- _(git)_ Align gix HTTP behavior with cgx HTTP config and document curl runtime deps ([#128](https://github.com/anelson/cgx/pull/128))
 
 ### 📚 Documentation
 
@@ -34,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Miscellaneous Tasks
 
 - Update Cargo.toml dependencies
+
 ## [0.0.8] - 2025-11-16
 
 ### 🚀 Features
@@ -43,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Miscellaneous Tasks
 
 - Configure cargo-dist to exclude cargo-cgx from release text ([#65](https://github.com/anelson/cgx/pull/65))
+
 ## [0.0.7] - 2025-11-07
 
 ### 🚀 Features
@@ -52,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Miscellaneous Tasks
 
 - Do not try to use `cargo-auditable` when building `cgx` release bins ([#62](https://github.com/anelson/cgx/pull/62))
+
 ## [0.0.6] - 2025-11-06
 
 ### 🚀 Features
@@ -61,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Miscellaneous Tasks
 
 - Update Cargo.lock dependencies
+
 ## [0.0.5] - 2025-11-04
 
 ### 🚜 Refactor
@@ -70,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚙️ Miscellaneous Tasks
 
 - Update Cargo.toml dependencies
+
 ## [0.0.4] - 2025-11-04
 
 ### 🚀 Features
@@ -94,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🧪 Testing
 
 - Add integration tests that actually drive the CLI and verify behavior ([#34](https://github.com/anelson/cgx/pull/34))
+
 ## [0.0.3] - 2025-10-05
 
 ### ⚙️ Miscellaneous Tasks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ resolver        = "3"
 
 [workspace.package]
 edition      = "2024"
-homepage     = "https://github.com/anelson-labs/cgx"
+homepage     = "https://github.com/anelson/cgx"
 license      = "MIT OR Apache-2.0"
-repository   = "https://github.com/anelson-labs/cgx"
+repository   = "https://github.com/anelson/cgx"
 rust-version = "1.85.1"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cgx
 
-[![CI](https://github.com/anelson-labs/cgx/actions/workflows/ci.yml/badge.svg)](https://github.com/anelson-labs/cgx/actions/workflows/ci.yml)
+[![CI](https://github.com/anelson/cgx/actions/workflows/ci.yml/badge.svg)](https://github.com/anelson/cgx/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cgx?link=https%3A%2F%2Fcrates.io%2Fcrates%2Fcgx)](https://crates.io/crates/cgx)
 ![license](https://img.shields.io/crates/l/cgx.svg)
 
@@ -19,19 +19,19 @@ command.
 **macOS and Linux:**
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/anelson-labs/cgx/releases/latest/download/cgx-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/anelson/cgx/releases/latest/download/cgx-installer.sh | sh
 ```
 
 **Windows:**
 
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://github.com/anelson-labs/cgx/releases/latest/download/cgx-installer.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/anelson/cgx/releases/latest/download/cgx-installer.ps1 | iex"
 ```
 
 The installer will download the appropriate binary for your platform and add it to your PATH.
 
 > **Note:** To install a specific version for CI/reproducible builds, replace `latest` in the URL above with the desired
-> version tag from the [Releases page](https://github.com/anelson-labs/cgx/releases), such as `v0.0.10`.
+> version tag from the [Releases page](https://github.com/anelson/cgx/releases), such as `v0.0.10`.
 
 ### Alternative Installation Methods
 
@@ -51,7 +51,7 @@ cargo binstall cgx
 
 **Manual download:**
 
-Download prebuilt binaries directly from the [Releases page](https://github.com/anelson-labs/cgx/releases).
+Download prebuilt binaries directly from the [Releases page](https://github.com/anelson/cgx/releases).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -127,7 +127,7 @@ We believe in recognizing security researchers who help keep `cgx` secure:
 
 **Stay Informed:**
 
-- Subscribe to [GitHub releases](https://github.com/anelson-labs/cgx/releases) for security updates.
+- Subscribe to [GitHub releases](https://github.com/anelson/cgx/releases) for security updates.
 - Enable GitHub notifications for security advisories.
 
 **Update Process:**

--- a/cargo-cgx/README.md
+++ b/cargo-cgx/README.md
@@ -31,4 +31,4 @@ cgx eza -la
 This is a thin wrapper around cgx that provides cargo subcommand integration.
 
 For complete documentation on cgx's features, configuration, and usage, please see the [cgx crate
-documentation](https://docs.rs/cgx/) and the [project README](https://github.com/anelson-labs/cgx#readme).
+documentation](https://docs.rs/cgx/) and the [project README](https://github.com/anelson/cgx#readme).


### PR DESCRIPTION
Update docs, config, GHA, and code to reflect the new location of the repo.

It was only in `anelson-labs` for historical reasons, back when the `cgx` repo was still private I needed it to be in an org on a paid plan to be able to use the runners that I needed for testing.  Now that the repo is public, I have access to all necessary runners even with the repo in my individual account.
