### PR TITLE
build: Modify GHA workflows to run full platform tests less often

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,8 +236,8 @@ jobs:
       - name: Run dependency checks
         run: just depcheck
 
-  # Stage 2: Linux amd64 Build and Test.  This will catch most build issues and broken tests,
-  # before we we move on to the more expensive and slower platform-specific builds and tests.
+  # Stage 2: Linux amd64 Build and Test.  This is one of the three representative platforms where
+  # regular PR CI executes the full integration test suite.
   test-linux-amd64:
     name: Test (Linux amd64)
     needs: [detect-pr-type, lint]
@@ -280,11 +280,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: cargo test --workspace
 
-  # Stage 3: Primary platforms (Windows amd64, Mac ARM64)
-  # After Linux amd64, these are the platforms most likely to catch platform-specific breakage.
+  # Stage 3: Representative non-Linux platforms. Regular PR CI executes the full integration test
+  # suite on one Windows and one macOS target
   test-platforms:
     name: Test (${{ matrix.name }})
-    needs: [detect-pr-type, test-linux-amd64]
+    needs: [detect-pr-type, lint]
     if: needs.detect-pr-type.outputs.is-dependabot == 'false' && needs.detect-pr-type.outputs.is-release-plz == 'false'
     strategy:
       fail-fast: false
@@ -293,10 +293,6 @@ jobs:
           - os: windows-2025
             name: Windows amd64
             cache_key: x86_64-pc-windows-msvc
-          - os: windows-2025
-            name: Windows GNU amd64
-            target: x86_64-pc-windows-gnu
-            cache_key: x86_64-pc-windows-gnu
           - os: macos-15
             name: Mac ARM64
             cache_key: aarch64-apple-darwin
@@ -306,10 +302,6 @@ jobs:
 
       - *install-rust
 
-      - name: Add target
-        if: matrix.target
-        run: rustup target add ${{ matrix.target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.cache_key }}
@@ -317,22 +309,19 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build test artifacts
-        env:
-          TARGET_FLAG: ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
-        run: cargo test --workspace ${{ env.TARGET_FLAG }} --no-run
+        run: cargo test --workspace --no-run
 
       - name: Run tests
         env:
-          TARGET_FLAG: ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: cargo test --workspace ${{ env.TARGET_FLAG }}
+        run: cargo test --workspace
 
-  # Stage 3b: Linux musl (static, vendored OpenSSL + libcurl)
-  # Builds each arch natively on its own runner and links statically against the musl target.
-  # The musl OpenSSL/libcurl come from the vendored static build configured in cgx-core/Cargo.toml,
-  test-musl:
-    name: Test (Linux musl ${{ matrix.name }})
-    needs: [detect-pr-type, test-linux-amd64]
+  # Stage 3b: Linux musl build coverage (static, vendored OpenSSL + libcurl)
+  # Regular PR CI compiles tests on these targets but does not execute the slow integration suite.
+  # The musl OpenSSL/libcurl come from the vendored static build configured in cgx-core/Cargo.toml.
+  build-musl:
+    name: Build Tests (Linux musl ${{ matrix.name }})
+    needs: [detect-pr-type, lint]
     if: needs.detect-pr-type.outputs.is-dependabot == 'false' && needs.detect-pr-type.outputs.is-release-plz == 'false'
     strategy:
       fail-fast: false
@@ -368,23 +357,21 @@ jobs:
       - name: Build test artifacts
         run: cargo test --workspace --target ${{ matrix.target }} --no-run
 
