### PR TITLE
ci: Switch to using Trusted Publishing to crates.io

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      id-token: write
     if: ${{ github.repository_owner == 'anelson' }}
     steps:
       - &checkout
@@ -32,7 +33,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -60,4 +60,3 @@ jobs:
           # which would leave the release PR with no CI checks and therefore
           # unmergeable under the required-status branch protection.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - _(refactor)_ Move from `anelson-labs/cgx` to `anelson/cgx` ([#191](https://github.com/anelson/cgx/pull/191))
 
+### 🛡️ Security
+
+- _(ci)_ Switch to using Trusted Publishing to crates.io ([#192](https://github.com/anelson/cgx/pull/192))
+
 ## [0.0.10] - 2026-05-28
 
 ### 💼 Other


### PR DESCRIPTION
See #1 for more details.

This now uses GitHub OIDC to generate short-lived crates.io tokens, that are specifically scoped to the org, repo, and GitHub workflow that I've configured on crates.io.  This makes it harder for a bad actor to mount a supply chain attack on this crate, by requiring them to publish their malicious code via the existing GitHub release process.

This isn't a silver bullet; I must still be vigilant and regard PRs with some skepticism, particularly from new contributors.  But at least with Trusted Publishing enabled, an attacker that is able to compromise my crates.io token but does not get control of my GitHub account will be unable to publish malicious releases.