-      - name: Run tests
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: cargo test --workspace --target ${{ matrix.target }}
-
-  # Stage 4: Extended platforms (ARM + Intel Mac)
-  # Alternative architectures that in all likelihood work just as well as the primary arch,
-  # but we build and test them anyway in the interest of being thorough.
-  # No point wasting resources on these unless the primary platforms have already passed.
-  test-platforms-extended:
-    name: Test (${{ matrix.name }})
-    needs: [detect-pr-type, test-linux-amd64, test-platforms]
+  # Stage 3c: Additional platform build coverage
+  # These targets compile all tests on regular PRs. Full test execution for each target happens in
+  # the separate Full Platform Tests workflow before release-plz updates the release PR.
+  build-platforms:
+    name: Build Tests (${{ matrix.name }})
+    needs: [detect-pr-type, lint]
     if: needs.detect-pr-type.outputs.is-dependabot == 'false' && needs.detect-pr-type.outputs.is-release-plz == 'false'
     strategy:
       fail-fast: false
       matrix:
         include:
+          - os: windows-2025
+            name: Windows GNU amd64
+            target: x86_64-pc-windows-gnu
+            cache_key: x86_64-pc-windows-gnu
           - os: windows-11-arm
             name: Windows ARM64
             cache_key: aarch64-pc-windows-msvc
@@ -400,6 +387,10 @@ jobs:
 
       - *install-rust
 
+      - name: Add target
+        if: matrix.target
+        run: rustup target add ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.cache_key }}
@@ -407,12 +398,9 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Build test artifacts
-        run: cargo test --workspace --no-run
-
-      - name: Run tests
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: cargo test --workspace
+          TARGET_FLAG: ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+        run: cargo test --workspace ${{ env.TARGET_FLAG }} --no-run
 
   # Aggregate job that depends on all previous builds.  This is the check that
   # must pass for the PR to be considered successful.
@@ -428,8 +416,8 @@ jobs:
         release-plz-check,
         test-linux-amd64,
         test-platforms,
-        test-musl,
-        test-platforms-extended,
+        build-musl,
+        build-platforms,
       ]
     runs-on: ubuntu-24.04
     if: always()
@@ -457,12 +445,12 @@ jobs:
             echo "All dependabot checks passed"
           else
             echo "Checking full CI for regular PR..."
-            # For regular PRs, check all full CI jobs
+            # For regular PRs, check representative full-test jobs and all build-only jobs.
             if [ "${{ needs.test-linux-amd64.result }}" != "success" ] || \
                [ "${{ needs.test-platforms.result }}" != "success" ] || \
-               [ "${{ needs.test-musl.result }}" != "success" ] || \
-               [ "${{ needs.test-platforms-extended.result }}" != "success" ]; then
-              echo "One or more test jobs failed"
+               [ "${{ needs.build-musl.result }}" != "success" ] || \
+               [ "${{ needs.build-platforms.result }}" != "success" ]; then
+              echo "One or more regular CI jobs failed"
               exit 1
             fi
             echo "All builds and tests passed"

--- a/.github/workflows/full-platform-tests.yml
+++ b/.github/workflows/full-platform-tests.yml
@@ -1,0 +1,264 @@
+name: Full Platform Tests
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  should-run:
+    name: Check Whether Full Tests Are Needed
+    runs-on: ubuntu-24.04
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Decide whether to run
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FILE: full-platform-tests.yml
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Manual dispatch always runs the full platform test suite."
+            exit 0
+          fi
+
+          last_success_sha="$(
+            gh run list \
+              --repo "$GITHUB_REPOSITORY" \
+              --workflow "$WORKFLOW_FILE" \
+              --branch master \
+              --status success \
+              --limit 1 \
+              --json headSha \
+              --jq '.[0].headSha // ""'
+          )"
+
+          if [ -z "$last_success_sha" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "No previous successful full-platform run found."
+          elif [ "$last_success_sha" = "$GITHUB_SHA" ]; then
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "Current master SHA $GITHUB_SHA was already covered by a successful full-platform run."
+          else
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Current master SHA $GITHUB_SHA is newer than last successful full-platform SHA $last_success_sha."
+          fi
+
+  test-linux-amd64:
+    name: Test (Linux amd64)
+    needs: should-run
+    if: needs.should-run.outputs.should-run == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - &install-rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85.1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-gnu
+          add-job-id-key: false
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build test artifacts
+        run: cargo test --workspace --no-run
+
+      - name: Verify runtime linkage (Linux)
+        run: |
+          LINKAGE_OUTPUT="$(ldd target/debug/cgx 2>&1 || true)"
+          echo "$LINKAGE_OUTPUT"
+
+          if echo "$LINKAGE_OUTPUT" | grep -q "not a dynamic executable"; then
+            echo "Static binary detected; shared-library runtime check skipped."
+            exit 0
+          fi
+
+          if echo "$LINKAGE_OUTPUT" | grep -q "not found"; then
+            echo "Missing runtime shared library dependency detected."
+            exit 1
+          fi
+
+      - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo test --workspace
+
+  test-platforms:
+    name: Test (${{ matrix.name }})
+    needs: should-run
+    if: needs.should-run.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2025
+            name: Windows amd64
+            cache_key: x86_64-pc-windows-msvc
+          - os: windows-2025
+            name: Windows GNU amd64
+            target: x86_64-pc-windows-gnu
+            cache_key: x86_64-pc-windows-gnu
+          - os: macos-15
+            name: Mac ARM64
+            cache_key: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - *install-rust
+
+      - name: Add target
+        if: matrix.target
+        run: rustup target add ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.cache_key }}
+          add-job-id-key: false
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build test artifacts
+        env:
+          TARGET_FLAG: ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+        run: cargo test --workspace ${{ env.TARGET_FLAG }} --no-run
+
+      - name: Run tests
+        env:
+          TARGET_FLAG: ${{ matrix.target && format('--target {0}', matrix.target) || '' }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo test --workspace ${{ env.TARGET_FLAG }}
+
+  test-musl:
+    name: Test (Linux musl ${{ matrix.name }})
+    needs: should-run
+    if: needs.should-run.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            name: amd64
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-24.04-arm
+            name: arm64
+            target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - *install-rust
+
+      - name: Add musl target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install musl build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.target }}
+          add-job-id-key: false
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build test artifacts
+        run: cargo test --workspace --target ${{ matrix.target }} --no-run
+
+      - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo test --workspace --target ${{ matrix.target }}
+
+  test-platforms-extended:
+    name: Test (${{ matrix.name }})
+    needs: should-run
+    if: needs.should-run.outputs.should-run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-11-arm
+            name: Windows ARM64
+            cache_key: aarch64-pc-windows-msvc
+          - os: ubuntu-24.04-arm
+            name: Linux ARM64
+            cache_key: aarch64-unknown-linux-gnu
+          - os: macos-15-intel
+            name: Mac Intel
+            cache_key: x86_64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - *install-rust
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.cache_key }}
+          add-job-id-key: false
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Build test artifacts
+        run: cargo test --workspace --no-run
+
+      - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo test --workspace
+
+  release-plz-pr:
+    name: Release-plz PR
+    needs:
+      [
+        should-run,
+        test-linux-amd64,
+        test-platforms,
+        test-musl,
+        test-platforms-extended,
+      ]
+    if: >-
+      needs.should-run.outputs.should-run == 'true' &&
+      github.repository_owner == 'anelson' &&
+      github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          # Use the PAT, not GITHUB_TOKEN, so the PR-open and PR-update events
+          # actually fire workflow runs. GitHub's recursive-loop safeguard
+          # suppresses `pull_request` events caused by the default GITHUB_TOKEN,
+          # which would leave the release PR with no CI checks and therefore
+          # unmergeable under the required-status branch protection.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -9,22 +9,20 @@ jobs:
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: read
       id-token: write
     if: ${{ github.repository_owner == 'anelson' }}
     steps:
-      - &checkout
-        name: Checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
-      - &install-rust
-        name: Install Rust toolchain
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
@@ -32,31 +30,4 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-
-  # Create a PR with the new versions and changelog, preparing the next release.
-  release-plz-pr:
-    name: Release-plz PR
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    concurrency:
-      group: release-plz-${{ github.ref }}
-      cancel-in-progress: false
-    if: ${{ github.repository_owner == 'anelson' }}
-    steps:
-      - *checkout
-      - *install-rust
-
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release-pr
-        env:
-          # Use the PAT, not GITHUB_TOKEN, so the PR-open and PR-update events
-          # actually fire workflow runs. GitHub's recursive-loop safeguard
-          # suppresses `pull_request` events caused by the default GITHUB_TOKEN,
-          # which would leave the release PR with no CI checks and therefore
-          # unmergeable under the required-status branch protection.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -126,6 +126,30 @@ just xmac-check
 
 Both of these assume that you're running on Linux (or, in the case of `xmac-check`, any platform that can run Docker).
 
+## CI Builds
+
+Regular PR CI is optimized for fast feedback without dropping platform build coverage. It runs the full test suite on
+one representative target per major OS family:
+
+- Linux amd64 on `ubuntu-24.04`
+- Windows amd64 MSVC on `windows-2025`
+- macOS ARM64 on `macos-15`
+
+The remaining supported targets still compile all test artifacts with `cargo test --workspace --no-run`, but do not run
+the integration tests during ordinary PR CI:
+
+- Windows GNU amd64
+- Linux musl amd64
+- Linux musl arm64
+- Windows ARM64
+- Linux ARM64
+- macOS Intel
+
+The full all-platform test suite runs in the `Full Platform Tests` workflow. That workflow runs nightly on `master`
+only when `master` has new commits since the last successful full-platform run, and it can also be started manually
+from GitHub Actions. Dependabot and release-plz PRs use intentionally lighter CI fast paths because their expected
+changes are narrow and mechanical.
+
 ## Release Infrastructure
 
 Releases are driven by release-plz and cargo-dist:
@@ -134,6 +158,20 @@ Releases are driven by release-plz and cargo-dist:
 - cargo-dist owns the generated release workflow in `.github/workflows/release.yml`.
 - `release.yml` and `.github/workflows/dist-dry-run-release.yml` are generated files. Do not edit them directly; run
   `just regen-dist-release` after changing cargo-dist config or release workflow setup.
+
+### Making a release
+
+Releases are prepared by the release-plz PR. That PR is created or updated only after the `Full Platform Tests` workflow
+passes on `master`.
+
+If new commits land on `master` after the release-plz PR was last updated, the release PR will not automatically include
+those commits until another full-platform workflow run succeeds. To refresh the release PR sooner than the next
+scheduled run, manually dispatch `Full Platform Tests` on `master` from GitHub Actions and wait for it to pass.
+
+Before merging a release-plz PR that is expected to produce a release, run the release dry run described below.
+
+To publish a release, review and merge the release-plz PR. Once the PR lands on `master`, the `Release-plz` workflow runs
+the release command that publishes crates and creates the version tag.
 
 ### Linux musl build targets
 


### PR DESCRIPTION
With this change, PR builds actually run the unit tests only for Linux amd64, Windows amd64, and Mac arm64.  Unit tests for all other platform targets are compiled, but not run.

Instead, the full run of all tests is in a new `full-platform-tests` workflow that runs nightly (or on-demand).  It is also in `full-platform-tests` that `release-plz` is run to update the release PR, which means that the PR is only updated if all of the platform tests have passed.  This still keeps us honest, but doesn't take up so much time.

Now, to land a PR, all of the tests on all platforms must compile (this is pretty fast thanks to caching), and they must run on one Windows, one Linux, and one Mac target.  That will be much faster than the current approach which requires ALL tests on ALL supported targets to pass.

To make a release will still require ALL tests on ALL supported targets to pass, but normally that will run overnight.  For releases that can't wait, we can always run `full-platform-tests` manually.

Closes #193