### PR TITLE
Add prefetch options

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,13 @@ cgx ripgrep@=14.1.1
 You can also pass the version requirement as a `cgx` option before the crate name:
 
 ```sh
-cgx --version 14 ripgrep
+cgx --crate-version 14 ripgrep
 ```
+
+> **NOTE:** `cgx --version` (or `cgx -V`) prints the version of `cgx` itself. To specify the semver version requirement
+> for the crate that you are running, use the `@VERSION` suffix or the `--crate-version` option shown above. A
+> `--version` placed _after_ the crate name is forwarded to the tool (e.g. `cgx ripgrep --version`
+> runs `ripgrep --version`).
 
 ## Sources
 
@@ -181,6 +186,30 @@ cgx --refresh ripgrep
 `--no-exec` prints the resolved executable path to stdout. `--list-targets` lists the crate's binary and example targets
 without building or executing them.
 
+## Prefetching Crates
+
+You can prepare crates ahead of time so later runs are fast and work offline:
+
+```sh
+# Prepare a single crate (download or build) without running it; prints nothing
+cgx --prefetch ripgrep
+
+# Prefetch every tool and alias configured across your cgx.toml files
+cgx --prefetch-all
+```
+
+To see what tools and aliases are configured (and thus would be prefetched with `--prefetch-all`), you can run:
+
+```sh
+# List the tools and aliases configured across all cgx.toml files
+cgx --list-tools
+```
+
+`--prefetch` is equivalent to `--no-exec` but prints nothing on success; once a crate is prefetched it is guaranteed to
+be runnable later without network access and without building froms ource (as long as you don't change build options,
+features, or toolchain). `--prefetch-all` is a convenience shortcut equivalent to running `--prefetch` for each
+configured tool and alias.
+
 ## Configuration Files
 
 One of the handy features of tools like `uvx` and `npx` is that you can pin or customize tools in your workspace. `cgx`
@@ -229,6 +258,8 @@ Config files are loaded and merged in order of precedence, with later sources ov
 
 Use `--config-file <FILE>` to read only one config file and bypass the normal search. See
 [`cgx-example.toml`](cgx-example.toml) for a more comprehensive example.
+
+You can use `cgx --list-tools` to see the final merged configuration of tools and aliases that `cgx` will use, after applying all config files and CLI options.
 
 ## Prebuilt Binaries
 

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ cargo-deny = "=0.17.0"
 # Detailed configuration with features
 taplo-cli = { version = "1.0", features = ["full"] }
 
+# Default features can be disabled, just like in a Cargo dependency
+sccache = { version = "0.8", default-features = false }
+
 # Git repository source
 my-tool = { git = "https://github.com/owner/repo.git", tag = "v1.0.0" }
 

--- a/cargo-cgx/tests/integration.rs
+++ b/cargo-cgx/tests/integration.rs
@@ -43,8 +43,8 @@ fn test_version_output() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::is_empty())
-        .stderr(predicates::str::is_match(r"cgx \d+\.\d+\.\d+").unwrap());
+        .stdout(predicates::str::is_match(r"cgx \d+\.\d+\.\d+").unwrap())
+        .stderr(predicates::str::is_empty());
 }
 
 /// Test the cargo subcommand invocation pattern: `cargo cgx` -> `cargo-cgx cgx`
@@ -76,8 +76,8 @@ fn test_cargo_subcommand_with_version() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::is_empty())
-        .stderr(predicates::str::is_match(r"cgx \d+\.\d+\.\d+").unwrap());
+        .stdout(predicates::str::is_match(r"cgx \d+\.\d+\.\d+").unwrap())
+        .stderr(predicates::str::is_empty());
 }
 
 /// Test that the cargo subcommand pattern works with cgx flags after the subcommand arg.

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -60,8 +60,9 @@ pub(crate) fn create_resolver(
     reporter: crate::messages::MessageReporter,
     http_client: HttpClient,
 ) -> impl BinaryResolver {
+    let mode = config.prebuilt_binaries.use_prebuilt_binaries;
     let inner = DefaultBinaryResolver::new(config, reporter.clone(), http_client);
-    CachingResolver::new(inner, cache, reporter)
+    CachingResolver::new(inner, cache, reporter, mode)
 }
 
 struct DefaultBinaryResolver {
@@ -285,14 +286,6 @@ impl BinaryResolver for DefaultBinaryResolver {
             }
         }
 
-        if self.config.prebuilt_binaries.use_prebuilt_binaries == UsePrebuiltBinaries::Always {
-            return error::PrebuiltBinaryRequiredSnafu {
-                name: resolved.name.clone(),
-                version: resolved.version.to_string(),
-            }
-            .fail();
-        }
-
         self.reporter.report(|| {
             PrebuiltBinaryMessage::no_binary_found(
                 resolved,
@@ -308,14 +301,21 @@ struct CachingResolver<R: BinaryResolver> {
     inner: R,
     cache: Cache,
     reporter: crate::messages::MessageReporter,
+    mode: UsePrebuiltBinaries,
 }
 
 impl<R: BinaryResolver> CachingResolver<R> {
-    fn new(inner: R, cache: Cache, reporter: crate::messages::MessageReporter) -> Self {
+    fn new(
+        inner: R,
+        cache: Cache,
+        reporter: crate::messages::MessageReporter,
+        mode: UsePrebuiltBinaries,
+    ) -> Self {
         Self {
             inner,
             cache,
             reporter,
+            mode,
         }
     }
 }
@@ -326,21 +326,56 @@ impl<R: BinaryResolver> BinaryResolver for CachingResolver<R> {
         krate: &DownloadedCrate,
         build_options: &BuildOptions,
     ) -> Result<Option<ResolvedBinary>> {
-        // Check build options disqualification BEFORE touching cache
+        // This layer owns the use-prebuilt-binaries mode policy. Every path that can decline to
+        // produce a binary is decided here, so `always` mode cannot be bypassed by a
+        // disqualification short-circuit or by a cached negative result.
+        if self.mode == UsePrebuiltBinaries::Never {
+            self.reporter
+                .report(PrebuiltBinaryMessage::prebuilt_binaries_disabled);
+            return Ok(None);
+        }
+
+        // Check build options disqualification BEFORE touching cache: the binary cache is keyed
+        // on the resolved crate alone, so a cached binary must not be served to a build whose
+        // options prohibit prebuilt binaries.
         if let Some(reason) = is_disqualified(build_options) {
+            if self.mode == UsePrebuiltBinaries::Always {
+                return error::PrebuiltBinaryDisqualifiedSnafu {
+                    name: krate.resolved.name.clone(),
+                    version: krate.resolved.version.to_string(),
+                    reason,
+                }
+                .fail();
+            }
             self.reporter
                 .report(|| PrebuiltBinaryMessage::disqualified_due_to_customization(reason));
             return Ok(None);
         }
 
-        // Delegate to cache (which handles Never mode and caching), keyed on the resolved crate
-        self.cache
-            .get_or_resolve_binary(&krate.resolved, || self.inner.resolve(krate, build_options))
+        let result = self
+            .cache
+            .get_or_resolve_binary(&krate.resolved, || self.inner.resolve(krate, build_options))?;
+
+        if result.is_none() && self.mode == UsePrebuiltBinaries::Always {
+            return error::PrebuiltBinaryRequiredSnafu {
+                name: krate.resolved.name.clone(),
+                version: krate.resolved.version.to_string(),
+            }
+            .fail();
+        }
+
+        Ok(result)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::{cell::Cell, path::PathBuf, rc::Rc};
+
+    use assert_matches::assert_matches;
+    use semver::Version;
+    use tempfile::TempDir;
+
     use super::*;
     use crate::builder::{BuildOptions, BuildTarget};
 
@@ -419,5 +454,176 @@ mod tests {
         let mut options = BuildOptions::default();
         options.toolchain = Some("nightly".to_string());
         assert_eq!(is_disqualified(&options), Some("custom toolchain specified"));
+    }
+
+    /// A [`BinaryResolver`] standing in for the provider-backed inner resolver, returning a
+    /// canned result and counting how often it is consulted.
+    struct StubResolver {
+        result: Option<ResolvedBinary>,
+        calls: Rc<Cell<usize>>,
+    }
+
+    impl BinaryResolver for StubResolver {
+        fn resolve(
+            &self,
+            _krate: &DownloadedCrate,
+            _build_options: &BuildOptions,
+        ) -> Result<Option<ResolvedBinary>> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(self.result.clone())
+        }
+    }
+
+    fn test_cache() -> (Cache, TempDir) {
+        crate::logging::init_test_logging();
+
+        let (temp_dir, config) = crate::config::create_test_env();
+        (
+            Cache::new(config, crate::messages::MessageReporter::null()),
+            temp_dir,
+        )
+    }
+
+    fn stub_caching_resolver(
+        cache: Cache,
+        mode: UsePrebuiltBinaries,
+        result: Option<ResolvedBinary>,
+    ) -> (CachingResolver<StubResolver>, Rc<Cell<usize>>) {
+        let calls = Rc::new(Cell::new(0));
+        let stub = StubResolver {
+            result,
+            calls: calls.clone(),
+        };
+        let resolver = CachingResolver::new(stub, cache, crate::messages::MessageReporter::null(), mode);
+        (resolver, calls)
+    }
+
+    fn test_downloaded_crate() -> DownloadedCrate {
+        DownloadedCrate {
+            resolved: ResolvedCrate {
+                name: "serde".to_string(),
+                version: Version::parse("1.0.0").unwrap(),
+                source: ResolvedSource::CratesIo,
+            },
+            crate_path: PathBuf::from("/nonexistent"),
+        }
+    }
+
+    fn test_resolved_binary() -> ResolvedBinary {
+        ResolvedBinary {
+            krate: test_downloaded_crate().resolved,
+            provider: BinaryProvider::GithubReleases,
+            path: PathBuf::from("/fake/bin/serde"),
+        }
+    }
+
+    /// In `always` mode, build options that disqualify the use of prebuilt binaries fail the binary
+    /// resolution because the user demanded a prebuilt binary, and yet the build options would
+    /// force a source build.
+    #[test]
+    fn always_mode_rejects_disqualifying_build_options() {
+        let (cache, _temp) = test_cache();
+        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+        let options = BuildOptions {
+            // Set a a custom profile which will disqualify the use of prebuilt binaries
+            profile: Some("dev".to_string()),
+            ..Default::default()
+        };
+
+        let result = resolver.resolve(&test_downloaded_crate(), &options);
+
+        // Prebuilt binaries can't be used because a `profile` is set, but the
+        // `UsePrebuiltBinaries::Always` mode requires a prebuilt binary, so attempting to resolve
+        // this is an error.
+        assert_matches!(
+            result,
+            Err(error::Error::PrebuiltBinaryDisqualified { ref name, ref reason, .. })
+                if name == "serde" && reason.contains("profile")
+        );
+        assert_eq!(calls.get(), 0);
+    }
+
+    /// In `auto` mode, disqualifying build options skip prebuilt binaries so the crate falls
+    /// back to a source build.
+    #[test]
+    fn auto_mode_skips_prebuilt_for_disqualifying_build_options() {
+        let (cache, _temp) = test_cache();
+        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Auto, None);
+        let options = BuildOptions {
+            profile: Some("dev".to_string()),
+            ..Default::default()
+        };
+
+        let result = resolver.resolve(&test_downloaded_crate(), &options).unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(calls.get(), 0);
+    }
+
+    /// In `always` mode a missing prebuilt binary is an error rather than a silent reversion to
+    /// building from source.
+    #[test]
+    fn always_mode_errors_when_no_provider_has_binary() {
+        let (cache, _temp) = test_cache();
+        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+
+        let result = resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
+
+        assert_matches!(
+            result,
+            Err(error::Error::PrebuiltBinaryRequired { ref name, .. }) if name == "serde"
+        );
+        assert_eq!(calls.get(), 1);
+    }
+
+    /// `always` mode applies to cached negative results too: a previous run's "no binary
+    /// available" answer fails the invocation instead of silently building from source.
+    #[test]
+    fn always_mode_errors_on_cached_negative_result() {
+        let (cache, _temp) = test_cache();
+
+        let (auto_resolver, auto_calls) =
+            stub_caching_resolver(cache.clone(), UsePrebuiltBinaries::Auto, None);
+        assert_matches!(
+            auto_resolver.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(None)
+        );
+        assert_eq!(auto_calls.get(), 1);
+
+        let (always_resolver, always_calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+        let result = always_resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
+
+        assert_matches!(result, Err(error::Error::PrebuiltBinaryRequired { .. }));
+        assert_eq!(always_calls.get(), 0);
+    }
+
+    /// In `never` mode the cache and providers are not consulted at all.
+    #[test]
+    fn never_mode_returns_none_without_consulting_providers() {
+        let (cache, _temp) = test_cache();
+        let (resolver, calls) =
+            stub_caching_resolver(cache, UsePrebuiltBinaries::Never, Some(test_resolved_binary()));
+
+        let result = resolver
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+
+        assert_eq!(result, None);
+        assert_eq!(calls.get(), 0);
+    }
+
+    /// A binary the providers resolve passes through unchanged in `always` mode.
+    #[test]
+    fn resolved_binary_passes_through_in_always_mode() {
+        let (cache, _temp) = test_cache();
+        let binary = test_resolved_binary();
+        let (resolver, _calls) =
+            stub_caching_resolver(cache, UsePrebuiltBinaries::Always, Some(binary.clone()));
+
+        let result = resolver
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+
+        assert_eq!(result, Some(binary));
     }
 }

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -204,16 +204,21 @@ impl BuildOptions {
         // `default-features`. If features haven't been explicitly overridden on the command line but
         // were specified in the config for this crate, use those. `default-features = false` disables
         // default features the same as `--no-default-features`.
-        if let Some(crate_name) = crate_spec.configured_tool_name() {
-            if let Some(tool_config) = config.tools.get(crate_name) {
-                if overrides.features.is_none() {
-                    if let Some(features) = tool_config.features() {
-                        options.features = features.to_vec();
+        //
+        // Under `--all-features` neither setting is applied: cargo is invoked with `--all-features`
+        // alone, so they could not affect the build and would only perturb the build-cache key.
+        if !options.all_features {
+            if let Some(crate_name) = crate_spec.configured_tool_name() {
+                if let Some(tool_config) = config.tools.get(crate_name) {
+                    if overrides.features.is_none() {
+                        if let Some(features) = tool_config.features() {
+                            options.features = features.to_vec();
+                        }
                     }
-                }
 
-                if !tool_config.default_features() {
-                    options.no_default_features = true;
+                    if !tool_config.default_features() {
+                        options.no_default_features = true;
+                    }
                 }
             }
         }

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -171,6 +171,30 @@ impl BuildOptions {
         })
     }
 
+    /// Load build options for a configured tool name.
+    ///
+    /// This starts with [`Self::load`] and then applies configured tool features when the CLI did
+    /// not provide `--features`.
+    pub fn load_for_tool_name(
+        config: &Config,
+        args: &BuildOptionsArgs,
+        verbose: u8,
+        tool_name: Option<&str>,
+    ) -> Result<Self> {
+        let mut options = Self::load(config, args, verbose)?;
+
+        if args.features.is_none() {
+            if let Some(features) = tool_name
+                .and_then(|name| config.tools.get(name))
+                .and_then(crate::config::ToolConfig::features)
+            {
+                options.features = features.to_vec();
+            }
+        }
+
+        Ok(options)
+    }
+
     /// Parse a feature string into a vector of feature names.
     ///
     /// Handles both comma-separated and space-separated features.
@@ -1559,7 +1583,7 @@ mod tests {
 
     mod build_options {
         use super::*;
-        use crate::cli::CliArgs;
+        use crate::cli::Cli;
 
         mod features_parsing {
             use super::*;
@@ -1568,8 +1592,10 @@ mod tests {
             #[test]
             fn empty_features_string() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", "", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", "", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.features.is_empty());
             }
@@ -1578,8 +1604,10 @@ mod tests {
             #[test]
             fn single_feature() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", "feat1", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", "feat1", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.features, vec!["feat1"]);
             }
@@ -1588,8 +1616,10 @@ mod tests {
             #[test]
             fn comma_separated_features() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", "feat1,feat2", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", "feat1,feat2", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1598,8 +1628,10 @@ mod tests {
             #[test]
             fn space_separated_features() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", "feat1 feat2", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", "feat1 feat2", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1608,8 +1640,10 @@ mod tests {
             #[test]
             fn mixed_separator_features() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", "feat1, feat2 feat3", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", "feat1, feat2 feat3", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2", "feat3"]);
             }
@@ -1618,8 +1652,10 @@ mod tests {
             #[test]
             fn whitespace_handling() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--features", " feat1 , feat2 ", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--features", " feat1 , feat2 ", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1628,8 +1664,10 @@ mod tests {
             #[test]
             fn no_features_flag() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.features.is_empty());
             }
@@ -1642,8 +1680,10 @@ mod tests {
             #[test]
             fn debug_flag_maps_to_dev() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--debug", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--debug", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.profile, Some("dev".to_string()));
             }
@@ -1652,8 +1692,10 @@ mod tests {
             #[test]
             fn explicit_profile() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--profile", "custom", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--profile", "custom", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.profile, Some("custom".to_string()));
             }
@@ -1662,8 +1704,10 @@ mod tests {
             #[test]
             fn no_profile_specified() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.profile, None);
             }
@@ -1676,8 +1720,10 @@ mod tests {
             #[test]
             fn default_bin_when_no_flags() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::DefaultBin);
             }
@@ -1686,8 +1732,10 @@ mod tests {
             #[test]
             fn explicit_bin() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--bin", "foo", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--bin", "foo", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::Bin("foo".to_string()));
             }
@@ -1696,8 +1744,10 @@ mod tests {
             #[test]
             fn explicit_example() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--example", "bar", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--example", "bar", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::Example("bar".to_string()));
             }
@@ -1713,8 +1763,10 @@ mod tests {
             #[test]
             fn reads_default_locked_true() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.locked, "Should read locked=true from default Config");
                 assert!(!options.offline, "Should read offline=false from default Config");
@@ -1726,8 +1778,10 @@ mod tests {
                     locked: false,
                     ..Default::default()
                 };
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(!options.locked, "Should read locked=false from Config");
             }
@@ -1738,8 +1792,10 @@ mod tests {
                     offline: true,
                     ..Default::default()
                 };
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.offline, "Should read offline=true from Config");
             }
@@ -1751,8 +1807,10 @@ mod tests {
                     offline: true,
                     ..Default::default()
                 };
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(!options.locked, "Should read locked=false from Config");
                 assert!(options.offline, "Should read offline=true from Config");
@@ -1770,8 +1828,10 @@ mod tests {
             #[test]
             fn reads_default_none() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(
                     options.toolchain, None,
@@ -1785,8 +1845,10 @@ mod tests {
                     toolchain: Some("stable".to_string()),
                     ..Default::default()
                 };
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(
                     options.toolchain,
@@ -1801,8 +1863,10 @@ mod tests {
                     toolchain: Some("nightly".to_string()),
                     ..Default::default()
                 };
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(
                     options.toolchain,
@@ -1819,8 +1883,10 @@ mod tests {
             #[test]
             fn all_features() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--all-features", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--all-features", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.all_features);
             }
@@ -1829,8 +1895,10 @@ mod tests {
             #[test]
             fn no_default_features() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--no-default-features", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--no-default-features", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.no_default_features);
             }
@@ -1839,8 +1907,10 @@ mod tests {
             #[test]
             fn target() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--target", "x86_64-unknown-linux-gnu", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--target", "x86_64-unknown-linux-gnu", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.target, Some("x86_64-unknown-linux-gnu".to_string()));
             }
@@ -1849,8 +1919,10 @@ mod tests {
             #[test]
             fn jobs() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--jobs", "4", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--jobs", "4", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert_eq!(options.jobs, Some(4));
             }
@@ -1859,8 +1931,10 @@ mod tests {
             #[test]
             fn ignore_rust_version() {
                 let config = Config::default();
-                let args = CliArgs::parse_from_test_args(["--ignore-rust-version", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["--ignore-rust-version", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
 
                 assert!(options.ignore_rust_version);
             }
@@ -1870,16 +1944,22 @@ mod tests {
             fn cargo_verbosity() {
                 let config = Config::default();
 
-                let args = CliArgs::parse_from_test_args(["tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
                 assert_eq!(options.cargo_verbosity, CargoVerbosity::Normal);
 
-                let args = CliArgs::parse_from_test_args(["-v", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["-v", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
                 assert_eq!(options.cargo_verbosity, CargoVerbosity::Verbose);
 
-                let args = CliArgs::parse_from_test_args(["-vv", "tool"]);
-                let options = BuildOptions::load(&config, &args.build_options, args.verbose).unwrap();
+                let args = Cli::parse_from_test_args(["-vv", "tool"]);
+                let options =
+                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
+                        .unwrap();
                 assert_eq!(options.cargo_verbosity, CargoVerbosity::VeryVerbose);
             }
         }

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -200,16 +200,20 @@ impl BuildOptions {
         // Look up the tool-specific options for this crate, if any, and apply them if they are not
         // overridden by the build overrides from the CLI.
         //
-        // At the moment the only option that can be specified in the `[tools]` section that has
-        // any bearing on building is the selected features.  So, if features haven't been explicitly
-        // overridden on the command line, but features were specified in the config for this crate,
-        // then use those features.
+        // The `[tools]` settings that bear on building are the selected features and
+        // `default-features`. If features haven't been explicitly overridden on the command line but
+        // were specified in the config for this crate, use those. `default-features = false` disables
+        // default features the same as `--no-default-features`.
         if let Some(crate_name) = crate_spec.configured_tool_name() {
             if let Some(tool_config) = config.tools.get(crate_name) {
                 if overrides.features.is_none() {
                     if let Some(features) = tool_config.features() {
                         options.features = features.to_vec();
                     }
+                }
+
+                if !tool_config.default_features() {
+                    options.no_default_features = true;
                 }
             }
         }

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -6,10 +6,10 @@ use snafu::ResultExt;
 use crate::{
     Result,
     cache::Cache,
-    cargo::{CargoMetadataOptions, CargoRunner, CargoVerbosity, Metadata},
-    cli::BuildOptionsArgs,
+    cargo::{CargoMetadataOptions, CargoRunner, Metadata},
     config::Config,
     crate_resolver::ResolvedSource,
+    cratespec::CrateSpec,
     downloader::DownloadedCrate,
     error,
 };
@@ -27,6 +27,40 @@ pub enum BuildTarget {
 
     /// A specific example target to build.
     Example(String),
+}
+
+/// Build-related overrides (presumed to come from CLI arguments) that are merged with config
+/// settings to produce final [`BuildOptions`] for building a crate.
+#[derive(Clone, Debug, Default)]
+pub struct BuildOverrides {
+    /// Features to activate
+    ///
+    /// `None` means `--features` was not given; `Some(vec![])` means it was given but empty
+    pub features: Option<Vec<String>>,
+
+    /// Activate all available features
+    pub all_features: bool,
+
+    /// Do not activate the `default` feature
+    pub no_default_features: bool,
+
+    /// Build profile
+    pub profile: Option<String>,
+
+    /// Target triple for cross-compilation
+    pub target: Option<String>,
+
+    /// Number of parallel jobs for compilation
+    pub jobs: Option<usize>,
+
+    /// Ignore `rust-version` specification in packages
+    pub ignore_rust_version: bool,
+
+    /// Which executable within the crate to build
+    pub target_selection: BuildTarget,
+
+    /// Rust toolchain override
+    pub toolchain: Option<String>,
 }
 
 /// Options that control how a crate is built.
@@ -49,6 +83,14 @@ pub enum BuildTarget {
 /// those are present here because they directly influence the command line passed to `cargo
 /// build`, although they get populated from the [`Config`] struct which reflects settings in the
 /// config files and any overrides of those settings that the user applied at the CLI.
+///
+/// Another way to reason about whether something should be in this struct or in [`Config`] is that
+/// this struct implements [`Hash`], and that hash is used a cache key for caching build artifacts.
+/// So if a field has a different value, should that invalidate any cached build artifacts and
+/// cause a rebuild?  If so, then it probably belongs here.  If not, then it probably belongs in
+/// [`Config`].  A good example of this is the `verbose` command, which literally translates into a
+/// `cargo` command but is NOT considered a build option, because why would we rebuild a crate just
+/// because the verbosity level is different?
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BuildOptions {
     /// Features to activate (corresponds to `--features`).
@@ -90,11 +132,6 @@ pub struct BuildOptions {
     ///
     /// When set, Cargo is run through `rustup run <toolchain>`.
     pub toolchain: Option<String>,
-
-    /// Verbosity level for cargo build output.
-    ///
-    /// Controls the `-v` flags passed to cargo build commands.
-    pub cargo_verbosity: CargoVerbosity,
 }
 
 impl Default for BuildOptions {
@@ -111,99 +148,85 @@ impl Default for BuildOptions {
             ignore_rust_version: false,
             build_target: BuildTarget::default(),
             toolchain: None,
-            cargo_verbosity: CargoVerbosity::default(),
         }
     }
 }
 
 impl BuildOptions {
-    /// Load build options from config and CLI args, with proper precedence.
+    /// Merge build options from config and already-translated CLI overrides, with proper
+    /// precedence.
     ///
     /// Config-handled settings (`locked`, `offline`, `toolchain`) come from [`Config`], which
-    /// has already processed CLI overrides like `--locked`, `--unlocked`, `--frozen`, `--offline`,
-    /// and `+toolchain`.
+    /// has already processed CLI overrides like `--locked`, `--unlocked`, `--frozen`, `--offline`.
     ///
-    /// Crate-specific settings (features, profile, target, etc.) come from [`BuildOptionsArgs`].
-    ///
-    /// The `verbose` parameter is passed separately because it controls both overall cgx
-    /// logging (via tracing) and cargo build verbosity (passed to `cargo build`).
-    pub fn load(config: &Config, args: &BuildOptionsArgs, verbose: u8) -> Result<Self> {
-        // Parse features from CLI string (space or comma separated)
-        let features = if let Some(features_str) = &args.features {
-            Self::parse_features(features_str)
-        } else {
-            Vec::new()
-        };
-
-        // Profile: CLI --debug maps to "dev", otherwise use explicit --profile value
-        let profile = if args.debug {
-            Some("dev".to_string())
-        } else {
-            args.profile.clone()
-        };
-
-        // Build target: --bin, --example, or default
-        let build_target = match (&args.bin, &args.example) {
-            (Some(_), Some(_)) => {
-                unreachable!("BUG: clap should enforce mutual exclusivity");
-            }
-            (Some(bin_name), None) => BuildTarget::Bin(bin_name.clone()),
-            (None, Some(example_name)) => BuildTarget::Example(example_name.clone()),
-            (None, None) => BuildTarget::default(),
-        };
-
+    /// Crate-specific settings (features, profile, target, etc.) come from [`BuildOverrides`],
+    /// which the CLI front-end has already produced from the raw arguments (tokenizing
+    /// features, folding `--debug`, resolving `--bin`/`--example`).
+    pub fn load(config: &Config, overrides: &BuildOverrides) -> Result<Self> {
         Ok(BuildOptions {
             // These come from the config settings, `Config` will already apply any CLI overrides
             locked: config.locked,
             offline: config.offline,
-            toolchain: config.toolchain.clone(),
 
-            // The rest of these come exclusively from CLI args
-            features,
-            all_features: args.all_features,
-            no_default_features: args.no_default_features,
-            profile,
-            target: args.target.clone(),
-            jobs: args.jobs,
-            ignore_rust_version: args.ignore_rust_version,
-            build_target,
-            cargo_verbosity: CargoVerbosity::from_count(verbose),
+            // This can be set in the config file, but it can be overridden on the CLI
+            toolchain: overrides.toolchain.clone().or_else(|| config.toolchain.clone()),
+
+            // The rest of these come exclusively from the CLI overrides
+            features: overrides.features.clone().unwrap_or_default(),
+            all_features: overrides.all_features,
+            no_default_features: overrides.no_default_features,
+            profile: overrides.profile.clone(),
+            target: overrides.target.clone(),
+            jobs: overrides.jobs,
+            ignore_rust_version: overrides.ignore_rust_version,
+            build_target: overrides.target_selection.clone(),
         })
     }
 
-    /// Load build options for a configured tool name.
+    /// Load the build options for a specific crate.
     ///
-    /// This starts with [`Self::load`] and then applies configured tool features when the CLI did
-    /// not provide `--features`.
-    pub fn load_for_tool_name(
+    /// This will respect the `[tools]` section in the cgx config TOML, if there is an entry for
+    /// this crate then the options specified for that crate will be applied unless they have been
+    /// overridden in `BuildOverrides`.
+    pub fn load_for_crate(
         config: &Config,
-        args: &BuildOptionsArgs,
-        verbose: u8,
-        tool_name: Option<&str>,
+        overrides: &BuildOverrides,
+        crate_spec: &CrateSpec,
     ) -> Result<Self> {
-        let mut options = Self::load(config, args, verbose)?;
+        // Load the standard build options from the CLI/config files, without any crate-specific
+        // options.
+        let mut options = Self::load(config, overrides)?;
 
-        if args.features.is_none() {
-            if let Some(features) = tool_name
-                .and_then(|name| config.tools.get(name))
-                .and_then(crate::config::ToolConfig::features)
-            {
-                options.features = features.to_vec();
+        // Look up the tool-specific options for this crate, if any, and apply them if they are not
+        // overridden by the build overrides from the CLI.
+        //
+        // At the moment the only option that can be specified in the `[tools]` section that has
+        // any bearing on building is the selected features.  So, if features haven't been explicitly
+        // overridden on the command line, but features were specified in the config for this crate,
+        // then use those features.
+        if let Some(crate_name) = crate_spec.configured_tool_name() {
+            if let Some(tool_config) = config.tools.get(crate_name) {
+                if overrides.features.is_none() {
+                    if let Some(features) = tool_config.features() {
+                        options.features = features.to_vec();
+                    }
+                }
             }
         }
 
         Ok(options)
     }
 
-    /// Parse a feature string into a vector of feature names.
+    /// The resolved Rust target triple this build targets: the explicit `--target`, or cgx's own
+    /// host triple ([`build_context::TARGET`]) when none was given.
     ///
-    /// Handles both comma-separated and space-separated features.
-    fn parse_features(features_str: &str) -> Vec<String> {
-        features_str
-            .split(|c: char| c == ',' || c.is_whitespace())
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_string())
-            .collect()
+    /// This matches how cgx resolves the platform everywhere else (pre-built binary lookup, cargo
+    /// metadata filtering, and the build cache), so it reliably names the triple the binary is for
+    /// even on a default build where cargo writes to `target/debug` rather than a triple subdir.
+    pub(crate) fn target_platform(&self) -> String {
+        self.target
+            .clone()
+            .unwrap_or_else(|| build_context::TARGET.to_string())
     }
 }
 
@@ -228,8 +251,10 @@ pub trait CrateBuilder {
     /// the local source tree.  So this may or may not actually compile anything,
     /// depending on the crate source, the state of the cache, and the config.
     ///
-    /// Returns the full path to the compiled binary on success.
-    fn build(&self, krate: &DownloadedCrate, options: &BuildOptions) -> Result<PathBuf>;
+    /// Returns the full path to the compiled binary and the concrete [`BuildTarget`] that was built
+    /// (a `DefaultBin` request is resolved to the actual `Bin`/`Example` here, even on a cache
+    /// hit).
+    fn build(&self, krate: &DownloadedCrate, options: &BuildOptions) -> Result<(PathBuf, BuildTarget)>;
 }
 
 pub(crate) fn create_builder(
@@ -264,7 +289,7 @@ impl CrateBuilder for RealCrateBuilder {
         Self::list_targets_internal(krate, &metadata)
     }
 
-    fn build(&self, krate: &DownloadedCrate, options: &BuildOptions) -> Result<PathBuf> {
+    fn build(&self, krate: &DownloadedCrate, options: &BuildOptions) -> Result<(PathBuf, BuildTarget)> {
         // Gather metadata about the crate in its current source form.
         // The act of building will re-gather the metadata after the build, but this is needed to
         // resolve target and package information before building.
@@ -284,6 +309,11 @@ impl CrateBuilder for RealCrateBuilder {
             Cow::Borrowed(options)
         };
 
+        // The build target (ie, which binary or example to run) is now known, whether resolved
+        // just above or supplied explicitly. Report it alongside the binary, including on a cache
+        // hit.
+        let built_target = options.build_target.clone();
+
         // Crates resolved from local sources are, by definition, local.  Not only does that mean
         // that they are on a local filesystem (and presumably fast to access), but it also means
         // that their source contents are mutable.  Even if we wanted to cache them, we would need
@@ -292,13 +322,15 @@ impl CrateBuilder for RealCrateBuilder {
         // from their sources, and never cached
         if matches!(krate.resolved.source, ResolvedSource::LocalDir { .. }) {
             let (binary_path, _sbom) = self.build_uncached(krate, options.as_ref(), &metadata)?;
-            return Ok(binary_path);
+            return Ok((binary_path, built_target));
         }
 
-        self.cache
+        let binary_path = self
+            .cache
             .get_or_build_binary(&krate.resolved, options.as_ref(), || {
                 self.build_uncached(krate, options.as_ref(), &metadata)
-            })
+            })?;
+        Ok((binary_path, built_target))
     }
 }
 
@@ -600,7 +632,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        cargo::find_cargo,
+        cargo::create_cargo_runner,
         crate_resolver::{ResolvedCrate, ResolvedSource},
         error::Error,
         testdata::CrateTestCase,
@@ -616,7 +648,8 @@ mod tests {
         fs::create_dir_all(&config.build_dir).unwrap();
 
         let cache = Cache::new(config.clone(), crate::messages::MessageReporter::null());
-        let cargo_runner = Arc::new(find_cargo(crate::messages::MessageReporter::null()).unwrap());
+        let cargo_runner =
+            Arc::new(create_cargo_runner(config.clone(), crate::messages::MessageReporter::null()).unwrap());
 
         let builder = RealCrateBuilder {
             config,
@@ -808,11 +841,12 @@ mod tests {
         #[test]
         fn builds_all_testcases_with_bins() {
             let (builder, _temp) = test_builder();
-            let cargo = find_cargo(crate::messages::MessageReporter::null()).unwrap();
+            let cargo_runner =
+                create_cargo_runner(Config::default(), crate::messages::MessageReporter::null()).unwrap();
 
             for tc in CrateTestCase::all() {
                 let metadata_opts = CargoMetadataOptions::default();
-                let metadata = cargo.metadata(tc.path(), &metadata_opts).unwrap();
+                let metadata = cargo_runner.metadata(tc.path(), &metadata_opts).unwrap();
 
                 let workspace_pkgs = metadata.workspace_packages();
                 let buildable_packages: Vec<_> = workspace_pkgs
@@ -846,7 +880,7 @@ mod tests {
 
                     let result = builder.build(&krate, &options);
 
-                    if let Ok(binary) = result {
+                    if let Ok((binary, _target)) = result {
                         assert!(binary.exists(), "Binary missing for {}/{}", tc.name, pkg.name);
 
                         let binary_name = binary.file_name().unwrap().to_str().unwrap();
@@ -908,7 +942,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
 
             assert!(binary.exists());
             assert!(binary.is_file());
@@ -940,7 +974,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, target) = builder.build(&krate, &options).unwrap();
             assert!(binary.exists());
             let binary_name = binary.file_name().unwrap().to_str().unwrap();
             assert_eq!(
@@ -949,6 +983,9 @@ mod tests {
                 "Should build bin1 or the crate's default binary, got: {}",
                 binary_name
             );
+
+            // The `DefaultBin` request is resolved to the concrete target that was built.
+            assert_eq!(target, BuildTarget::Bin("bin1".to_string()));
         }
 
         #[test]
@@ -969,7 +1006,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             assert!(binary.exists());
             let binary_name = binary.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary_name, expected_bin_name("bin2"));
@@ -1026,7 +1063,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             assert!(binary.exists());
 
             let binary_name = binary.file_name().unwrap().to_str().unwrap();
@@ -1082,7 +1119,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary1 = builder.build(&krate1, &options).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("timestamp"));
             let output1 = run_timestamp_binary(&binary1);
@@ -1097,7 +1134,7 @@ mod tests {
                 None,
             );
 
-            let binary2 = builder.build(&krate2, &options).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("timestamp"));
             let output2 = run_timestamp_binary(&binary2);
@@ -1122,7 +1159,7 @@ mod tests {
                 profile: Some("dev".to_string()),
                 ..Default::default()
             };
-            let binary1 = builder.build(&krate1, &options1).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options1).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("timestamp"));
             let output1 = run_timestamp_binary(&binary1);
@@ -1138,7 +1175,7 @@ mod tests {
                 profile: Some("release".to_string()),
                 ..Default::default()
             };
-            let binary2 = builder.build(&krate2, &options2).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options2).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("timestamp"));
             let output2 = run_timestamp_binary(&binary2);
@@ -1164,7 +1201,7 @@ mod tests {
                 target: None,
                 ..Default::default()
             };
-            let binary1 = builder.build(&krate1, &options1).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options1).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("simple-bin-no-deps"));
 
@@ -1180,7 +1217,7 @@ mod tests {
                 target: Some(build_context::TARGET.to_string()),
                 ..Default::default()
             };
-            let binary2 = builder.build(&krate2, &options2).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options2).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("simple-bin-no-deps"));
 
@@ -1209,7 +1246,7 @@ mod tests {
                 locked: true,
                 ..Default::default()
             };
-            let binary1 = builder.build(&krate1, &options1).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options1).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("stale-serde"));
             let sbom1 = read_sbom_for_binary(&binary1);
@@ -1232,7 +1269,7 @@ mod tests {
                 locked: false,
                 ..Default::default()
             };
-            let binary2 = builder.build(&krate2, &options2).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options2).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("stale-serde"));
             let sbom2 = read_sbom_for_binary(&binary2);
@@ -1266,7 +1303,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary1 = builder.build(&krate1, &options).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("stale-serde"));
 
@@ -1278,7 +1315,7 @@ mod tests {
                 None,
             );
 
-            let binary2 = builder.build(&krate2, &options).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("stale-serde"));
 
@@ -1301,7 +1338,7 @@ mod tests {
                 profile: Some("dev".to_string()),
                 ..Default::default()
             };
-            let binary1 = builder.build(&krate1, &options1).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options1).unwrap();
             let binary1_name = binary1.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary1_name, expected_bin_name("timestamp"));
             let sbom1 = read_sbom_for_binary(&binary1);
@@ -1320,7 +1357,7 @@ mod tests {
                 no_default_features: true,
                 ..Default::default()
             };
-            let binary2 = builder.build(&krate2, &options2).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options2).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("timestamp"));
             let sbom2 = read_sbom_for_binary(&binary2);
@@ -1351,7 +1388,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             let binary_name = binary.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary_name, expected_bin_name("timestamp"));
             let output = run_timestamp_binary(&binary);
@@ -1380,7 +1417,7 @@ mod tests {
             );
             let options = BuildOptions::default();
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             let sbom = read_sbom_for_binary(&binary);
 
             assert_eq!(
@@ -1409,7 +1446,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             let sbom = read_sbom_for_binary(&binary);
 
             assert_eq!(
@@ -1437,7 +1474,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
 
             assert!(!binary.starts_with(&builder.config.bin_dir));
             assert!(binary.starts_with(tc.path()));
@@ -1466,7 +1503,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary1 = builder.build(&krate1, &options).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options).unwrap();
 
             assert!(binary1.starts_with(&builder.config.bin_dir));
 
@@ -1483,7 +1520,7 @@ mod tests {
                 },
                 None,
             );
-            let binary2 = builder.build(&krate2, &options).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("simple-bin-no-deps"));
 
@@ -1508,7 +1545,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary1 = builder.build(&krate1, &options).unwrap();
+            let (binary1, _target) = builder.build(&krate1, &options).unwrap();
 
             assert!(binary1.starts_with(&builder.config.bin_dir));
 
@@ -1526,7 +1563,7 @@ mod tests {
                 },
                 None,
             );
-            let binary2 = builder.build(&krate2, &options).unwrap();
+            let (binary2, _target) = builder.build(&krate2, &options).unwrap();
             let binary2_name = binary2.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary2_name, expected_bin_name("simple-bin-no-deps"));
 
@@ -1554,7 +1591,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let binary = builder.build(&krate, &options).unwrap();
+            let (binary, _target) = builder.build(&krate, &options).unwrap();
             let binary_name = binary.file_name().unwrap().to_str().unwrap();
             assert_eq!(binary_name, expected_bin_name("proc-macro-dep"));
 
@@ -1592,10 +1629,8 @@ mod tests {
             #[test]
             fn empty_features_string() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", "", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", "", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.features.is_empty());
             }
@@ -1604,10 +1639,8 @@ mod tests {
             #[test]
             fn single_feature() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", "feat1", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", "feat1", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.features, vec!["feat1"]);
             }
@@ -1616,10 +1649,8 @@ mod tests {
             #[test]
             fn comma_separated_features() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", "feat1,feat2", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", "feat1,feat2", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1628,10 +1659,8 @@ mod tests {
             #[test]
             fn space_separated_features() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", "feat1 feat2", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", "feat1 feat2", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1640,10 +1669,8 @@ mod tests {
             #[test]
             fn mixed_separator_features() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", "feat1, feat2 feat3", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", "feat1, feat2 feat3", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2", "feat3"]);
             }
@@ -1652,10 +1679,8 @@ mod tests {
             #[test]
             fn whitespace_handling() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--features", " feat1 , feat2 ", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--features", " feat1 , feat2 ", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.features, vec!["feat1", "feat2"]);
             }
@@ -1664,10 +1689,8 @@ mod tests {
             #[test]
             fn no_features_flag() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.features.is_empty());
             }
@@ -1680,10 +1703,8 @@ mod tests {
             #[test]
             fn debug_flag_maps_to_dev() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--debug", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--debug", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.profile, Some("dev".to_string()));
             }
@@ -1692,10 +1713,8 @@ mod tests {
             #[test]
             fn explicit_profile() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--profile", "custom", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--profile", "custom", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.profile, Some("custom".to_string()));
             }
@@ -1704,10 +1723,8 @@ mod tests {
             #[test]
             fn no_profile_specified() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.profile, None);
             }
@@ -1720,10 +1737,8 @@ mod tests {
             #[test]
             fn default_bin_when_no_flags() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::DefaultBin);
             }
@@ -1732,10 +1747,8 @@ mod tests {
             #[test]
             fn explicit_bin() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--bin", "foo", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--bin", "foo", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::Bin("foo".to_string()));
             }
@@ -1744,10 +1757,8 @@ mod tests {
             #[test]
             fn explicit_example() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--example", "bar", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--example", "bar", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.build_target, BuildTarget::Example("bar".to_string()));
             }
@@ -1763,10 +1774,8 @@ mod tests {
             #[test]
             fn reads_default_locked_true() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.locked, "Should read locked=true from default Config");
                 assert!(!options.offline, "Should read offline=false from default Config");
@@ -1778,10 +1787,8 @@ mod tests {
                     locked: false,
                     ..Default::default()
                 };
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(!options.locked, "Should read locked=false from Config");
             }
@@ -1792,10 +1799,8 @@ mod tests {
                     offline: true,
                     ..Default::default()
                 };
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.offline, "Should read offline=true from Config");
             }
@@ -1807,10 +1812,8 @@ mod tests {
                     offline: true,
                     ..Default::default()
                 };
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(!options.locked, "Should read locked=false from Config");
                 assert!(options.offline, "Should read offline=true from Config");
@@ -1828,10 +1831,8 @@ mod tests {
             #[test]
             fn reads_default_none() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(
                     options.toolchain, None,
@@ -1845,10 +1846,8 @@ mod tests {
                     toolchain: Some("stable".to_string()),
                     ..Default::default()
                 };
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(
                     options.toolchain,
@@ -1863,10 +1862,8 @@ mod tests {
                     toolchain: Some("nightly".to_string()),
                     ..Default::default()
                 };
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(
                     options.toolchain,
@@ -1883,10 +1880,8 @@ mod tests {
             #[test]
             fn all_features() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--all-features", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--all-features", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.all_features);
             }
@@ -1895,10 +1890,8 @@ mod tests {
             #[test]
             fn no_default_features() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--no-default-features", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--no-default-features", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.no_default_features);
             }
@@ -1907,10 +1900,8 @@ mod tests {
             #[test]
             fn target() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--target", "x86_64-unknown-linux-gnu", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--target", "x86_64-unknown-linux-gnu", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.target, Some("x86_64-unknown-linux-gnu".to_string()));
             }
@@ -1919,10 +1910,8 @@ mod tests {
             #[test]
             fn jobs() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--jobs", "4", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--jobs", "4", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert_eq!(options.jobs, Some(4));
             }
@@ -1931,36 +1920,10 @@ mod tests {
             #[test]
             fn ignore_rust_version() {
                 let config = Config::default();
-                let args = Cli::parse_from_test_args(["--ignore-rust-version", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
+                let cli = Cli::parse_from_test_args(["--ignore-rust-version", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
                 assert!(options.ignore_rust_version);
-            }
-
-            /// Test that `-v` flags are converted to [`CargoVerbosity`].
-            #[test]
-            fn cargo_verbosity() {
-                let config = Config::default();
-
-                let args = Cli::parse_from_test_args(["tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
-                assert_eq!(options.cargo_verbosity, CargoVerbosity::Normal);
-
-                let args = Cli::parse_from_test_args(["-v", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
-                assert_eq!(options.cargo_verbosity, CargoVerbosity::Verbose);
-
-                let args = Cli::parse_from_test_args(["-vv", "tool"]);
-                let options =
-                    BuildOptions::load(&config, &args.crate_invocation().build_options, args.verbose())
-                        .unwrap();
-                assert_eq!(options.cargo_verbosity, CargoVerbosity::VeryVerbose);
             }
         }
     }

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -17,7 +17,7 @@ use crate::{
     Result,
     bin_resolver::ResolvedBinary,
     builder::{BuildOptions, BuildTarget},
-    config::{Config, UsePrebuiltBinaries},
+    config::Config,
     crate_resolver::{ResolvedCrate, ResolvedSource},
     cratespec::{CrateSpec, Forge, RegistrySource},
     downloader::DownloadedCrate,
@@ -203,14 +203,6 @@ impl Cache {
     where
         F: FnOnce() -> Result<Option<ResolvedBinary>>,
     {
-        // Check if prebuilt binaries are disabled entirely (before cache lookup)
-        if self.inner.config.prebuilt_binaries.use_prebuilt_binaries == UsePrebuiltBinaries::Never {
-            self.inner
-                .reporter
-                .report(PrebuiltBinaryMessage::prebuilt_binaries_disabled);
-            return Ok(None);
-        }
-
         // Check cache unless refresh mode is enabled
         let use_cache = !self.inner.config.refresh;
 

--- a/cgx-core/src/cargo.rs
+++ b/cgx-core/src/cargo.rs
@@ -48,6 +48,10 @@ pub(crate) struct CargoMetadataOptions {
     /// Require Cargo.lock is up to date.
     /// Corresponds to `--locked` flag.
     pub locked: bool,
+
+    /// Rust toolchain override to query metadata with (e.g., "nightly", "1.70.0", "stable").
+    /// When set, `cargo metadata` is run using the specified toolchain.
+    pub toolchain: Option<String>,
 }
 
 impl From<&BuildOptions> for CargoMetadataOptions {
@@ -60,6 +64,7 @@ impl From<&BuildOptions> for CargoMetadataOptions {
             no_default_features: opts.no_default_features,
             offline: opts.offline,
             locked: opts.locked,
+            toolchain: opts.toolchain.clone(),
         }
     }
 }
@@ -154,8 +159,13 @@ struct RealCargoRunner {
     verbosity: Verbosity,
 }
 
-impl CargoRunner for RealCargoRunner {
-    fn metadata(&self, source_dir: &Path, options: &CargoMetadataOptions) -> Result<Metadata> {
+impl RealCargoRunner {
+    /// Construct the complete `cargo metadata` command for the given options.
+    ///
+    /// When [`CargoMetadataOptions::toolchain`] is set, the command is routed through
+    /// `rustup run <toolchain> cargo`.  This is the same technique used for `cargo build`
+    /// elsewhere in this module.
+    fn metadata_command(&self, source_dir: &Path, options: &CargoMetadataOptions) -> Result<Command> {
         let mut cmd = cargo_metadata::MetadataCommand::new();
         cmd.cargo_path(&self.cargo_path).current_dir(source_dir);
 
@@ -212,8 +222,55 @@ impl CargoRunner for RealCargoRunner {
             cmd.other_options(other_args);
         }
 
-        cmd.exec().with_context(|_| error::CargoMetadataSnafu {
-            cargo_path: self.cargo_path.clone(),
+        // If no toolchain is specified then we're done, otherwise we need to construct a `rustup`
+        // invocation to set the toolchain.
+        let inner = cmd.cargo_command();
+        let Some(toolchain) = &options.toolchain else {
+            return Ok(inner);
+        };
+
+        let rustup_path = self
+            .rustup_path
+            .as_ref()
+            .with_context(|| error::RustupNotFoundSnafu {
+                toolchain: toolchain.clone(),
+            })?;
+
+        // The rendered cargo command's working directory does not transfer to the wrapping
+        // command, so set it again.
+        let mut wrapped = Command::new(rustup_path);
+        wrapped.args(["run", toolchain, "cargo"]);
+        wrapped.args(inner.get_args());
+        wrapped.current_dir(source_dir);
+        Ok(wrapped)
+    }
+
+    /// Run a fully constructed `cargo metadata` command and parse its output.
+    ///
+    /// Mirrors [`cargo_metadata::MetadataCommand::exec`], which cannot be used directly because the
+    /// command may be wrapped in `rustup run`.
+    fn run_metadata_command(cmd: &mut Command) -> std::result::Result<Metadata, cargo_metadata::Error> {
+        let output = cmd.output()?;
+        if !output.status.success() {
+            return Err(cargo_metadata::Error::CargoMetadata {
+                stderr: String::from_utf8(output.stderr)?,
+            });
+        }
+        let stdout = std::str::from_utf8(&output.stdout)?
+            .lines()
+            .find(|line| line.starts_with('{'))
+            .ok_or(cargo_metadata::Error::NoJson)?;
+        cargo_metadata::MetadataCommand::parse(stdout)
+    }
+}
+
+impl CargoRunner for RealCargoRunner {
+    fn metadata(&self, source_dir: &Path, options: &CargoMetadataOptions) -> Result<Metadata> {
+        let mut cmd = self.metadata_command(source_dir, options)?;
+        let program = PathBuf::from(cmd.get_program());
+
+        Self::run_metadata_command(&mut cmd).with_context(|_| error::CargoMetadataSnafu {
+            cargo_path: program,
             source_dir: source_dir.to_path_buf(),
         })
     }
@@ -477,6 +534,8 @@ fn find_executable(name: &str, env_var: &str) -> Result<PathBuf> {
 /// all various scenarios, but it's better than nothing.
 #[cfg(test)]
 mod tests {
+    use assert_matches::assert_matches;
+
     use super::*;
     use crate::{builder::BuildTarget, testdata::CrateTestCase};
 
@@ -571,6 +630,99 @@ mod tests {
             file_name == "cgx" || file_name == "cgx.exe",
             "Binary should be named cgx or cgx.exe, got {}",
             file_name
+        );
+    }
+
+    #[test]
+    fn metadata_command_uses_cargo_directly_without_toolchain() {
+        let cargo = RealCargoRunner {
+            cargo_path: PathBuf::from("/fake/cargo"),
+            rustup_path: None,
+            reporter: MessageReporter::null(),
+            verbosity: Verbosity::Normal,
+        };
+
+        let cmd = cargo
+            .metadata_command(Path::new("/src"), &CargoMetadataOptions::default())
+            .unwrap();
+
+        assert_eq!(cmd.get_program().to_string_lossy(), "/fake/cargo");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(&args[..3], ["metadata", "--format-version", "1"]);
+        assert!(!args.contains(&"run".to_string()), "args: {args:?}");
+    }
+
+    #[test]
+    fn metadata_command_wraps_cargo_with_rustup_for_toolchain() {
+        let cargo = RealCargoRunner {
+            cargo_path: PathBuf::from("/fake/cargo"),
+            rustup_path: Some(PathBuf::from("/fake/rustup")),
+            reporter: MessageReporter::null(),
+            verbosity: Verbosity::Normal,
+        };
+
+        let cmd = cargo
+            .metadata_command(
+                Path::new("/src"),
+                &CargoMetadataOptions {
+                    locked: true,
+                    toolchain: Some("nightly".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        assert_eq!(cmd.get_program().to_string_lossy(), "/fake/rustup");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            &args[..6],
+            ["run", "nightly", "cargo", "metadata", "--format-version", "1"]
+        );
+        assert!(args.contains(&"--locked".to_string()), "args: {args:?}");
+    }
+
+    #[test]
+    fn build_options_toolchain_carries_into_metadata_options() {
+        let build_options = BuildOptions {
+            toolchain: Some("nightly".to_string()),
+            ..Default::default()
+        };
+
+        let metadata_options = CargoMetadataOptions::from(&build_options);
+        assert_eq!(metadata_options.toolchain.as_deref(), Some("nightly"));
+    }
+
+    /// Metadata queries follow the same toolchain contract as builds: a requested toolchain
+    /// requires rustup, rather than being silently resolved with the default cargo.
+    #[test]
+    fn metadata_with_toolchain_requires_rustup() {
+        crate::logging::init_test_logging();
+
+        let cargo = RealCargoRunner {
+            cargo_path: find_executable("cargo", "CARGO").unwrap(),
+            rustup_path: None,
+            reporter: MessageReporter::null(),
+            verbosity: Verbosity::Normal,
+        };
+
+        let result = cargo.metadata(
+            &cgx_project_root(),
+            &CargoMetadataOptions {
+                no_deps: true,
+                toolchain: Some("nightly".to_string()),
+                ..Default::default()
+            },
+        );
+
+        assert_matches!(
+            result,
+            Err(error::Error::RustupNotFound { ref toolchain }) if toolchain == "nightly"
         );
     }
 

--- a/cgx-core/src/cargo.rs
+++ b/cgx-core/src/cargo.rs
@@ -12,42 +12,10 @@ use tracing::debug;
 use crate::{
     Result,
     builder::{BuildOptions, BuildTarget},
+    config::{Config, Verbosity},
     error,
     messages::{BuildMessage, MessageReporter},
 };
-
-/// Verbosity level for cargo build operations.
-///
-/// Maps to cargo's `-v` flags for controlling build output verbosity.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum CargoVerbosity {
-    /// Normal cargo output (no verbosity flags).
-    #[default]
-    Normal,
-
-    /// Verbose output (corresponds to `-v`).
-    Verbose,
-
-    /// Very verbose output (corresponds to `-vv`).
-    VeryVerbose,
-
-    /// Extremely verbose output including build.rs output (corresponds to `-vvv`).
-    ExtremelyVerbose,
-}
-
-impl CargoVerbosity {
-    /// Construct a [`CargoVerbosity`] from a verbosity counter.
-    ///
-    /// The counter typically comes from CLI arguments where `-v` can be repeated.
-    pub(crate) fn from_count(count: u8) -> Self {
-        match count {
-            0 => Self::Normal,
-            1 => Self::Verbose,
-            2 => Self::VeryVerbose,
-            _ => Self::ExtremelyVerbose,
-        }
-    }
-}
 
 /// Options for controlling cargo metadata invocation.
 #[derive(Clone, Debug, Default)]
@@ -156,7 +124,7 @@ pub(crate) trait CargoRunner: std::fmt::Debug + Send + Sync + 'static {
 }
 
 /// Locate cargo and construct a runner instance that will use it.
-pub(crate) fn find_cargo(reporter: MessageReporter) -> Result<impl CargoRunner> {
+pub(crate) fn create_cargo_runner(config: Config, reporter: MessageReporter) -> Result<impl CargoRunner> {
     // Locate cargo and rustup executables.
     //
     // Searches for cargo in priority order:
@@ -174,6 +142,7 @@ pub(crate) fn find_cargo(reporter: MessageReporter) -> Result<impl CargoRunner> 
         cargo_path,
         rustup_path,
         reporter,
+        verbosity: config.verbosity,
     })
 }
 
@@ -182,6 +151,7 @@ struct RealCargoRunner {
     cargo_path: PathBuf,
     rustup_path: Option<PathBuf>,
     reporter: MessageReporter,
+    verbosity: Verbosity,
 }
 
 impl CargoRunner for RealCargoRunner {
@@ -338,16 +308,16 @@ impl CargoRunner for RealCargoRunner {
             cmd.arg("--locked");
         }
 
-        // Verbosity flags
-        match options.cargo_verbosity {
-            CargoVerbosity::Normal => {}
-            CargoVerbosity::Verbose => {
+        // Translate the verbosity level to cargo's repeated `-v` flag.
+        match self.verbosity {
+            Verbosity::Normal => {}
+            Verbosity::Verbose => {
                 cmd.arg("-v");
             }
-            CargoVerbosity::VeryVerbose => {
+            Verbosity::VeryVerbose => {
                 cmd.arg("-vv");
             }
-            CargoVerbosity::ExtremelyVerbose => {
+            Verbosity::ExtremelyVerbose => {
                 cmd.arg("-vvv");
             }
         }
@@ -520,19 +490,19 @@ mod tests {
     }
 
     #[test]
-    fn find_cargo_succeeds() {
+    fn create_cargo_runner_succeeds() {
         crate::logging::init_test_logging();
 
         // This test verifies that we can locate cargo on the system.
         // This should always succeed since cargo is required to run the tests.
-        let _cargo = find_cargo(MessageReporter::null()).unwrap();
+        let _cargo = create_cargo_runner(Config::default(), MessageReporter::null()).unwrap();
     }
 
     #[test]
     fn metadata_reads_cgx_crate() {
         crate::logging::init_test_logging();
 
-        let cargo = find_cargo(MessageReporter::null()).unwrap();
+        let cargo = create_cargo_runner(Config::default(), MessageReporter::null()).unwrap();
         let cgx_root = cgx_project_root();
 
         let metadata = cargo
@@ -569,7 +539,7 @@ mod tests {
     fn build_compiles_cgx_in_tempdir() {
         crate::logging::init_test_logging();
 
-        let cargo = find_cargo(MessageReporter::null()).unwrap();
+        let cargo = create_cargo_runner(Config::default(), MessageReporter::null()).unwrap();
         let cgx_root = cgx_project_root();
         let temp_dir = tempfile::tempdir().unwrap();
 
@@ -608,7 +578,7 @@ mod tests {
     fn metadata_loads_all_testcases() {
         crate::logging::init_test_logging();
 
-        let cargo = find_cargo(MessageReporter::null()).unwrap();
+        let cargo = create_cargo_runner(Config::default(), MessageReporter::null()).unwrap();
 
         for testcase in CrateTestCase::all() {
             let result = cargo.metadata(testcase.path(), &CargoMetadataOptions::default());

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -7,7 +7,9 @@ use clap::{
 use strum::VariantNames;
 
 use crate::{
-    config::{BinaryProvider, UsePrebuiltBinaries},
+    builder::{BuildOverrides, BuildTarget},
+    config::{BinaryProvider, ConfigOverrides, LockMode, UsePrebuiltBinaries, Verbosity},
+    cratespec::{CrateRequest, Source},
     git::GitSelector,
 };
 
@@ -16,18 +18,18 @@ use crate::{
 #[derive(Clone, Debug)]
 pub enum Cli {
     /// Resolve a crate and list its runnable targets without building or executing.
-    ListTargets(CrateInvocation),
+    ListTargets(CrateArgs),
     /// Render the merged configured tools and aliases without resolving them.
     ListTools(ListTools),
     /// Prepare a crate without executing it or printing its path.
-    Prefetch(CrateInvocation),
+    Prefetch(CrateArgs),
     /// Prefetch every tool and alias configured in the `cgx` configuration.
     PrefetchAll(PrefetchAll),
     /// Prepare a crate without executing it; print the resolved binary path to stdout.
-    NoExec(CrateInvocation),
+    NoExec(CrateArgs),
     /// Prepare a crate and execute it, forwarding `tool_args` to the executed binary.
     Run {
-        invocation: CrateInvocation,
+        args: CrateArgs,
         tool_args: Vec<OsString>,
     },
 }
@@ -43,40 +45,19 @@ impl Cli {
         Self::parse_from_arg_strings(args, Some(version)).unwrap_or_else(|err| err.exit())
     }
 
-    /// Gather the configuration-affecting arguments this command supplies, defaulting the groups
-    /// the command does not accept.
+    /// Translate the configuration-affecting arguments this command supplies into a
+    /// [`ConfigOverrides`], leaving as default any options that the command doesn't accept.
     ///
-    /// Not all commands even take all config options, but by having a single [`ConfigInputs`]
-    /// representation for the sum total of CLI-based config settings it makes it easier to load
-    /// and render the config in a single shared code path.
-    pub fn config_inputs(&self) -> ConfigInputs {
+    /// Not all commands even take all config options, but by translating each into a single
+    /// [`ConfigOverrides`] representation of the sum total of CLI-based config settings it makes it
+    /// easier to load and render the config in a single shared code path.
+    pub fn to_config_overrides(&self) -> ConfigOverrides {
         match self {
-            Cli::ListTargets(invocation)
-            | Cli::Prefetch(invocation)
-            | Cli::NoExec(invocation)
-            | Cli::Run { invocation, .. } => ConfigInputs {
-                config: invocation.config.clone(),
-                http: invocation.http.clone(),
-                prebuilt: invocation.prebuilt.clone(),
-                cargo: invocation.cargo.clone(),
-                toolchain: invocation.toolchain.clone(),
-            },
-            Cli::ListTools(list_tools) => ConfigInputs {
-                config: list_tools.config.clone(),
-                toolchain: list_tools.toolchain.clone(),
-                ..ConfigInputs::default()
-            },
-            Cli::PrefetchAll(prefetch_all) => ConfigInputs {
-                config: prefetch_all.config.clone(),
-                http: prefetch_all.http.clone(),
-                prebuilt: PrebuiltBinaryArgs::default(),
-                cargo: CargoBehaviorArgs {
-                    offline: prefetch_all.offline,
-                    refresh: prefetch_all.refresh,
-                    ..CargoBehaviorArgs::default()
-                },
-                toolchain: prefetch_all.toolchain.clone(),
-            },
+            Cli::ListTargets(args) | Cli::Prefetch(args) | Cli::NoExec(args) | Cli::Run { args, .. } => {
+                args.to_config_overrides()
+            }
+            Cli::ListTools(list_tools) => list_tools.to_config_overrides(),
+            Cli::PrefetchAll(prefetch_all) => prefetch_all.to_config_overrides(),
         }
     }
 
@@ -86,17 +67,16 @@ impl Cli {
     }
 
     /// The requested verbosity level for this command.
-    pub fn verbose(&self) -> u8 {
-        self.reporting().verbose
+    pub fn verbosity(&self) -> Verbosity {
+        Verbosity::from_count(self.reporting().verbose)
     }
 
     /// The reporting controls carried by this command's variant.
     fn reporting(&self) -> &ReportingArgs {
         match self {
-            Cli::ListTargets(invocation)
-            | Cli::Prefetch(invocation)
-            | Cli::NoExec(invocation)
-            | Cli::Run { invocation, .. } => &invocation.reporting,
+            Cli::ListTargets(args) | Cli::Prefetch(args) | Cli::NoExec(args) | Cli::Run { args, .. } => {
+                &args.reporting
+            }
             Cli::ListTools(list_tools) => &list_tools.reporting,
             Cli::PrefetchAll(prefetch_all) => &prefetch_all.reporting,
         }
@@ -232,18 +212,17 @@ impl Cli {
         Self::parse_from_arg_strings(args, None)
     }
 
-    /// Borrow the [`CrateInvocation`] of a crate-level command, panicking for config-level
-    /// commands.
+    /// Borrow the [`CrateArgs`] of a crate-level command, panicking on commands that don't
+    /// take crate args.
     ///
-    /// Test helper for asserting on resolved crate invocations.
+    /// Test helper for asserting on parsed crate arguments.
     #[cfg(test)]
-    pub fn crate_invocation(&self) -> &CrateInvocation {
+    pub fn crate_args(&self) -> &CrateArgs {
         match self {
-            Cli::ListTargets(invocation)
-            | Cli::Prefetch(invocation)
-            | Cli::NoExec(invocation)
-            | Cli::Run { invocation, .. } => invocation,
-            other => panic!("expected a crate-level command, got {other:?}"),
+            Cli::ListTargets(args) | Cli::Prefetch(args) | Cli::NoExec(args) | Cli::Run { args, .. } => args,
+            other @ (Cli::ListTools(_) | Cli::PrefetchAll(_)) => {
+                panic!("expected a crate-level command, got {other:?}")
+            }
         }
     }
 
@@ -257,9 +236,12 @@ impl Cli {
     }
 }
 
-/// Arguments for the invocation (or at least preparation to invoke) a single crate.
+/// The parsed command-line arguments for preparing or running a single crate.
+///
+/// Not all possible commands involve running a single crate so not all commands will include
+/// these crate args.
 #[derive(Clone, Debug)]
-pub struct CrateInvocation {
+pub struct CrateArgs {
     /// The crate spec (name, optionally with an `@VERSION` suffix), or `None` when the name is
     /// discovered from the source (e.g. `--git`/`--path`).
     pub crate_spec: Option<String>,
@@ -285,6 +267,98 @@ pub struct CrateInvocation {
     pub toolchain: Option<String>,
 }
 
+impl CrateArgs {
+    /// Translate these arguments into a [`CrateRequest`] for [`crate::cratespec::CrateSpec::load`].
+    ///
+    /// This also performs some validation checking for conflicting args that `clap` is not
+    /// expressive enough to handle on its own, therefore it's fallible.
+    pub fn crate_request(&self) -> crate::Result<CrateRequest> {
+        // Split the CLI-only `name@version` convention into name and version-suffix string.
+        let (name, at_version) = match &self.crate_spec {
+            Some(spec) => match spec.split_once('@') {
+                Some((name, version)) => (Some(name.to_string()), Some(version.to_string())),
+                None => (Some(spec.clone()), None),
+            },
+            None => (None, None),
+        };
+
+        // Users can either specify a semver version req with the `name@version` syntax in the
+        // crate name, or they can specify the version with `--crate-version`, but they cannot
+        // provide both. (of course they can also not specify any version at all to default to the
+        // latest suitable version)
+        let version = match (at_version, self.crate_version.clone()) {
+            (Some(at_version), Some(flag_version)) => {
+                return crate::error::ConflictingVersionsSnafu {
+                    at_version,
+                    flag_version,
+                }
+                .fail();
+            }
+            (Some(version), None) | (None, Some(version)) => Some(version),
+            (None, None) => None,
+        };
+
+        Ok(CrateRequest {
+            name,
+            version,
+            source: self.source.clone(),
+            git_ref: self.git_selector.clone(),
+        })
+    }
+
+    /// Translate a subset of these arguments into [`BuildOverrides`] for
+    /// [`crate::builder::BuildOptions::load`].
+    pub fn to_build_overrides(&self) -> BuildOverrides {
+        let build = &self.build_options;
+        BuildOverrides {
+            features: build.features.as_deref().map(Self::parse_features),
+            all_features: build.all_features,
+            no_default_features: build.no_default_features,
+            profile: if build.debug {
+                Some("dev".to_string())
+            } else {
+                build.profile.clone()
+            },
+            target: build.target.clone(),
+            jobs: build.jobs,
+            ignore_rust_version: build.ignore_rust_version,
+            target_selection: build.build_target(),
+            toolchain: self.toolchain.clone(),
+        }
+    }
+
+    /// Translate a subset of these arguments into [`ConfigOverrides`]
+    pub fn to_config_overrides(&self) -> ConfigOverrides {
+        ConfigOverrides {
+            http_timeout: self.http.http_timeout.clone(),
+            http_retries: self.http.http_retries,
+            http_proxy: self.http.http_proxy.clone(),
+            lockfile: self.cargo.lock_mode(),
+            offline: self.cargo.offline,
+            refresh: self.cargo.refresh,
+            prebuilt_binary: self.prebuilt.prebuilt_binary,
+            prebuilt_binary_sources: self.prebuilt.prebuilt_binary_sources.clone(),
+            prebuilt_binary_no_verify_checksums: self.prebuilt.prebuilt_binary_no_verify_checksums,
+            prebuilt_binary_no_verify_signatures: self.prebuilt.prebuilt_binary_no_verify_signatures,
+            verbosity: Verbosity::from_count(self.reporting.verbose),
+            ..self.config.to_config_overrides()
+        }
+    }
+
+    /// Tokenize a `--features` string into individual feature names.
+    ///
+    /// Features may be separated by commas or whitespace; empty tokens are dropped, so an empty
+    /// input yields an empty vector (distinct from `--features` being absent, which the caller
+    /// represents as `None`).
+    fn parse_features(features_str: &str) -> Vec<String> {
+        features_str
+            .split(|c: char| c == ',' || c.is_whitespace())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
 /// Arguments for `--prefetch-all`
 #[derive(Clone, Debug, Default)]
 pub struct PrefetchAll {
@@ -307,32 +381,28 @@ pub struct PrefetchAll {
 }
 
 impl PrefetchAll {
-    /// Build the per-tool [`CrateInvocation`] used to prefetch one configured tool by name, given
-    /// that crate's name.
+    /// The build overrides applied to every tool prefetched by `--prefetch-all`.
     ///
-    /// None of the usual crate-level params are set here, because in the case of `--prefetch-all`
-    /// the list of crates to prefetch and all of their options come from the `cgx` config.
-    pub fn invocation_for(&self, crate_spec: &str) -> CrateInvocation {
-        CrateInvocation {
-            crate_spec: Some(crate_spec.to_string()),
-            crate_version: None,
-            source: Source::Default,
-            git_selector: GitSelector::DefaultBranch,
-            build_options: BuildOptionsArgs {
-                jobs: self.jobs,
-                ignore_rust_version: self.ignore_rust_version,
-                ..BuildOptionsArgs::default()
-            },
-            cargo: CargoBehaviorArgs {
-                offline: self.offline,
-                refresh: self.refresh,
-                ..CargoBehaviorArgs::default()
-            },
-            prebuilt: PrebuiltBinaryArgs::default(),
-            config: self.config.clone(),
-            http: self.http.clone(),
-            reporting: self.reporting.clone(),
+    /// `--prefetch-all` doesn't take per-crate compilation options, so only the generic build knobs
+    /// it does accept are set; the rest take the defaults or can be set in the config file.
+    pub fn to_build_overrides(&self) -> BuildOverrides {
+        BuildOverrides {
+            jobs: self.jobs,
+            ignore_rust_version: self.ignore_rust_version,
             toolchain: self.toolchain.clone(),
+            ..BuildOverrides::default()
+        }
+    }
+
+    /// The config overrides applied when loading config for the `--prefetch-all` run.
+    pub fn to_config_overrides(&self) -> ConfigOverrides {
+        ConfigOverrides {
+            http_timeout: self.http.http_timeout.clone(),
+            http_retries: self.http.http_retries,
+            http_proxy: self.http.http_proxy.clone(),
+            offline: self.offline,
+            refresh: self.refresh,
+            ..self.config.to_config_overrides()
         }
     }
 }
@@ -344,57 +414,15 @@ pub struct ListTools {
     pub config: ConfigArgs,
     /// Output and diagnostic controls.
     pub reporting: ReportingArgs,
-    /// Toolchain from a leading `+toolchain` token.
-    pub toolchain: Option<String>,
 }
 
-/// The source from which to obtain a crate, collapsed from the mutually-exclusive source selectors.
-///
-/// The raw strings held here are validated (URL and `owner/repo` parsing) downstream in
-/// [`CrateSpec::load`](crate::cratespec::CrateSpec::load) so that domain errors keep their typed
-/// [`Error`](crate::error::Error) variants instead of surfacing as clap errors.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub enum Source {
-    /// No explicit source selector; resolve via config if present, ultimately defaulting to
-    /// crates.io absent explicit config override.
-    #[default]
-    Default,
-    /// `--git <URL>`
-    Git { url: String },
-    /// `--registry <NAME>`
-    Registry { name: String },
-    /// `--index <URL>`
-    Index { url: String },
-    /// `--path <PATH>`
-    Path { path: PathBuf },
-    /// `--github <owner/repo>`, with optional `--github-url`
-    GitHub {
-        repo: String,
-        custom_url: Option<String>,
-    },
-    /// `--gitlab <owner/repo>`, with optional `--gitlab-url`
-    GitLab {
-        repo: String,
-        custom_url: Option<String>,
-    },
-}
-
-impl Source {
-    /// True for git-backed sources, the only sources a non-default [`GitSelector`] may accompany.
-    pub fn is_git(&self) -> bool {
-        matches!(
-            self,
-            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. }
-        )
-    }
-
-    /// True when a crate name can be discovered from the source itself, making an explicit crate
-    /// spec optional.
-    fn allows_crate_discovery(&self) -> bool {
-        matches!(
-            self,
-            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. } | Source::Path { .. }
-        )
+impl ListTools {
+    /// The config overrides applied when loading config for the `--list-tools` run.
+    pub fn to_config_overrides(&self) -> ConfigOverrides {
+        ConfigOverrides {
+            verbosity: Verbosity::from_count(self.reporting.verbose),
+            ..self.config.to_config_overrides()
+        }
     }
 }
 
@@ -464,9 +492,21 @@ impl BuildOptionsArgs {
     fn is_present(&self) -> bool {
         self.has_compilation_options() || self.jobs.is_some() || self.ignore_rust_version
     }
-}
 
-/// Lockfile and cache behavior flags that affect dependency resolution and cache identity for one tool.
+    /// Resolve the mutually-exclusive `--bin`/`--example` flags into a [`BuildTarget`].
+    fn build_target(&self) -> BuildTarget {
+        match (&self.bin, &self.example) {
+            (Some(_), Some(_)) => {
+                unreachable!("BUG: clap should enforce mutual exclusivity");
+            }
+            (Some(bin_name), None) => BuildTarget::Bin(bin_name.clone()),
+            (None, Some(example_name)) => BuildTarget::Example(example_name.clone()),
+            (None, None) => BuildTarget::default(),
+        }
+    }
+}
+/// Lockfile and cache behavior flags that affect dependency resolution and cache identity for one
+/// tool.
 ///
 /// The mutually-exclusive `--locked`/`--frozen`/`--unlocked` flags share a `lockfile`
 /// arg-group
@@ -491,6 +531,24 @@ pub struct CargoBehaviorArgs {
     /// Force refresh of all cached data for this crate.
     #[arg(long)]
     pub refresh: bool,
+}
+
+impl CargoBehaviorArgs {
+    /// Collapse the mutually-exclusive `--locked`/`--frozen`/`--unlocked` flags into a
+    /// [`LockMode`].
+    ///
+    /// The `lockfile` clap arg-group guarantees at most one is set.
+    fn lock_mode(&self) -> LockMode {
+        if self.unlocked {
+            LockMode::Unlocked
+        } else if self.frozen {
+            LockMode::Frozen
+        } else if self.locked {
+            LockMode::Locked
+        } else {
+            LockMode::Default
+        }
+    }
 }
 
 /// Creates a clap value parser that uses strum's [`VariantNames`] for possible values
@@ -565,6 +623,20 @@ pub struct ConfigArgs {
     pub user_config_dir: Option<PathBuf>,
 }
 
+impl ConfigArgs {
+    /// Create a new [`ConfigOverrides`] consisting of default values except those that are
+    /// overridden by options specified in this struct.
+    fn to_config_overrides(&self) -> ConfigOverrides {
+        ConfigOverrides {
+            config_file: self.config_file.clone(),
+            system_config_dir: self.system_config_dir.clone(),
+            app_dir: self.app_dir.clone(),
+            user_config_dir: self.user_config_dir.clone(),
+            ..ConfigOverrides::default()
+        }
+    }
+}
+
 /// Network tuning options used by commands that may resolve, download, or build crates.
 #[derive(Clone, Debug, Default, Args)]
 pub struct HttpArgs {
@@ -613,22 +685,6 @@ pub struct ReportingArgs {
 pub enum MessageFormat {
     /// JSON format, one message per line
     Json,
-}
-
-/// The subset of arguments that influence configuration loading, gathered per command variant by
-/// [`Cli::config_inputs`].
-#[derive(Clone, Debug, Default)]
-pub struct ConfigInputs {
-    /// Config file discovery overrides.
-    pub config: ConfigArgs,
-    /// HTTP tuning options.
-    pub http: HttpArgs,
-    /// Pre-built binary lookup config.
-    pub prebuilt: PrebuiltBinaryArgs,
-    /// Cargo behavior flags (lockfile / offline / refresh).
-    pub cargo: CargoBehaviorArgs,
-    /// Toolchain from a leading `+toolchain` token.
-    pub toolchain: Option<String>,
 }
 
 // Raw clap parse result.
@@ -827,14 +883,14 @@ impl RawCli {
             if http.is_present() {
                 return Err(Self::forbidden(mode, "--http-* options"));
             }
-            return Ok(Cli::ListTools(ListTools {
-                config,
-                reporting,
-                toolchain,
-            }));
+            if toolchain.is_some() {
+                return Err(Self::forbidden(mode, "+toolchain"));
+            }
+            return Ok(Cli::ListTools(ListTools { config, reporting }));
         }
 
-        // Crate-level commands (run / no-exec / prefetch / list-targets).
+        // By this point we know that the command is one that operates on a specific crate, so
+        // crate-level args are supported as well
         let git_selector = source.git_selector();
         let source = source.to_source();
 
@@ -855,7 +911,7 @@ impl RawCli {
             ));
         }
 
-        let invocation = CrateInvocation {
+        let crate_args = CrateArgs {
             crate_spec,
             crate_version,
             source,
@@ -871,15 +927,15 @@ impl RawCli {
 
         if prefetch {
             Self::ensure_no_crate_args(&tool_args, "--prefetch")?;
-            Ok(Cli::Prefetch(invocation))
+            Ok(Cli::Prefetch(crate_args))
         } else if list_targets {
             Self::ensure_no_crate_args(&tool_args, "--list-targets")?;
-            Ok(Cli::ListTargets(invocation))
+            Ok(Cli::ListTargets(crate_args))
         } else if no_exec {
-            Ok(Cli::NoExec(invocation))
+            Ok(Cli::NoExec(crate_args))
         } else {
             Ok(Cli::Run {
-                invocation,
+                args: crate_args,
                 tool_args,
             })
         }
@@ -1067,12 +1123,29 @@ mod tests {
         RawCli::command().debug_assert();
     }
 
+    /// The repeated `-v` flag maps to a [`Verbosity`] level, saturating at the most verbose.
+    #[test]
+    fn verbosity_reflects_repeated_v_flag() {
+        let cases = [
+            (vec!["tool"], Verbosity::Normal),
+            (vec!["-v", "tool"], Verbosity::Verbose),
+            (vec!["-vv", "tool"], Verbosity::VeryVerbose),
+            (vec!["-vvv", "tool"], Verbosity::ExtremelyVerbose),
+            (vec!["-vvvv", "tool"], Verbosity::ExtremelyVerbose),
+        ];
+        for (args, expected) in cases {
+            let verbosity = Cli::parse_from_test_args(args).verbosity();
+            assert_eq!(verbosity, expected);
+        }
+    }
+
     mod cratespec {
         use super::*;
         fn parse_cratespec_from_args(args: &[&str]) -> Result<CrateSpec> {
             let cli = Cli::parse_from_test_args(args);
             let config = Config::default();
-            CrateSpec::load(&config, cli.crate_invocation())
+            let request = cli.crate_args().crate_request()?;
+            CrateSpec::load(&config, &request)
         }
 
         #[test]
@@ -1105,17 +1178,13 @@ mod tests {
         }
 
         #[test]
-        fn test_crate_with_matching_versions() {
-            let cr = parse_cratespec_from_args(&["--crate-version", "14", "ripgrep@14"]).unwrap();
-            assert_matches!(
-                cr,
-                CrateSpec::CratesIo { ref name, version: Some(ref v) }
-                if name == "ripgrep" && v == &semver::VersionReq::parse("14").unwrap()
-            );
-        }
-
-        #[test]
         fn test_crate_with_conflicting_versions() {
+            // Users can only specify the crate semver version req one way, either
+            // `--crate-version` or as part of the crate name.  It doesn't matter if they specify
+            // the same version in both, or different versions, it's not allowed.
+            let result = parse_cratespec_from_args(&["--crate-version", "14", "ripgrep@14"]);
+            assert_matches!(result, Err(crate::error::Error::ConflictingVersions { .. }));
+
             let result = parse_cratespec_from_args(&["--crate-version", "15", "ripgrep@14"]);
             assert_matches!(result, Err(crate::error::Error::ConflictingVersions { .. }));
         }
@@ -1575,7 +1644,7 @@ mod tests {
         fn parse_build_options_from_args(args: &[&str]) -> Result<BuildOptions> {
             let cli = Cli::parse_from_test_args(args);
             let config = Config::default();
-            BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose())
+            BuildOptions::load(&config, &cli.crate_args().to_build_overrides())
         }
 
         #[test]
@@ -1638,8 +1707,7 @@ mod tests {
                 offline: true,
                 ..Default::default()
             };
-            let opts =
-                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
+            let opts = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
             assert!(opts.locked);
             assert!(opts.offline);
         }
@@ -1652,8 +1720,7 @@ mod tests {
                 offline: false,
                 ..Default::default()
             };
-            let opts =
-                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
+            let opts = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
             assert!(opts.locked);
             assert!(!opts.offline);
         }
@@ -1666,8 +1733,7 @@ mod tests {
                 offline: true,
                 ..Default::default()
             };
-            let opts =
-                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
+            let opts = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
             assert!(!opts.locked);
             assert!(opts.offline);
         }
@@ -1793,7 +1859,7 @@ mod tests {
             let args = vec!["+nightly", "ripgrep", "--version", "14"];
             let cli = Cli::parse_from_test_args(args);
 
-            let invocation = cli.crate_invocation();
+            let invocation = cli.crate_args();
             assert_eq!(invocation.toolchain.as_deref(), Some("nightly"));
             assert_eq!(invocation.crate_spec.as_deref(), Some("ripgrep"));
 
@@ -1812,8 +1878,7 @@ mod tests {
                 toolchain: Some("nightly".to_string()),
                 ..Default::default()
             };
-            let opts =
-                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
+            let opts = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
             assert_eq!(opts.toolchain, Some("nightly".to_string()));
         }
 
@@ -1823,8 +1888,7 @@ mod tests {
             let cli = Cli::parse_from_test_args(args);
 
             let config = Config::default();
-            let opts =
-                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
+            let opts = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
             assert_eq!(opts.toolchain, None);
         }
     }
@@ -1835,8 +1899,6 @@ mod tests {
         #[test]
         fn test_config_overrides_can_combine() {
             // Verify that system-config-dir, app-dir, and user-config-dir work together.
-            // This tests our design decision that these three options are compatible,
-            // not just clap functionality.
             let inputs = Cli::parse_from_test_args([
                 "--system-config-dir",
                 "/tmp/system",
@@ -1846,13 +1908,10 @@ mod tests {
                 "/tmp/user",
                 "ripgrep",
             ])
-            .config_inputs();
-            assert_eq!(
-                inputs.config.system_config_dir,
-                Some(PathBuf::from("/tmp/system"))
-            );
-            assert_eq!(inputs.config.app_dir, Some(PathBuf::from("/tmp/app")));
-            assert_eq!(inputs.config.user_config_dir, Some(PathBuf::from("/tmp/user")));
+            .to_config_overrides();
+            assert_eq!(inputs.system_config_dir, Some(PathBuf::from("/tmp/system")));
+            assert_eq!(inputs.app_dir, Some(PathBuf::from("/tmp/app")));
+            assert_eq!(inputs.user_config_dir, Some(PathBuf::from("/tmp/user")));
         }
     }
 
@@ -1872,7 +1931,7 @@ mod tests {
             .unwrap();
 
             assert_matches!(&cli, Cli::Prefetch(_));
-            let invocation = cli.crate_invocation();
+            let invocation = cli.crate_args();
             assert_eq!(invocation.crate_spec.as_deref(), Some("timestamp"));
             assert_eq!(invocation.build_options.features.as_deref(), Some("frobnulator"));
             assert!(cli.tool_args().is_empty());
@@ -1929,6 +1988,39 @@ mod tests {
                 prefetch_all.config.user_config_dir,
                 Some(PathBuf::from("/tmp/user"))
             );
+        }
+
+        #[test]
+        fn prefetch_all_controls_reach_loaders() {
+            // The parse test above checks the raw flags properly map to `PrefetchAll`; this checks they
+            // actually flow through into `BuildOptions` and `Config`
+            let cli = Cli::parse_from_test_args([
+                "--prefetch-all",
+                "--offline",
+                "--refresh",
+                "--jobs",
+                "2",
+                "--ignore-rust-version",
+            ]);
+            let Cli::PrefetchAll(prefetch_all) = &cli else {
+                panic!("expected a prefetch-all command");
+            };
+
+            // Build knobs reach BuildOptions.
+            let build_options =
+                BuildOptions::load(&Config::default(), &prefetch_all.to_build_overrides()).unwrap();
+            assert_eq!(build_options.jobs, Some(2));
+            assert!(build_options.ignore_rust_version);
+
+            // Network/refresh knobs reach Config, loaded from an isolated tree so host config
+            // cannot interfere with the assertion.
+            let temp = tempfile::tempdir().unwrap();
+            let mut overrides = prefetch_all.to_config_overrides();
+            overrides.system_config_dir = Some(temp.path().join("system"));
+            overrides.user_config_dir = Some(temp.path().join("user"));
+            let config = Config::load_from_dir(temp.path(), &overrides).unwrap();
+            assert!(config.offline);
+            assert!(config.refresh);
         }
 
         #[test]
@@ -2005,6 +2097,9 @@ mod tests {
             }
         }
 
+        /// If `--features` isn't present on the command line and the config TOML has an entry for
+        /// the crate in the `[tools]` section that specifies features, those features are applied
+        /// to the build options for that crate.
         #[test]
         fn config_features_apply_when_cli_features_absent() {
             let cli = Cli::parse_from_test_args(["timestamp"]);
@@ -2023,17 +2118,21 @@ mod tests {
                 },
             );
 
-            let options = BuildOptions::load_for_tool_name(
+            let options = BuildOptions::load_for_crate(
                 &config,
-                &cli.crate_invocation().build_options,
-                cli.verbose(),
-                Some("timestamp"),
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
             )
             .unwrap();
 
             assert_eq!(options.features, vec!["frobnulator"]);
         }
 
+        /// When the config TOML contains a crate in the `[tools]` section that specifies features,
+        /// that is overridden by any features specified on the CLI.
         #[test]
         fn cli_features_replace_config_features() {
             let cli = Cli::parse_from_test_args(["--features", "gonkolator", "timestamp"]);
@@ -2052,11 +2151,13 @@ mod tests {
                 },
             );
 
-            let options = BuildOptions::load_for_tool_name(
+            let options = BuildOptions::load_for_crate(
                 &config,
-                &cli.crate_invocation().build_options,
-                cli.verbose(),
-                Some("timestamp"),
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
             )
             .unwrap();
 
@@ -2083,14 +2184,14 @@ mod tests {
         #[test]
         fn crate_then_tool_args_pass_through_without_dashdash() {
             let cli = run(&["ripgrep", "--color=always", "-i"]);
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("ripgrep"));
             assert_eq!(tool_args(&cli), ["--color=always", "-i"]);
         }
 
         #[test]
         fn cgx_flags_before_crate_are_not_tool_args() {
             let cli = run(&["--features", "foo", "ripgrep", "--color=always", "-i"]);
-            let invocation = cli.crate_invocation();
+            let invocation = cli.crate_args();
             assert_eq!(invocation.crate_spec.as_deref(), Some("ripgrep"));
             assert_eq!(invocation.build_options.features.as_deref(), Some("foo"));
             assert_eq!(tool_args(&cli), ["--color=always", "-i"]);
@@ -2100,10 +2201,7 @@ mod tests {
         fn same_flag_before_and_after_crate_is_split_by_position() {
             // `-F x` is cgx's features flag; `-F y` after the crate is forwarded to the tool.
             let cli = run(&["-F", "x", "ripgrep", "-F", "y"]);
-            assert_eq!(
-                cli.crate_invocation().build_options.features.as_deref(),
-                Some("x")
-            );
+            assert_eq!(cli.crate_args().build_options.features.as_deref(), Some("x"));
             assert_eq!(tool_args(&cli), ["-F", "y"]);
         }
 
@@ -2112,7 +2210,7 @@ mod tests {
             // The hard requirement: `cgx <crate> --version` runs the tool with `--version` and must
             // NOT print cgx's own version.
             let cli = run(&["ripgrep", "--version"]);
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("ripgrep"));
             assert_eq!(tool_args(&cli), ["--version"]);
 
             let cli = run(&["ripgrep", "-V"]);
@@ -2122,21 +2220,21 @@ mod tests {
         #[test]
         fn explicit_dashdash_forwards_following_args() {
             let cli = run(&["ripgrep", "--", "--version"]);
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("ripgrep"));
             assert_eq!(tool_args(&cli), ["--version"]);
         }
 
         #[test]
         fn at_version_suffix_with_tool_version_flag() {
             let cli = run(&["eza@=0.23.1", "--version"]);
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("eza@=0.23.1"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("eza@=0.23.1"));
             assert_eq!(tool_args(&cli), ["--version"]);
         }
 
         #[test]
         fn cargo_subcommand_is_normalized_and_remaining_args_forwarded() {
             let cli = run(&["cargo", "deny", "--all"]);
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("cargo-deny"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("cargo-deny"));
             assert_eq!(tool_args(&cli), ["--all"]);
         }
 
@@ -2145,7 +2243,7 @@ mod tests {
             // `prefetch` (no dashes) is a crate name, not the `--prefetch` mode.
             let cli = run(&["prefetch"]);
             assert_matches!(&cli, Cli::Run { .. });
-            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("prefetch"));
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("prefetch"));
         }
     }
 
@@ -2155,20 +2253,20 @@ mod tests {
         #[test]
         fn test_http_timeout_cli_arg() {
             let cli = Cli::parse_from_test_args(["--http-timeout", "2m", "test-crate"]);
-            assert_eq!(cli.crate_invocation().http.http_timeout, Some("2m".to_string()));
+            assert_eq!(cli.crate_args().http.http_timeout, Some("2m".to_string()));
         }
 
         #[test]
         fn test_http_retries_cli_arg() {
             let cli = Cli::parse_from_test_args(["--http-retries", "5", "test-crate"]);
-            assert_eq!(cli.crate_invocation().http.http_retries, Some(5));
+            assert_eq!(cli.crate_args().http.http_retries, Some(5));
         }
 
         #[test]
         fn test_http_proxy_cli_arg() {
             let cli = Cli::parse_from_test_args(["--http-proxy", "socks5://localhost:1080", "test-crate"]);
             assert_eq!(
-                cli.crate_invocation().http.http_proxy,
+                cli.crate_args().http.http_proxy,
                 Some("socks5://localhost:1080".to_string())
             );
         }
@@ -2176,15 +2274,15 @@ mod tests {
         #[test]
         fn test_http_args_default_none() {
             let cli = Cli::parse_from_test_args(["test-crate"]);
-            assert_eq!(cli.crate_invocation().http.http_timeout, None);
-            assert_eq!(cli.crate_invocation().http.http_retries, None);
-            assert_eq!(cli.crate_invocation().http.http_proxy, None);
+            assert_eq!(cli.crate_args().http.http_timeout, None);
+            assert_eq!(cli.crate_args().http.http_retries, None);
+            assert_eq!(cli.crate_args().http.http_proxy, None);
         }
 
         #[test]
         fn test_http_args_after_crate_spec_are_binary_args() {
             let cli = Cli::parse_from_test_args(["test-crate", "--http-timeout", "5s"]);
-            assert_eq!(cli.crate_invocation().http.http_timeout, None);
+            assert_eq!(cli.crate_args().http.http_timeout, None);
             let tool_args: Vec<&str> = cli.tool_args().iter().map(|arg| arg.to_str().unwrap()).collect();
             assert_eq!(tool_args, ["--http-timeout", "5s"]);
         }

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -1,429 +1,121 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{ffi::OsString, path::PathBuf};
 
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum, builder::TypedValueParser};
+use clap::{
+    ArgAction, Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum,
+    builder::TypedValueParser, error::ErrorKind,
+};
 use strum::VariantNames;
 
-use crate::config::{BinaryProvider, UsePrebuiltBinaries};
+use crate::{
+    config::{BinaryProvider, UsePrebuiltBinaries},
+    git::GitSelector,
+};
 
-/// Creates a clap value parser that uses strum's [`VariantNames`] for possible values
-/// and strum's [`FromStr`](std::str::FromStr) for parsing. This ensures:
-/// - `--help` shows valid values (from `VARIANTS`)
-/// - Parsing uses the same logic as config files (strum's [`EnumString`](strum::EnumString))
-macro_rules! strum_value_parser {
-    ($t:ty) => {
-        clap::builder::PossibleValuesParser::new(<$t>::VARIANTS).map(|s| s.parse::<$t>().unwrap())
-    };
+/// A fully validated command, produced by parsing the CLI args with
+/// [`Self::parse_from_cli_args`]
+#[derive(Clone, Debug)]
+pub enum Cli {
+    /// Resolve a crate and list its runnable targets without building or executing.
+    ListTargets(CrateInvocation),
+    /// Render the merged configured tools and aliases without resolving them.
+    ListTools(ListTools),
+    /// Prepare a crate without executing it or printing its path.
+    Prefetch(CrateInvocation),
+    /// Prefetch every tool and alias configured in the `cgx` configuration.
+    PrefetchAll(PrefetchAll),
+    /// Prepare a crate without executing it; print the resolved binary path to stdout.
+    NoExec(CrateInvocation),
+    /// Prepare a crate and execute it, forwarding `tool_args` to the executed binary.
+    Run {
+        invocation: CrateInvocation,
+        tool_args: Vec<OsString>,
+    },
 }
 
-/// Output format for structured messages.
-#[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum MessageFormat {
-    /// JSON format, one message per line
-    Json,
-}
-
-/// CLI arguments that are crate-specific and passed through to cargo build.
-///
-/// These args are segreated from the other CLI args to make the semantic distinction more
-/// explicit.  Most CLI args can also be set in config files to apply globally, but these are
-/// always crate-specific.
-#[derive(Clone, Debug, Default, Parser)]
-pub struct BuildOptionsArgs {
-    /// Space or comma separated list of features to activate
-    #[arg(short = 'F', long, value_name = "FEATURES")]
-    pub features: Option<String>,
-
-    /// Activate all available features
-    #[arg(long)]
-    pub all_features: bool,
-
-    /// Do not activate the default features
-    #[arg(long)]
-    pub no_default_features: bool,
-
-    /// Build with the specified profile
-    #[arg(long, value_name = "PROFILE-NAME", conflicts_with = "debug")]
-    pub profile: Option<String>,
-
-    /// Build in debug mode (with the 'dev' profile) instead of release mode
-    #[arg(long)]
-    pub debug: bool,
-
-    /// Build for the target triple
-    #[arg(long, value_name = "TRIPLE")]
-    pub target: Option<String>,
-
-    /// Number of parallel jobs, defaults to # of CPUs
-    #[arg(short = 'j', long, value_name = "N")]
-    pub jobs: Option<usize>,
-
-    /// Ignore `rust-version` specification in packages
-    #[arg(long)]
-    pub ignore_rust_version: bool,
-
-    /// Install only the specified binary
-    #[arg(long, value_name = "NAME", conflicts_with = "example")]
-    pub bin: Option<String>,
-
-    /// Install only the specified example
-    #[arg(long, value_name = "NAME")]
-    pub example: Option<String>,
-}
-
-#[derive(Clone, Debug, Parser)]
-#[command(name = "cgx")]
-#[command(about = "Rust equivalent of uvx or npx, for use with Rust crates")]
-#[command(disable_version_flag = true)]
-#[non_exhaustive]
-pub struct CliArgs {
-    /// Rust toolchain to use for building (e.g., +nightly, +stable, +1.70.0)
+impl Cli {
+    /// Parse the process command line into a validated [`Cli`] command.
     ///
-    /// This field is populated via pre-processing before clap parsing and is not directly
-    /// parsed from command line arguments.
-    #[arg(skip)]
-    pub toolchain: Option<String>,
-
-    /// Find crate in git repository at the given URL
-    #[arg(long, conflicts_with_all = ["registry", "path", "github", "gitlab", "index"])]
-    pub git: Option<String>,
-
-    /// Name of registry (configured in .cargo/config.toml) in which to find crate
-    #[arg(long, conflicts_with_all = ["git", "path", "github", "gitlab", "index"])]
-    pub registry: Option<String>,
-
-    /// Filesystem path to local crate to install from
-    #[arg(long, conflicts_with_all = ["git", "registry", "github", "gitlab", "index"])]
-    pub path: Option<PathBuf>,
-
-    /// Find crate in GitHub repository (format: owner/repo)
-    #[arg(long, conflicts_with_all = ["git", "registry", "path", "gitlab", "index"])]
-    pub github: Option<String>,
-
-    /// Find crate in GitLab repository (format: owner/repo)
-    #[arg(long, conflicts_with_all = ["git", "registry", "path", "github", "index"])]
-    pub gitlab: Option<String>,
-
-    /// Registry index URL to use
-    #[arg(long, conflicts_with_all = ["git", "registry", "path", "github", "gitlab"], value_name = "INDEX")]
-    pub index: Option<String>,
-
-    /// Custom GitHub instance URL (for GitHub Enterprise)
-    #[arg(long, requires = "github")]
-    pub github_url: Option<String>,
-
-    /// Custom GitLab instance URL (for self-hosted GitLab)
-    #[arg(long, requires = "gitlab")]
-    pub gitlab_url: Option<String>,
-
-    /// Branch to use when installing from a git repo
-    #[arg(long, conflicts_with_all = ["tag", "rev"])]
-    pub branch: Option<String>,
-
-    /// Tag to use when installing from a git repo
-    #[arg(long, conflicts_with_all = ["branch", "rev"])]
-    pub tag: Option<String>,
-
-    /// Specific commit to use when installing from a git repo
-    #[arg(long, conflicts_with_all = ["branch", "tag"])]
-    pub rev: Option<String>,
-
-    /// Print version information, or specify a crate version to install.
-    ///
-    /// When used without a value (e.g., `cgx --version`), prints the version of cgx itself.
-    /// When used with a value (e.g., `cgx foo --version 1.0`), specifies the version of the
-    /// crate to install (alternative to @VERSION suffix in crate name).
-    #[arg(short = 'V', long, num_args = 0..=1, default_missing_value = "", value_name = "VERSION")]
-    pub version: Option<String>,
-
-    /// Build-specific options that are passed through to cargo.
-    #[command(flatten)]
-    pub build_options: BuildOptionsArgs,
-
-    /// Honor Cargo.lock from the crate, equivalent to passing `--locked` to `cargo install`
-    ///
-    /// This is enabled by default; the command-line flag is present only for compatibility with
-    /// `cargo install` command lines.
-    ///
-    /// Unlike `cargo install`, `cgx` defaults to `--locked` behavior because this is almost always
-    /// preferable to re-resoving dependencies to versions that the binary crate author possibly
-    /// didn't test with.
-    ///
-    /// Use --unlocked to ignore Cargo.lock entirely, which is what `cargo install` does if not
-    /// passed the `--locked` flag.
-    #[arg(long, conflicts_with = "unlocked")]
-    pub locked: bool,
-
-    /// Equivalent to specifying both --locked and --offline
-    #[arg(long, conflicts_with = "unlocked")]
-    pub frozen: bool,
-
-    /// Ignore Cargo.lock and resolve dependencies fresh
-    ///
-    /// Deletes Cargo.lock from build directory before building,
-    /// forcing fresh dependency resolution. This mimics `cargo install` (without --locked).
-    #[arg(long, conflicts_with_all = ["locked", "frozen"])]
-    pub unlocked: bool,
-
-    /// Run without accessing the network
-    #[arg(long)]
-    pub offline: bool,
-
-    /// Use verbose output (-vv very verbose/build.rs output)
-    #[arg(short = 'v', long, action = clap::ArgAction::Count)]
-    pub verbose: u8,
-
-    /// Do not print cargo log messages
-    #[arg(short = 'q', long)]
-    pub quiet: bool,
-
-    /// Coloring: auto, always, never
-    #[arg(long, value_name = "WHEN")]
-    pub color: Option<String>,
-
-    /// Read configuration options from the given TOML file only, bypassing the usual config search
-    /// paths.
-    ///
-    /// By default, cgx will look for a file in the current directory called `cgx.toml`, if not
-    /// found it will check the parent, and the grandparent, up to the root.
-    ///
-    /// It will also read a `cgx.toml` file in the user's config directory, and it will read a
-    /// system-level `cgx.toml` at `/etc/cgx.toml`, or the equivalent on other OSes.
-    ///
-    /// All config files' options are merged, with highest priority given to the file closest to
-    /// the current directory.
-    ///
-    /// Specifying a config file with this option disables that logic, and
-    /// reads the config only from the specified file.
-    #[arg(
-        long,
-        value_name = "FILE",
-        conflicts_with_all = ["system_config_dir", "app_dir", "user_config_dir"]
-    )]
-    pub config_file: Option<PathBuf>,
-
-    /// Override the system config directory location.
-    ///
-    /// When set, cgx will look for `cgx.toml` in this directory instead of the default
-    /// system location (`/etc` on Unix, `%ProgramData%\cgx` on Windows).
-    ///
-    /// This is primarily useful for testing and CI environments where you need complete
-    /// control over config file locations without modifying system directories.
-    ///
-    /// Can also be set via the `CGX_SYSTEM_CONFIG_DIR` environment variable, with the
-    /// command-line argument taking precedence.
-    #[arg(long, value_name = "PATH", env = "CGX_SYSTEM_CONFIG_DIR")]
-    pub system_config_dir: Option<PathBuf>,
-
-    /// Override the base application directory.
-    ///
-    /// When set, cgx uses this as the root for all application data:
-    /// - Config: `<app-dir>/config/cgx.toml`
-    /// - Cache: `<app-dir>/cache/`
-    /// - Binaries: `<app-dir>/bins/`
-    /// - Build artifacts: `<app-dir>/build/`
-    ///
-    /// This provides complete isolation of cgx's data, useful for testing, CI, or
-    /// managing multiple independent cgx environments.
-    ///
-    /// Can also be set via the `CGX_APP_DIR` environment variable, with the
-    /// command-line argument taking precedence.
-    #[arg(long, value_name = "PATH", env = "CGX_APP_DIR")]
-    pub app_dir: Option<PathBuf>,
-
-    /// Override the user config directory location.
-    ///
-    /// When set, cgx will look for `cgx.toml` in this directory instead of the default
-    /// user config location (typically `$XDG_CONFIG_HOME/cgx` or platform equivalent).
-    ///
-    /// This option is more specific than `--app-dir`: when both are set, `--user-config-dir`
-    /// determines where cgx looks for the user config file, while `--app-dir` determines
-    /// the locations for cache, bins, and build directories.
-    ///
-    /// Can also be set via the `CGX_USER_CONFIG_DIR` environment variable, with the
-    /// command-line argument taking precedence.
-    #[arg(long, value_name = "PATH", env = "CGX_USER_CONFIG_DIR")]
-    pub user_config_dir: Option<PathBuf>,
-
-    /// HTTP request timeout (e.g., "30s", "2m").
-    ///
-    /// Controls the per-request timeout for registry queries, binary downloads,
-    /// and API calls.
-    ///
-    /// For git operations over HTTP/S, this timeout is also used by gix for both
-    /// connection timeout and stalled-transfer timeout detection.
-    ///
-    /// If not set, cgx honors the Cargo environment variable `CARGO_HTTP_TIMEOUT`
-    /// (integer seconds). If not set, defaults to 30s.
-    #[arg(long, value_name = "DURATION", env = "CGX_HTTP_TIMEOUT")]
-    pub http_timeout: Option<String>,
-
-    /// Maximum number of retries for transient HTTP failures (0 = no retries).
-    ///
-    /// When an HTTP request fails due to a transient error (rate limiting, server
-    /// errors, connection issues), cgx will retry up to this many times with
-    /// exponential backoff.
-    ///
-    /// If not set, cgx honors the Cargo environment variable `CARGO_NET_RETRY`
-    /// (integer). If not set, defaults to 2.
-    #[arg(long, value_name = "N", env = "CGX_HTTP_RETRIES")]
-    pub http_retries: Option<usize>,
-
-    /// HTTP or SOCKS5 proxy URL for all HTTP requests.
-    ///
-    /// Routes all HTTP requests through the specified proxy, including git
-    /// operations over HTTP/S. Supports http://, https://, and socks5:// URL
-    /// schemes. For proxy authentication, embed credentials in the URL:
-    /// `http://user:password@host:port`.
-    ///
-    /// If not set, cgx honors the Cargo environment variable `CARGO_HTTP_PROXY`,
-    /// followed by standard proxy variables (`HTTPS_PROXY`, `https_proxy`,
-    /// `http_proxy`). If none are set, no proxy is used.
-    #[arg(long, value_name = "URL", env = "CGX_HTTP_PROXY")]
-    pub http_proxy: Option<String>,
-
-    /// Build the binary but do not execute it; print its path to stdout instead.
-    ///
-    /// Performs all normal operations (resolve, download, build) but instead of executing
-    /// the binary at the end, prints its absolute path to stdout and exits with code 0.
-    /// All diagnostic output goes to stderr, making stdout clean for scripting.
-    ///
-    /// Useful for testing, scripting (e.g., `tool=$(cgx --no-exec ripgrep)`), or obtaining
-    /// a binary to run through debuggers/profilers.
-    #[arg(long)]
-    pub no_exec: bool,
-
-    /// Force refresh of all cached data for this crate.
-    ///
-    /// When set, cgx will bypass all cache lookups and perform fresh resolution, download, and
-    /// build operations. This also disables the fallback to stale cache entries on network errors,
-    /// so cgx will fail if a network error occurs rather than using potentially outdated cached
-    /// data.
-    #[arg(long)]
-    pub refresh: bool,
-
-    /// Control use of pre-built binaries: never (always build from source), always (fail if no
-    /// prebuilt binary found), or auto (use if available, fallback to build).
-    ///
-    /// When set to 'auto' (the default), cgx will attempt to download pre-built binaries from
-    /// configured providers and fall back to building from source if none are found. When set to
-    /// 'always', cgx will fail if no pre-built binary is found. When set to 'never', cgx will
-    /// always build from source and never look for pre-built binaries.
-    #[arg(long, value_name = "WHEN", value_parser = strum_value_parser!(UsePrebuiltBinaries))]
-    pub prebuilt_binary: Option<UsePrebuiltBinaries>,
-
-    /// Override the binary providers to check for pre-built binaries.
-    ///
-    /// Accepts a comma-separated list of providers to enable.
-    #[arg(
-        long,
-        value_name = "SOURCES",
-        value_delimiter = ',',
-        value_parser = strum_value_parser!(BinaryProvider)
-    )]
-    pub prebuilt_binary_sources: Option<Vec<BinaryProvider>>,
-
-    /// Disable checksum verification when downloading pre-built binaries.
-    ///
-    /// By default, cgx verifies downloaded binaries against checksums when available.
-    /// This flag disables that verification, which may be useful for debugging or
-    /// when checksums are known to be incorrect.
-    #[arg(long)]
-    pub prebuilt_binary_no_verify_checksums: bool,
-
-    /// Disable signature verification when downloading pre-built binaries.
-    ///
-    /// By default, cgx verifies downloaded binaries against signatures when available.
-    /// This flag disables that verification, which may be useful when minisign is not
-    /// installed or for debugging purposes.
-    #[arg(long)]
-    pub prebuilt_binary_no_verify_signatures: bool,
-
-    /// Output structured messages in the specified format.
-    ///
-    /// When set to "json", cgx will output machine-readable JSON messages to stdout describing
-    /// its operations: cache lookups, resolution results, downloads, builds, and execution plans.
-    /// This is useful for debugging, integration testing, and building tooling on top of cgx.
-    ///
-    /// All tracing/log output goes to stderr, keeping stdout clean for structured messages.
-    /// Each message is a single line of JSON.
-    ///
-    /// NOTE: The format of the JSON messages is considered unstable and may change in future
-    /// releases. This option is primarily intended for debugging and testing purposes.
-    #[arg(long, value_name = "FMT")]
-    pub message_format: Option<MessageFormat>,
-
-    /// List the crate's executable targets (bins and examples) without building or executing.
-    ///
-    /// Performs resolve and download operations, then inspects the crate's Cargo.toml
-    /// metadata to list all binary and example targets. Indicates which binary is the
-    /// default (if specified via default-run field).
-    ///
-    /// This can be useful for discovering what targets are available in a crate, or in the
-    /// (somewhat rare) case that a crate has multiple binaries and you need to know what they are
-    /// called in order to select one with `--bin`.
-    ///
-    /// Returns an error if the crate contains no executable targets (is library-only).
-    #[arg(long)]
-    pub list_targets: bool,
-
-    /// The crate to run (optionally with @VERSION suffix).
-    ///
-    /// This is optional when using `--path`, `--git`, `--github`, or `--gitlab`, as the crate
-    /// name can be discovered from the source (if it contains exactly one crate).
-    ///
-    /// Special case: if this is "cargo" and no source flags are present, then the first
-    /// element of `args` is treated as a cargo subcommand name, and "cargo-" is prepended
-    /// to form the actual crate name (e.g., `cgx cargo deny` runs the crate `cargo-deny`).
-    #[arg(value_name = "CRATE[@VERSION]",
-        required_unless_present_any = ["version", "path", "git", "github", "gitlab"])]
-    pub crate_spec: Option<String>,
-
-    /// Arguments to pass to the executed tool.
-    ///
-    /// If `crate_spec` is "cargo" and no source flags are present, the first element is
-    /// the cargo subcommand name, and remaining elements are passed to the tool.
-    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub args: Vec<String>,
-}
-
-impl CliArgs {
-    /// Parse CLI args from the current process's command line into a `CliArgs` struct.
-    ///
-    /// This simply spares a caller from having to have the [`clap::Parser`] trait in scope.
-    ///
-    /// Be advised that this uses `clap` which will exit the process if the args are invalid or
-    /// after printing `--help` output.
-    pub fn parse_from_cli_args() -> Self {
+    /// `version` is the string shown by `-V`/`--version`; clap prints it to stdout and exits. This
+    /// uses clap, which will exit the process on `--help`, `--version`, or invalid arguments.
+    pub fn parse_from_cli_args(version: String) -> Self {
         let args: Vec<String> = std::env::args().collect();
         let args = Self::strip_cargo_subcommand_arg(args);
-        let (toolchain, filtered_args) = Self::extract_toolchain(&args);
-        let (cgx_args, binary_args) = Self::split_at_crate_spec(filtered_args);
-
-        let mut cli = Self::parse_from(cgx_args);
-        cli.args = binary_args;
-        cli.toolchain = toolchain;
-        cli
+        Self::parse_from_arg_strings(args, Some(version)).unwrap_or_else(|err| err.exit())
     }
 
-    /// Parse the CLI args from an arbitary iterator of strings, useful for constructing
-    /// [`CLiArgs`] values for testing.
-    #[cfg(test)]
-    pub fn parse_from_test_args<I, T>(args: I) -> Self
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<std::ffi::OsString> + Clone,
-    {
-        // Prepend the name of the executable, as clap will be expecting.
-        // No reason to make every test have to remember to do this
-        let args = std::iter::once(std::ffi::OsString::from("cgx")).chain(args.into_iter().map(|s| s.into()));
-        let args: Vec<String> = args.map(|s| s.to_string_lossy().to_string()).collect();
-        let (toolchain, filtered_args) = Self::extract_toolchain(&args);
-        let (cgx_args, binary_args) = Self::split_at_crate_spec(filtered_args);
+    /// Gather the configuration-affecting arguments this command supplies, defaulting the groups
+    /// the command does not accept.
+    ///
+    /// Not all commands even take all config options, but by having a single [`ConfigInputs`]
+    /// representation for the sum total of CLI-based config settings it makes it easier to load
+    /// and render the config in a single shared code path.
+    pub fn config_inputs(&self) -> ConfigInputs {
+        match self {
+            Cli::ListTargets(invocation)
+            | Cli::Prefetch(invocation)
+            | Cli::NoExec(invocation)
+            | Cli::Run { invocation, .. } => ConfigInputs {
+                config: invocation.config.clone(),
+                http: invocation.http.clone(),
+                prebuilt: invocation.prebuilt.clone(),
+                cargo: invocation.cargo.clone(),
+                toolchain: invocation.toolchain.clone(),
+            },
+            Cli::ListTools(list_tools) => ConfigInputs {
+                config: list_tools.config.clone(),
+                toolchain: list_tools.toolchain.clone(),
+                ..ConfigInputs::default()
+            },
+            Cli::PrefetchAll(prefetch_all) => ConfigInputs {
+                config: prefetch_all.config.clone(),
+                http: prefetch_all.http.clone(),
+                prebuilt: PrebuiltBinaryArgs::default(),
+                cargo: CargoBehaviorArgs {
+                    offline: prefetch_all.offline,
+                    refresh: prefetch_all.refresh,
+                    ..CargoBehaviorArgs::default()
+                },
+                toolchain: prefetch_all.toolchain.clone(),
+            },
+        }
+    }
 
-        let mut cli = Self::parse_from(cgx_args);
-        cli.args = binary_args;
-        cli.toolchain = toolchain;
-        cli
+    /// The structured-message format requested for this command, if any.
+    pub fn message_format(&self) -> Option<MessageFormat> {
+        self.reporting().message_format
+    }
+
+    /// The requested verbosity level for this command.
+    pub fn verbose(&self) -> u8 {
+        self.reporting().verbose
+    }
+
+    /// The reporting controls carried by this command's variant.
+    fn reporting(&self) -> &ReportingArgs {
+        match self {
+            Cli::ListTargets(invocation)
+            | Cli::Prefetch(invocation)
+            | Cli::NoExec(invocation)
+            | Cli::Run { invocation, .. } => &invocation.reporting,
+            Cli::ListTools(list_tools) => &list_tools.reporting,
+            Cli::PrefetchAll(prefetch_all) => &prefetch_all.reporting,
+        }
+    }
+
+    /// Shared parse pipeline: extract a leading `+toolchain`, invoke clap (with an optional version
+    /// string for the `--version` action), and validate into a [`Cli`] via [`RawCli::render`].
+    fn parse_from_arg_strings(args: Vec<String>, version: Option<String>) -> Result<Self, clap::Error> {
+        let (toolchain, filtered_args) = Self::extract_toolchain(args);
+
+        let mut command = RawCli::command();
+        if let Some(version) = version {
+            command = command.version(version);
+        }
+
+        let matches = command.try_get_matches_from(filtered_args)?;
+        let mut raw = RawCli::from_arg_matches(&matches)?;
+        raw.toolchain = toolchain;
+        raw.render()
     }
 
     /// Strip the cargo subcommand argument when invoked as `cargo-cgx`.
@@ -516,195 +208,840 @@ impl CliArgs {
         }
     }
 
-    /// Split command-line arguments into cgx arguments and binary arguments.
-    ///
-    /// This function separates arguments that should be parsed by cgx from arguments
-    /// that should be passed through to the executed binary. The split point is the
-    /// crate spec (the first positional argument).
-    ///
-    /// # Why Manual Splitting?
-    ///
-    /// While clap provides `trailing_var_arg = true` to capture trailing arguments,
-    /// it still parses flags globally across the entire command line. This means
-    /// `cgx eza --version` would have `--version` parsed as a cgx flag
-    /// (since we have a `--version` flag) rather than being passed to eza.
-    ///
-    /// This behavior is tracked in [clap issue #1538]: "`TrailingVarArg` doesn't work
-    /// without `--`". The recommended workaround is to require users to use `--`
-    /// explicitly (e.g., `cgx eza -- --version`), but this is less ergonomic than
-    /// the npx/uvx pattern we're trying to emulate.
-    ///
-    /// # Prior Art
-    ///
-    /// This pattern of manual argument splitting is common in wrapper tools:
-    ///
-    /// - `npx`: "When run via the npx binary, all flags and options must be set
-    ///   prior to any positional arguments." Everything after the package name is
-    ///   passed to the tool.
-    ///   See: <https://docs.npmjs.com/cli/v8/commands/npx/>
-    ///
-    /// - `uvx`: Wrapper options like `--from`, `--with`, and `--python` must come
-    ///   before the tool name. Everything after the tool name is passed as arguments
-    ///   to that tool.
-    ///   See: <https://docs.astral.sh/uv/guides/tools/>
-    ///
-    /// - `cargo run`: Uses the `--` delimiter approach (`cargo run -- args`), which is more
-    ///   explicit but less convenient for repeated use.
-    ///
-    /// # Algorithm
-    ///
-    /// The function scans arguments left-to-right, tracking which arguments are flags
-    /// and which are flag values. The first argument that is neither a flag nor a flag
-    /// value is identified as the crate spec, and serves as the split point.
-    ///
-    /// For compatibility, if an explicit `--` delimiter is present, it is used as the
-    /// split point instead.
-    ///
-    /// # Examples
-    ///
-    /// ```text
-    /// cgx ripgrep --version
-    ///  cgx args: ["cgx", "ripgrep"]
-    ///  binary args: ["--version"]
-    ///
-    /// cgx --features foo ripgrep --color=always -i
-    ///  cgx args: ["cgx", "--features", "foo", "ripgrep"]
-    ///  binary args: ["--color=always", "-i"]
-    ///
-    /// cgx --path ./foo mycrate --help
-    ///  cgx args: ["cgx", "--path", "./foo", "mycrate"]
-    ///  binary args: ["--help"]
-    ///
-    /// cgx ripgrep -- --version
-    ///  cgx args: ["cgx", "ripgrep"]
-    ///  binary args: ["--version"]
-    /// ```
-    ///
-    /// [clap issue #1538](https://github.com/clap-rs/clap/issues/1538)
-    fn split_at_crate_spec<I, T>(args: I) -> (Vec<String>, Vec<String>)
+    /// Parse an arbitrary argument iterator for tests, panicking on parse or validation errors.
+    #[cfg(test)]
+    pub fn parse_from_test_args<I, T>(args: I) -> Self
     where
         I: IntoIterator<Item = T>,
-        T: Into<String>,
+        T: Into<OsString> + Clone,
     {
-        let args: Vec<String> = args.into_iter().map(|s| s.into()).collect();
+        Self::try_parse_from_test_args(args).unwrap()
+    }
 
-        // Check for explicit -- separator (standard POSIX convention)
-        // If present, everything before it goes to cgx, everything after goes to the binary
-        if let Some(dash_dash_pos) = args.iter().position(|arg| arg == "--") {
-            let cgx_args = args[..dash_dash_pos].to_vec();
-            let binary_args = args[dash_dash_pos + 1..].to_vec();
-            return (cgx_args, binary_args);
+    /// Try to parse an arbitrary argument iterator for tests, running the same preprocessing and
+    /// [`RawCli::render`] validation as the real entry point.
+    #[cfg(test)]
+    pub fn try_parse_from_test_args<I, T>(args: I) -> Result<Self, clap::Error>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        // Prepend the executable name, as clap expects, so callers don't have to.
+        let args = std::iter::once(OsString::from("cgx")).chain(args.into_iter().map(|s| s.into()));
+        let args: Vec<String> = args.map(|s| s.to_string_lossy().to_string()).collect();
+        Self::parse_from_arg_strings(args, None)
+    }
+
+    /// Borrow the [`CrateInvocation`] of a crate-level command, panicking for config-level
+    /// commands.
+    ///
+    /// Test helper for asserting on resolved crate invocations.
+    #[cfg(test)]
+    pub fn crate_invocation(&self) -> &CrateInvocation {
+        match self {
+            Cli::ListTargets(invocation)
+            | Cli::Prefetch(invocation)
+            | Cli::NoExec(invocation)
+            | Cli::Run { invocation, .. } => invocation,
+            other => panic!("expected a crate-level command, got {other:?}"),
+        }
+    }
+
+    /// The trailing tool arguments of a [`Cli::Run`] command (empty for any other). Test helper.
+    #[cfg(test)]
+    pub fn tool_args(&self) -> &[OsString] {
+        match self {
+            Cli::Run { tool_args, .. } => tool_args,
+            _ => &[],
+        }
+    }
+}
+
+/// Arguments for the invocation (or at least preparation to invoke) a single crate.
+#[derive(Clone, Debug)]
+pub struct CrateInvocation {
+    /// The crate spec (name, optionally with an `@VERSION` suffix), or `None` when the name is
+    /// discovered from the source (e.g. `--git`/`--path`).
+    pub crate_spec: Option<String>,
+    /// Version requirement from `--crate-version`.
+    pub crate_version: Option<String>,
+    /// Where to obtain the crate.
+    pub source: Source,
+    /// Which git ref to use, for git-backed sources.
+    pub git_selector: GitSelector,
+    /// Build options passed through to cargo.
+    pub build_options: BuildOptionsArgs,
+    /// Cargo behavior flags (lockfile / offline / refresh).
+    pub cargo: CargoBehaviorArgs,
+    /// Pre-built binary lookup options.
+    pub prebuilt: PrebuiltBinaryArgs,
+    /// Config file discovery options.
+    pub config: ConfigArgs,
+    /// HTTP tuning options.
+    pub http: HttpArgs,
+    /// Output and diagnostic controls.
+    pub reporting: ReportingArgs,
+    /// Toolchain from a leading `+toolchain` token.
+    pub toolchain: Option<String>,
+}
+
+/// Arguments for `--prefetch-all`
+#[derive(Clone, Debug, Default)]
+pub struct PrefetchAll {
+    /// Config file discovery overrides.
+    pub config: ConfigArgs,
+    /// HTTP tuning options.
+    pub http: HttpArgs,
+    /// Output and diagnostic controls.
+    pub reporting: ReportingArgs,
+    /// Run without accessing the network.
+    pub offline: bool,
+    /// Force refresh of all cached data.
+    pub refresh: bool,
+    /// Number of parallel jobs.
+    pub jobs: Option<usize>,
+    /// Ignore `rust-version` specifications in packages.
+    pub ignore_rust_version: bool,
+    /// Toolchain from a leading `+toolchain` token.
+    pub toolchain: Option<String>,
+}
+
+impl PrefetchAll {
+    /// Build the per-tool [`CrateInvocation`] used to prefetch one configured tool by name, given
+    /// that crate's name.
+    ///
+    /// None of the usual crate-level params are set here, because in the case of `--prefetch-all`
+    /// the list of crates to prefetch and all of their options come from the `cgx` config.
+    pub fn invocation_for(&self, crate_spec: &str) -> CrateInvocation {
+        CrateInvocation {
+            crate_spec: Some(crate_spec.to_string()),
+            crate_version: None,
+            source: Source::Default,
+            git_selector: GitSelector::DefaultBranch,
+            build_options: BuildOptionsArgs {
+                jobs: self.jobs,
+                ignore_rust_version: self.ignore_rust_version,
+                ..BuildOptionsArgs::default()
+            },
+            cargo: CargoBehaviorArgs {
+                offline: self.offline,
+                refresh: self.refresh,
+                ..CargoBehaviorArgs::default()
+            },
+            prebuilt: PrebuiltBinaryArgs::default(),
+            config: self.config.clone(),
+            http: self.http.clone(),
+            reporting: self.reporting.clone(),
+            toolchain: self.toolchain.clone(),
+        }
+    }
+}
+
+/// Arguments for `--list-tools`
+#[derive(Clone, Debug, Default)]
+pub struct ListTools {
+    /// Config file discovery overrides.
+    pub config: ConfigArgs,
+    /// Output and diagnostic controls.
+    pub reporting: ReportingArgs,
+    /// Toolchain from a leading `+toolchain` token.
+    pub toolchain: Option<String>,
+}
+
+/// The source from which to obtain a crate, collapsed from the mutually-exclusive source selectors.
+///
+/// The raw strings held here are validated (URL and `owner/repo` parsing) downstream in
+/// [`CrateSpec::load`](crate::cratespec::CrateSpec::load) so that domain errors keep their typed
+/// [`Error`](crate::error::Error) variants instead of surfacing as clap errors.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Source {
+    /// No explicit source selector; resolve via config if present, ultimately defaulting to
+    /// crates.io absent explicit config override.
+    #[default]
+    Default,
+    /// `--git <URL>`
+    Git { url: String },
+    /// `--registry <NAME>`
+    Registry { name: String },
+    /// `--index <URL>`
+    Index { url: String },
+    /// `--path <PATH>`
+    Path { path: PathBuf },
+    /// `--github <owner/repo>`, with optional `--github-url`
+    GitHub {
+        repo: String,
+        custom_url: Option<String>,
+    },
+    /// `--gitlab <owner/repo>`, with optional `--gitlab-url`
+    GitLab {
+        repo: String,
+        custom_url: Option<String>,
+    },
+}
+
+impl Source {
+    /// True for git-backed sources, the only sources a non-default [`GitSelector`] may accompany.
+    pub fn is_git(&self) -> bool {
+        matches!(
+            self,
+            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. }
+        )
+    }
+
+    /// True when a crate name can be discovered from the source itself, making an explicit crate
+    /// spec optional.
+    fn allows_crate_discovery(&self) -> bool {
+        matches!(
+            self,
+            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. } | Source::Path { .. }
+        )
+    }
+}
+
+/// CLI arguments that are crate-specific and passed through to cargo build.
+///
+/// These args are segreated from the other CLI args to make the semantic distinction more
+/// explicit.  Most CLI args can also be set in config files to apply globally, but these are
+/// always crate-specific.
+#[derive(Clone, Debug, Default, Args)]
+pub struct BuildOptionsArgs {
+    /// Space or comma separated list of features to activate
+    #[arg(short = 'F', long, value_name = "FEATURES")]
+    pub features: Option<String>,
+
+    /// Activate all available features
+    #[arg(long)]
+    pub all_features: bool,
+
+    /// Do not activate the default features
+    #[arg(long)]
+    pub no_default_features: bool,
+
+    /// Build with the specified profile
+    #[arg(long, value_name = "PROFILE-NAME", conflicts_with = "debug")]
+    pub profile: Option<String>,
+
+    /// Build in debug mode (with the 'dev' profile) instead of release mode
+    #[arg(long)]
+    pub debug: bool,
+
+    /// Build for the target triple
+    #[arg(long, value_name = "TRIPLE")]
+    pub target: Option<String>,
+
+    /// Number of parallel jobs, defaults to # of CPUs
+    #[arg(short = 'j', long, value_name = "N")]
+    pub jobs: Option<usize>,
+
+    /// Ignore `rust-version` specification in packages
+    #[arg(long)]
+    pub ignore_rust_version: bool,
+
+    /// Install only the specified binary
+    #[arg(long, value_name = "NAME", conflicts_with = "example")]
+    pub bin: Option<String>,
+
+    /// Install only the specified example
+    #[arg(long, value_name = "NAME")]
+    pub example: Option<String>,
+}
+
+impl BuildOptionsArgs {
+    /// True if any compilation-affecting option is set, such that a pre-built binary is not
+    /// suitable for this request.
+    fn has_compilation_options(&self) -> bool {
+        self.features.is_some()
+            || self.all_features
+            || self.no_default_features
+            || self.profile.is_some()
+            || self.debug
+            || self.target.is_some()
+            || self.bin.is_some()
+            || self.example.is_some()
+    }
+
+    /// True if any build option at all is set.
+    fn is_present(&self) -> bool {
+        self.has_compilation_options() || self.jobs.is_some() || self.ignore_rust_version
+    }
+}
+
+/// Lockfile and cache behavior flags that affect dependency resolution and cache identity for one tool.
+///
+/// The mutually-exclusive `--locked`/`--frozen`/`--unlocked` flags share a `lockfile`
+/// arg-group
+#[derive(Clone, Debug, Default, Args)]
+pub struct CargoBehaviorArgs {
+    /// Honor Cargo.lock from the crate, equivalent to passing `--locked` to `cargo install`
+    #[arg(long, group = "lockfile")]
+    pub locked: bool,
+
+    /// Equivalent to specifying both --locked and --offline
+    #[arg(long, group = "lockfile")]
+    pub frozen: bool,
+
+    /// Ignore Cargo.lock and resolve dependencies fresh
+    #[arg(long, group = "lockfile")]
+    pub unlocked: bool,
+
+    /// Run without accessing the network
+    #[arg(long)]
+    pub offline: bool,
+
+    /// Force refresh of all cached data for this crate.
+    #[arg(long)]
+    pub refresh: bool,
+}
+
+/// Creates a clap value parser that uses strum's [`VariantNames`] for possible values
+/// and strum's [`FromStr`](std::str::FromStr) for parsing. This ensures:
+/// - `--help` shows valid values (from `VARIANTS`)
+/// - Parsing uses the same logic as config files (strum's [`EnumString`](strum::EnumString))
+macro_rules! strum_value_parser {
+    ($t:ty) => {
+        clap::builder::PossibleValuesParser::new(<$t>::VARIANTS).map(|s| s.parse::<$t>().unwrap())
+    };
+}
+
+/// CLI config overrides for prebuilt binaries
+#[derive(Clone, Debug, Default, Args)]
+pub struct PrebuiltBinaryArgs {
+    /// Control use of pre-built binaries: never, always, or auto.
+    #[arg(long, value_name = "WHEN", value_parser = strum_value_parser!(UsePrebuiltBinaries))]
+    pub prebuilt_binary: Option<UsePrebuiltBinaries>,
+
+    /// Override the binary providers to check for pre-built binaries.
+    #[arg(
+        long,
+        value_name = "SOURCES",
+        value_delimiter = ',',
+        value_parser = strum_value_parser!(BinaryProvider)
+    )]
+    pub prebuilt_binary_sources: Option<Vec<BinaryProvider>>,
+
+    /// Disable checksum verification when downloading pre-built binaries.
+    #[arg(long)]
+    pub prebuilt_binary_no_verify_checksums: bool,
+
+    /// Disable signature verification when downloading pre-built binaries.
+    #[arg(long)]
+    pub prebuilt_binary_no_verify_signatures: bool,
+}
+
+impl PrebuiltBinaryArgs {
+    /// True if any prebuilt-binary override was given on the command line.
+    fn is_present(&self) -> bool {
+        self.prebuilt_binary.is_some()
+            || self.prebuilt_binary_sources.is_some()
+            || self.prebuilt_binary_no_verify_checksums
+            || self.prebuilt_binary_no_verify_signatures
+    }
+}
+
+/// Options that control which configuration files are loaded before executing a command.
+///
+/// Every command that respects config files accepts these args.
+#[derive(Clone, Debug, Default, Args)]
+pub struct ConfigArgs {
+    /// Read configuration options from the given TOML file only, bypassing the usual config search
+    /// paths.
+    #[arg(
+        long,
+        value_name = "FILE",
+        conflicts_with_all = ["system_config_dir", "app_dir", "user_config_dir"]
+    )]
+    pub config_file: Option<PathBuf>,
+
+    /// Override the system config directory location.
+    #[arg(long, value_name = "PATH", env = "CGX_SYSTEM_CONFIG_DIR")]
+    pub system_config_dir: Option<PathBuf>,
+
+    /// Override the base application directory.
+    #[arg(long, value_name = "PATH", env = "CGX_APP_DIR")]
+    pub app_dir: Option<PathBuf>,
+
+    /// Override the user config directory location.
+    #[arg(long, value_name = "PATH", env = "CGX_USER_CONFIG_DIR")]
+    pub user_config_dir: Option<PathBuf>,
+}
+
+/// Network tuning options used by commands that may resolve, download, or build crates.
+#[derive(Clone, Debug, Default, Args)]
+pub struct HttpArgs {
+    /// HTTP request timeout (e.g., "30s", "2m").
+    #[arg(long, value_name = "DURATION", env = "CGX_HTTP_TIMEOUT")]
+    pub http_timeout: Option<String>,
+
+    /// Maximum number of retries for transient HTTP failures (0 = no retries).
+    #[arg(long, value_name = "N", env = "CGX_HTTP_RETRIES")]
+    pub http_retries: Option<usize>,
+
+    /// HTTP or SOCKS5 proxy URL for all HTTP requests.
+    #[arg(long, value_name = "URL", env = "CGX_HTTP_PROXY")]
+    pub http_proxy: Option<String>,
+}
+
+impl HttpArgs {
+    /// True if any HTTP tuning option was given on the command line.
+    fn is_present(&self) -> bool {
+        self.http_timeout.is_some() || self.http_retries.is_some() || self.http_proxy.is_some()
+    }
+}
+
+/// Output and diagnostic controls for commands that may produce operational messages.
+#[derive(Clone, Debug, Default, Args)]
+pub struct ReportingArgs {
+    /// Use verbose output (-vv very verbose/build.rs output)
+    #[arg(short = 'v', long, action = ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Do not print cargo log messages
+    #[arg(short = 'q', long)]
+    pub quiet: bool,
+
+    /// Coloring: auto, always, never
+    #[arg(long, value_name = "WHEN")]
+    pub color: Option<String>,
+
+    /// Output structured messages in the specified format.
+    #[arg(long, value_name = "FMT")]
+    pub message_format: Option<MessageFormat>,
+}
+
+/// Output format for structured messages.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum MessageFormat {
+    /// JSON format, one message per line
+    Json,
+}
+
+/// The subset of arguments that influence configuration loading, gathered per command variant by
+/// [`Cli::config_inputs`].
+#[derive(Clone, Debug, Default)]
+pub struct ConfigInputs {
+    /// Config file discovery overrides.
+    pub config: ConfigArgs,
+    /// HTTP tuning options.
+    pub http: HttpArgs,
+    /// Pre-built binary lookup config.
+    pub prebuilt: PrebuiltBinaryArgs,
+    /// Cargo behavior flags (lockfile / offline / refresh).
+    pub cargo: CargoBehaviorArgs,
+    /// Toolchain from a leading `+toolchain` token.
+    pub toolchain: Option<String>,
+}
+
+// Raw clap parse result.
+//
+// Private on purpose: the public surface is [`Cli`], produced by [`Self::resolve`], which enforces
+// the per-mode rules clap cannot express structurally and collapses the flat flags into typed
+// command variants. The mutually-exclusive mode flags share a `mode` ArgGroup, so clap rejects two
+// modes natively without a `conflicts_with` explosion.
+//
+// This is how we can treat things like `--prefetch` and `--list-tools` as if they were clap
+// subcommands, and still properly handle `cgx foo` for literally any `foo` as an invocation of
+// crate `foo`.
+//
+// This uses a regular comment, not a doc comment, so the explanation does not leak into `--help`
+// output as the command's long description.
+#[derive(Clone, Debug, Parser)]
+#[command(name = "cgx")]
+#[command(about = "Rust equivalent of uvx or npx, for running Rust crates")]
+#[command(
+    after_help = "To run a crate, pass its name (optionally with @VERSION) followed by any arguments for \
+                  the tool, e.g. `cgx ripgrep --color=always`. cgx's own options must come before the crate \
+                  name; everything after it is forwarded to the tool. Use `cgx cargo <subcommand>` to run a \
+                  cargo plugin (e.g. `cgx cargo deny` is equivalent to `cgx cargo-deny`)."
+)]
+struct RawCli {
+    /// Build the binary but do not execute it; print its path to stdout instead.
+    #[arg(long, group = "mode")]
+    no_exec: bool,
+
+    /// Prepare the crate binary and exit without printing or executing it.
+    #[arg(long, group = "mode")]
+    prefetch: bool,
+
+    /// Prefetch all tools configured in the `cgx` configuration.
+    #[arg(long, group = "mode")]
+    prefetch_all: bool,
+
+    /// List the crate's executable targets (bins and examples) without building or executing.
+    #[arg(long, group = "mode")]
+    list_targets: bool,
+
+    /// List all configured tools and aliases in the `cgx` configuration.
+    #[arg(long, group = "mode")]
+    list_tools: bool,
+
+    /// Version requirement of the crate to run (alternative to the `@VERSION` suffix).
+    ///
+    /// Must appear before the crate name (e.g. `cgx --crate-version 1.0 ripgrep`); a
+    /// `--crate-version` after the crate name is passed through to the tool. The `@VERSION` suffix
+    /// (`cgx ripgrep@1.0`) is the preferred form.
+    #[arg(long, value_name = "REQ")]
+    crate_version: Option<String>,
+
+    #[command(flatten)]
+    source: SourceArgs,
+
+    #[command(flatten)]
+    build_options: BuildOptionsArgs,
+
+    #[command(flatten)]
+    cargo: CargoBehaviorArgs,
+
+    #[command(flatten)]
+    prebuilt: PrebuiltBinaryArgs,
+
+    #[command(flatten)]
+    config: ConfigArgs,
+
+    #[command(flatten)]
+    http: HttpArgs,
+
+    #[command(flatten)]
+    reporting: ReportingArgs,
+
+    /// The crate to run plus any trailing tool arguments, captured raw via an external subcommand.
+    ///
+    /// This is the trick we use to be able to capture anything other than a recognized argument as
+    /// the name of a crate followed by args to that crate.
+    #[command(subcommand)]
+    invocation: Option<Invocation>,
+
+    /// Toolchain extracted from a leading `+toolchain` token before clap parsing.
+    ///
+    /// Populated by [`Cli::extract_toolchain`], not parsed directly from the command line.
+    #[arg(skip)]
+    toolchain: Option<String>,
+}
+
+impl RawCli {
+    /// Split the captured external-subcommand vector into a crate spec and trailing tool arguments.
+    fn split_invocation(invocation: Option<Invocation>) -> (Option<String>, Vec<OsString>) {
+        let Some(Invocation::Crate(mut parts)) = invocation else {
+            return (None, Vec::new());
+        };
+        if parts.is_empty() {
+            return (None, Vec::new());
         }
 
-        // Build flag lists dynamically from clap metadata, so that this function works reliably
-        // as we add and modify CLI options.
-
-        let cmd = CliArgs::command();
-        let mut no_value_flags = HashSet::new();
-        let mut value_taking_flags = HashSet::new();
-        let mut short_value_taking_flags = HashSet::new();
-
-        for arg in cmd.get_arguments() {
-            // Skip positional arguments
-            if arg.is_positional() {
-                continue;
-            }
-
-            // Determine if this flag takes a value based on its action
-            let takes_value = matches!(arg.get_action(), ArgAction::Set | ArgAction::Append);
-
-            // Handle long flags
-            if let Some(long) = arg.get_long() {
-                let flag = format!("--{}", long);
-                if takes_value {
-                    value_taking_flags.insert(flag);
-                } else {
-                    no_value_flags.insert(flag);
-                }
-            }
-
-            // Handle short flags
-            if let Some(short) = arg.get_short() {
-                if takes_value {
-                    short_value_taking_flags.insert(short);
-                }
-                // Note: short no-value flags don't need tracking; we handle them via else clause
-            }
-        }
-
-        let mut position = 1; // Start after binary name (args[0])
-
-        while position < args.len() {
-            let arg = &args[position];
-
-            if let Some(flag) = arg.strip_prefix("--") {
-                // Long flag
-                if flag.contains('=') {
-                    // --flag=value syntax, counts as one argument
-                    position += 1;
-                } else if no_value_flags.contains(arg.as_str()) {
-                    position += 1;
-                } else if value_taking_flags.contains(arg.as_str()) {
-                    // Skip flag and its value (next argument)
-                    position += 2;
-                } else if arg == "--version" {
-                    // Special case: --version can have 0 or 1 values
-                    // If next arg exists and doesn't look like a flag, it's the version value
-                    if position + 1 < args.len() && !args[position + 1].starts_with('-') {
-                        position += 2;
-                    } else {
-                        position += 1;
-                    }
-                } else {
-                    // Unknown long flag, conservatively assume it takes no value
-                    position += 1;
-                }
-            } else if let Some(flag) = arg.strip_prefix('-') {
-                // Short flag(s)
-                if flag.is_empty() {
-                    // Just "-", often used to indicate stdin - treat as positional argument
-                    break;
-                }
-
-                let first_char = flag.chars().next().unwrap();
-
-                if short_value_taking_flags.contains(&first_char) {
-                    if flag.len() == 1 {
-                        // -F foo (flag and value are separate arguments)
-                        position += 2;
-                    } else {
-                        // -Ffoo (flag and value combined in one argument)
-                        position += 1;
-                    }
-                } else if first_char == 'V' {
-                    // -V is short for --version, same special handling
-                    if flag.len() == 1 && position + 1 < args.len() && !args[position + 1].starts_with('-') {
-                        // -V 14 (separate arguments)
-                        position += 2;
-                    } else {
-                        // -V or -V14 (combined)
-                        position += 1;
-                    }
-                } else {
-                    // Assume no value (like -v, -q, or bundled flags like -vvv or -qv)
-                    position += 1;
-                }
-            } else {
-                // Not a flag - this is the crate spec (first positional argument)!
-                break;
-            }
-        }
-
-        // Split at the crate spec position
-        if position < args.len() {
-            // Found a crate spec: split after it
-            let cgx_args = args[..=position].to_vec();
-            let binary_args = args[position + 1..].to_vec();
-            (cgx_args, binary_args)
+        let crate_spec = parts.remove(0).to_string_lossy().into_owned();
+        let (crate_spec, mut tool_args) = if crate_spec == "cargo" && !parts.is_empty() {
+            let subcommand = parts.remove(0);
+            (format!("cargo-{}", subcommand.to_string_lossy()), parts)
         } else {
-            // No crate spec found (e.g., `cgx --path ./foo` with no crate name specified)
-            // All args go to cgx, none to binary
-            (args, vec![])
+            (crate_spec, parts)
+        };
+
+        // A leading `--` immediately after the crate is the conventional argument separator; drop it
+        // so `cgx rg -- --flag` forwards `--flag` to the tool, matching the no-separator
+        // `cgx rg --flag`.
+        if matches!(tool_args.first().and_then(|arg| arg.to_str()), Some("--")) {
+            tool_args.remove(0);
+        }
+
+        (Some(crate_spec), tool_args)
+    }
+
+    /// Validate the raw parse and render it into a typed [`Cli`] command.
+    ///
+    /// This is the single place semantic rules live: the mode arg-group already guarantees at most
+    /// one mode flag, and here we enforce which other flags each mode permits, whether a crate is
+    /// required or forbidden, and whether trailing tool arguments are allowed.
+    ///
+    /// It would be nice if more of the rules about which args are allowed with which modes could
+    /// be expressed usign `clap` proc macros, but we're already pushing the limits of clap as it
+    /// is.  An earlier attempt at CLI parsing was even more horrifyingly manual and
+    /// stringly-typed.
+    fn render(self) -> Result<Cli, clap::Error> {
+        let RawCli {
+            no_exec,
+            prefetch,
+            prefetch_all,
+            list_targets,
+            list_tools,
+            crate_version,
+            source,
+            build_options,
+            cargo,
+            prebuilt,
+            config,
+            http,
+            reporting,
+            invocation,
+            toolchain,
+        } = self;
+
+        let (crate_spec, tool_args) = Self::split_invocation(invocation);
+
+        if prefetch_all {
+            let mode = "--prefetch-all";
+            Self::ensure_no_crate(&crate_spec, &tool_args, mode)?;
+            if source.is_present() {
+                return Err(Self::forbidden(mode, "source selectors"));
+            }
+            if prebuilt.is_present() {
+                return Err(Self::forbidden(mode, "--prebuilt-binary options"));
+            }
+            if cargo.locked || cargo.frozen || cargo.unlocked {
+                return Err(Self::forbidden(mode, "--locked/--frozen/--unlocked"));
+            }
+            if crate_version.is_some() {
+                return Err(Self::forbidden(mode, "--crate-version"));
+            }
+            if build_options.has_compilation_options() {
+                return Err(Self::forbidden(mode, "build/compilation options"));
+            }
+            return Ok(Cli::PrefetchAll(PrefetchAll {
+                config,
+                http,
+                reporting,
+                offline: cargo.offline,
+                refresh: cargo.refresh,
+                jobs: build_options.jobs,
+                ignore_rust_version: build_options.ignore_rust_version,
+                toolchain,
+            }));
+        }
+
+        if list_tools {
+            let mode = "--list-tools";
+            Self::ensure_no_crate(&crate_spec, &tool_args, mode)?;
+            if source.is_present() {
+                return Err(Self::forbidden(mode, "source selectors"));
+            }
+            if prebuilt.is_present() {
+                return Err(Self::forbidden(mode, "--prebuilt-binary options"));
+            }
+            if cargo.locked || cargo.frozen || cargo.unlocked || cargo.offline || cargo.refresh {
+                return Err(Self::forbidden(mode, "cargo behavior flags"));
+            }
+            if crate_version.is_some() {
+                return Err(Self::forbidden(mode, "--crate-version"));
+            }
+            if build_options.is_present() {
+                return Err(Self::forbidden(mode, "build options"));
+            }
+            if http.is_present() {
+                return Err(Self::forbidden(mode, "--http-* options"));
+            }
+            return Ok(Cli::ListTools(ListTools {
+                config,
+                reporting,
+                toolchain,
+            }));
+        }
+
+        // Crate-level commands (run / no-exec / prefetch / list-targets).
+        let git_selector = source.git_selector();
+        let source = source.to_source();
+
+        let mode = if prefetch {
+            "--prefetch"
+        } else if list_targets {
+            "--list-targets"
+        } else if no_exec {
+            "--no-exec"
+        } else {
+            "cgx"
+        };
+
+        if crate_spec.is_none() && !source.allows_crate_discovery() {
+            return Err(clap::Error::raw(
+                ErrorKind::MissingRequiredArgument,
+                format!("{mode} requires a crate name, or a discoverable source such as --git or --path\n"),
+            ));
+        }
+
+        let invocation = CrateInvocation {
+            crate_spec,
+            crate_version,
+            source,
+            git_selector,
+            build_options,
+            cargo,
+            prebuilt,
+            config,
+            http,
+            reporting,
+            toolchain,
+        };
+
+        if prefetch {
+            Self::ensure_no_crate_args(&tool_args, "--prefetch")?;
+            Ok(Cli::Prefetch(invocation))
+        } else if list_targets {
+            Self::ensure_no_crate_args(&tool_args, "--list-targets")?;
+            Ok(Cli::ListTargets(invocation))
+        } else if no_exec {
+            Ok(Cli::NoExec(invocation))
+        } else {
+            Ok(Cli::Run {
+                invocation,
+                tool_args,
+            })
+        }
+    }
+
+    /// Build a clap error reporting that `what` is not allowed in the `mode` command.
+    fn forbidden(mode: &str, what: &str) -> clap::Error {
+        clap::Error::raw(
+            ErrorKind::ArgumentConflict,
+            format!("{what} cannot be used with {mode}\n"),
+        )
+    }
+
+    /// Reject a crate spec or trailing arguments for the config-level commands that take neither.
+    fn ensure_no_crate(
+        crate_spec: &Option<String>,
+        tool_args: &[OsString],
+        mode: &str,
+    ) -> Result<(), clap::Error> {
+        if crate_spec.is_some() || !tool_args.is_empty() {
+            Err(clap::Error::raw(
+                ErrorKind::UnknownArgument,
+                format!("{mode} does not accept a crate or trailing arguments\n"),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Reject trailing arguments for crate-level commands that prepare but never execute a crate.
+    fn ensure_no_crate_args(tool_args: &[OsString], mode: &str) -> Result<(), clap::Error> {
+        if tool_args.is_empty() {
+            Ok(())
+        } else {
+            Err(clap::Error::raw(
+                ErrorKind::UnknownArgument,
+                format!("{mode} cannot be used with trailing tool arguments\n"),
+            ))
+        }
+    }
+}
+
+// External-subcommand capture for when the user has not specified one of the subcommands and is
+// just running a crate
+//
+// Modeling the crate-and-arguments case as an external subcommand makes clap split the crate spec
+// from the trailing tool arguments natively, with no `--` separator required and no reserved
+// words.  It's a clever hack to get around the fact that we want `cgx foo` for literally any `foo`
+// to refer to running crate `foo` but we also have some options like `--prefetch` and the like
+// that really work like clap subcommands.
+//
+// NOTE: This deliberately is a regular comment, not a doc comment, so it does not become the
+// command's `--help` text.
+#[derive(Clone, Debug, Subcommand)]
+enum Invocation {
+    #[command(external_subcommand)]
+    Crate(Vec<OsString>),
+}
+
+/// Source selectors for commands that operate on one concrete crate invocation, to specify the
+/// source of a crate.
+///
+/// The mutually-exclusive selectors share clap arg-groups (`source` for the
+/// forge/registry/path selectors, `git_ref` for the branch/tag/rev selectors) so clap rejects
+/// invalid combinations natively, and [`Self::to_source`] collapses the flat flags into the
+/// [`Source`] enum.
+#[derive(Clone, Debug, Default, Args)]
+struct SourceArgs {
+    /// Find crate in git repository at the given URL
+    #[arg(long, group = "source")]
+    git: Option<String>,
+
+    /// Name of registry (configured in .cargo/config.toml) in which to find crate
+    #[arg(long, group = "source")]
+    registry: Option<String>,
+
+    /// Filesystem path to local crate to install from
+    #[arg(long, group = "source")]
+    path: Option<PathBuf>,
+
+    /// Find crate in GitHub repository (format: owner/repo)
+    #[arg(long, group = "source")]
+    github: Option<String>,
+
+    /// Find crate in GitLab repository (format: owner/repo)
+    #[arg(long, group = "source")]
+    gitlab: Option<String>,
+
+    /// Registry index URL to use
+    #[arg(long, group = "source", value_name = "INDEX")]
+    index: Option<String>,
+
+    /// Custom GitHub instance URL (for GitHub Enterprise)
+    #[arg(long, requires = "github")]
+    github_url: Option<String>,
+
+    /// Custom GitLab instance URL (for self-hosted GitLab)
+    #[arg(long, requires = "gitlab")]
+    gitlab_url: Option<String>,
+
+    /// Branch to use when installing from a git repo
+    #[arg(long, group = "git_ref")]
+    branch: Option<String>,
+
+    /// Tag to use when installing from a git repo
+    #[arg(long, group = "git_ref")]
+    tag: Option<String>,
+
+    /// Specific commit to use when installing from a git repo
+    #[arg(long, group = "git_ref")]
+    rev: Option<String>,
+}
+
+impl SourceArgs {
+    /// True when any source or git-ref selector was given on the command line.
+    fn is_present(&self) -> bool {
+        self.git.is_some()
+            || self.registry.is_some()
+            || self.path.is_some()
+            || self.github.is_some()
+            || self.gitlab.is_some()
+            || self.index.is_some()
+            || self.github_url.is_some()
+            || self.gitlab_url.is_some()
+            || self.branch.is_some()
+            || self.tag.is_some()
+            || self.rev.is_some()
+    }
+
+    /// Collapse the mutually-exclusive `--branch`/`--tag`/`--rev` flags into a [`GitSelector`].
+    fn git_selector(&self) -> GitSelector {
+        match (&self.branch, &self.tag, &self.rev) {
+            (Some(branch), None, None) => GitSelector::Branch(branch.clone()),
+            (None, Some(tag), None) => GitSelector::Tag(tag.clone()),
+            (None, None, Some(rev)) => GitSelector::Commit(rev.clone()),
+            (None, None, None) => GitSelector::DefaultBranch,
+            _ => unreachable!("BUG: the `git_ref` ArgGroup enforces mutual exclusivity"),
+        }
+    }
+
+    /// Collapse the mutually-exclusive source selectors into the typed [`Source`] enum.
+    fn to_source(&self) -> Source {
+        if let Some(url) = &self.git {
+            Source::Git { url: url.clone() }
+        } else if let Some(name) = &self.registry {
+            Source::Registry { name: name.clone() }
+        } else if let Some(url) = &self.index {
+            Source::Index { url: url.clone() }
+        } else if let Some(path) = &self.path {
+            Source::Path { path: path.clone() }
+        } else if let Some(repo) = &self.github {
+            Source::GitHub {
+                repo: repo.clone(),
+                custom_url: self.github_url.clone(),
+            }
+        } else if let Some(repo) = &self.gitlab {
+            Source::GitLab {
+                repo: repo.clone(),
+                custom_url: self.gitlab_url.clone(),
+            }
+        } else {
+            Source::Default
         }
     }
 }
@@ -712,28 +1049,30 @@ impl CliArgs {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
-    use clap::{CommandFactory, Parser};
+    use clap::CommandFactory;
 
     use super::*;
     use crate::{
         Result,
         builder::{BuildOptions, BuildTarget},
-        config::Config,
+        config::{Config, ToolConfig},
         cratespec::{CrateSpec, Forge, RegistrySource},
         git::GitSelector,
     };
 
+    /// Using `clap`'s built in afforance, assert that the `clap` definition is valid and won't
+    /// panic at runtime when attempting to parse arguments
     #[test]
     fn verify_cli() {
-        CliArgs::command().debug_assert();
+        RawCli::command().debug_assert();
     }
 
     mod cratespec {
         use super::*;
         fn parse_cratespec_from_args(args: &[&str]) -> Result<CrateSpec> {
-            let cli = CliArgs::parse_from_test_args(args);
+            let cli = Cli::parse_from_test_args(args);
             let config = Config::default();
-            CrateSpec::load(&config, &cli)
+            CrateSpec::load(&config, cli.crate_invocation())
         }
 
         #[test]
@@ -757,7 +1096,7 @@ mod tests {
 
         #[test]
         fn test_crate_with_flag_version() {
-            let cr = parse_cratespec_from_args(&["--version", "14", "ripgrep"]).unwrap();
+            let cr = parse_cratespec_from_args(&["--crate-version", "14", "ripgrep"]).unwrap();
             assert_matches!(
                 cr,
                 CrateSpec::CratesIo { ref name, version: Some(ref v) }
@@ -767,7 +1106,7 @@ mod tests {
 
         #[test]
         fn test_crate_with_matching_versions() {
-            let cr = parse_cratespec_from_args(&["--version", "14", "ripgrep@14"]).unwrap();
+            let cr = parse_cratespec_from_args(&["--crate-version", "14", "ripgrep@14"]).unwrap();
             assert_matches!(
                 cr,
                 CrateSpec::CratesIo { ref name, version: Some(ref v) }
@@ -777,7 +1116,7 @@ mod tests {
 
         #[test]
         fn test_crate_with_conflicting_versions() {
-            let result = parse_cratespec_from_args(&["--version", "15", "ripgrep@14"]);
+            let result = parse_cratespec_from_args(&["--crate-version", "15", "ripgrep@14"]);
             assert_matches!(result, Err(crate::error::Error::ConflictingVersions { .. }));
         }
 
@@ -1234,9 +1573,9 @@ mod tests {
         use super::*;
 
         fn parse_build_options_from_args(args: &[&str]) -> Result<BuildOptions> {
-            let cli = CliArgs::parse_from_test_args(args);
+            let cli = Cli::parse_from_test_args(args);
             let config = Config::default();
-            BuildOptions::load(&config, &cli.build_options, cli.verbose)
+            BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose())
         }
 
         #[test]
@@ -1293,39 +1632,42 @@ mod tests {
             // BuildOptions reads locked/offline from Config, not CLI args.
             // CLI override tests (--locked, --unlocked, --frozen, --offline) belong in config.rs
             // since that's where CLI-to-Config override logic lives.
-            let cli = CliArgs::parse_from_test_args(["ripgrep"]);
+            let cli = Cli::parse_from_test_args(["ripgrep"]);
             let config = Config {
                 locked: true,
                 offline: true,
                 ..Default::default()
             };
-            let opts = BuildOptions::load(&config, &cli.build_options, cli.verbose).unwrap();
+            let opts =
+                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
             assert!(opts.locked);
             assert!(opts.offline);
         }
 
         #[test]
         fn test_config_locked_without_offline() {
-            let cli = CliArgs::parse_from_test_args(["ripgrep"]);
+            let cli = Cli::parse_from_test_args(["ripgrep"]);
             let config = Config {
                 locked: true,
                 offline: false,
                 ..Default::default()
             };
-            let opts = BuildOptions::load(&config, &cli.build_options, cli.verbose).unwrap();
+            let opts =
+                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
             assert!(opts.locked);
             assert!(!opts.offline);
         }
 
         #[test]
         fn test_config_offline_without_locked() {
-            let cli = CliArgs::parse_from_test_args(["ripgrep"]);
+            let cli = Cli::parse_from_test_args(["ripgrep"]);
             let config = Config {
                 locked: false,
                 offline: true,
                 ..Default::default()
             };
-            let opts = BuildOptions::load(&config, &cli.build_options, cli.verbose).unwrap();
+            let opts =
+                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
             assert!(!opts.locked);
             assert!(opts.offline);
         }
@@ -1375,7 +1717,7 @@ mod tests {
         #[test]
         fn test_extract_toolchain_nightly() {
             let args = vec!["cgx", "+nightly", "ripgrep"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, Some("nightly".to_string()));
             assert_eq!(filtered, vec!["cgx", "ripgrep"]);
@@ -1384,7 +1726,7 @@ mod tests {
         #[test]
         fn test_extract_toolchain_specific_version() {
             let args = vec!["cgx", "+1.70.0", "ripgrep"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain.as_deref(), Some("1.70.0"));
             assert_eq!(filtered, vec!["cgx", "ripgrep"]);
@@ -1393,7 +1735,7 @@ mod tests {
         #[test]
         fn test_extract_toolchain_stable() {
             let args = vec!["cgx", "+stable", "ripgrep"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, Some("stable".to_string()));
             assert_eq!(filtered, vec!["cgx", "ripgrep"]);
@@ -1408,7 +1750,7 @@ mod tests {
                 "https://github.com/foo/bar",
                 "mycrate",
             ];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, Some("nightly".to_string()));
             assert_eq!(
@@ -1420,7 +1762,7 @@ mod tests {
         #[test]
         fn test_no_toolchain() {
             let args = vec!["cgx", "ripgrep"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, None);
             assert_eq!(filtered, vec!["cgx", "ripgrep"]);
@@ -1429,7 +1771,7 @@ mod tests {
         #[test]
         fn test_bare_plus() {
             let args = vec!["cgx", "+", "ripgrep"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, None);
             assert_eq!(filtered, vec!["cgx", "+", "ripgrep"]);
@@ -1438,7 +1780,7 @@ mod tests {
         #[test]
         fn test_plus_in_middle_not_toolchain() {
             let args = vec!["cgx", "ripgrep", "+something"];
-            let (toolchain, filtered) = CliArgs::extract_toolchain(args);
+            let (toolchain, filtered) = Cli::extract_toolchain(args);
 
             assert_eq!(toolchain, None);
             assert_eq!(filtered, vec!["cgx", "ripgrep", "+something"]);
@@ -1446,11 +1788,17 @@ mod tests {
 
         #[test]
         fn test_toolchain_with_version_flag() {
+            // `--version` after the crate name is a tool argument, not cgx's: the crate is ripgrep
+            // and `--version 14` is forwarded to it.
             let args = vec!["+nightly", "ripgrep", "--version", "14"];
-            let cli = CliArgs::parse_from_test_args(args);
+            let cli = Cli::parse_from_test_args(args);
 
-            assert_eq!(cli.toolchain, Some("nightly".to_string()));
-            assert_eq!(cli.crate_spec, Some("ripgrep".to_string()));
+            let invocation = cli.crate_invocation();
+            assert_eq!(invocation.toolchain.as_deref(), Some("nightly"));
+            assert_eq!(invocation.crate_spec.as_deref(), Some("ripgrep"));
+
+            let tool_args: Vec<&str> = cli.tool_args().iter().map(|arg| arg.to_str().unwrap()).collect();
+            assert_eq!(tool_args, ["--version", "14"]);
         }
 
         #[test]
@@ -1458,23 +1806,25 @@ mod tests {
             // BuildOptions reads toolchain from Config, not from CLI args directly.
             // CLI toolchain override (+nightly) is applied by Config::load_from_dir().
             let args = vec!["ripgrep"];
-            let cli = CliArgs::parse_from_test_args(args);
+            let cli = Cli::parse_from_test_args(args);
 
             let config = Config {
                 toolchain: Some("nightly".to_string()),
                 ..Default::default()
             };
-            let opts = BuildOptions::load(&config, &cli.build_options, cli.verbose).unwrap();
+            let opts =
+                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
             assert_eq!(opts.toolchain, Some("nightly".to_string()));
         }
 
         #[test]
         fn test_no_toolchain_in_build_options() {
             let args = vec!["ripgrep"];
-            let cli = CliArgs::parse_from_test_args(args);
+            let cli = Cli::parse_from_test_args(args);
 
             let config = Config::default();
-            let opts = BuildOptions::load(&config, &cli.build_options, cli.verbose).unwrap();
+            let opts =
+                BuildOptions::load(&config, &cli.crate_invocation().build_options, cli.verbose()).unwrap();
             assert_eq!(opts.toolchain, None);
         }
     }
@@ -1487,8 +1837,7 @@ mod tests {
             // Verify that system-config-dir, app-dir, and user-config-dir work together.
             // This tests our design decision that these three options are compatible,
             // not just clap functionality.
-            let result = CliArgs::try_parse_from([
-                "cgx",
+            let inputs = Cli::parse_from_test_args([
                 "--system-config-dir",
                 "/tmp/system",
                 "--app-dir",
@@ -1496,171 +1845,307 @@ mod tests {
                 "--user-config-dir",
                 "/tmp/user",
                 "ripgrep",
-            ]);
-            assert!(result.is_ok());
-            let cli = result.unwrap();
-            assert_eq!(cli.system_config_dir, Some(PathBuf::from("/tmp/system")));
-            assert_eq!(cli.app_dir, Some(PathBuf::from("/tmp/app")));
-            assert_eq!(cli.user_config_dir, Some(PathBuf::from("/tmp/user")));
+            ])
+            .config_inputs();
+            assert_eq!(
+                inputs.config.system_config_dir,
+                Some(PathBuf::from("/tmp/system"))
+            );
+            assert_eq!(inputs.config.app_dir, Some(PathBuf::from("/tmp/app")));
+            assert_eq!(inputs.config.user_config_dir, Some(PathBuf::from("/tmp/user")));
         }
     }
 
-    mod argument_splitting {
+    mod mode_validation {
         use super::*;
 
         #[test]
-        fn test_simple_split_at_crate_spec() {
-            let args = vec!["cgx", "ripgrep", "--version"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
+        fn prefetch_accepts_single_tool_build_options() {
+            let cli = Cli::try_parse_from_test_args([
+                "--prefetch",
+                "--features",
+                "frobnulator",
+                "--bin",
+                "timestamp",
+                "timestamp",
+            ])
+            .unwrap();
 
-            assert_eq!(cgx_args, vec!["cgx", "ripgrep"]);
-            assert_eq!(binary_args, vec!["--version"]);
+            assert_matches!(&cli, Cli::Prefetch(_));
+            let invocation = cli.crate_invocation();
+            assert_eq!(invocation.crate_spec.as_deref(), Some("timestamp"));
+            assert_eq!(invocation.build_options.features.as_deref(), Some("frobnulator"));
+            assert!(cli.tool_args().is_empty());
         }
 
         #[test]
-        fn test_split_with_cgx_flags_before_crate() {
-            let args = vec!["cgx", "--features", "foo", "ripgrep", "--color=always", "-i"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--features", "foo", "ripgrep"]);
-            assert_eq!(binary_args, vec!["--color=always", "-i"]);
+        fn prefetch_rejects_trailing_args() {
+            let result = Cli::try_parse_from_test_args(["--prefetch", "timestamp", "--help"]);
+            assert_matches!(result, Err(_));
         }
 
         #[test]
-        fn test_split_with_path_flag() {
-            let args = vec!["cgx", "--path", "./foo", "mycrate", "--help"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--path", "./foo", "mycrate"]);
-            assert_eq!(binary_args, vec!["--help"]);
+        fn prefetch_rejects_no_exec() {
+            let result = Cli::try_parse_from_test_args(["--prefetch", "--no-exec", "timestamp"]);
+            assert_matches!(result, Err(_));
         }
 
         #[test]
-        fn test_no_crate_spec_no_binary_args() {
-            let args = vec!["cgx", "--path", "./foo", "--version"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
+        fn prefetch_all_accepts_allowed_controls() {
+            let cli = Cli::try_parse_from_test_args([
+                "--prefetch-all",
+                "--offline",
+                "--refresh",
+                "--jobs",
+                "2",
+                "--ignore-rust-version",
+                "--http-timeout",
+                "5s",
+                "--system-config-dir",
+                "/tmp/system",
+                "--app-dir",
+                "/tmp/app",
+                "--user-config-dir",
+                "/tmp/user",
+                "--message-format",
+                "json",
+            ])
+            .unwrap();
 
-            assert_eq!(cgx_args, vec!["cgx", "--path", "./foo", "--version"]);
-            assert_eq!(binary_args, Vec::<String>::new());
-        }
-
-        #[test]
-        fn test_explicit_dash_dash_separator() {
-            let args = vec!["cgx", "ripgrep", "--", "--version"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "ripgrep"]);
-            assert_eq!(binary_args, vec!["--version"]);
-        }
-
-        #[test]
-        fn test_dash_dash_before_crate_spec() {
-            let args = vec!["cgx", "--path", "./foo", "--", "--help"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--path", "./foo"]);
-            assert_eq!(binary_args, vec!["--help"]);
-        }
-
-        #[test]
-        fn test_short_flags() {
-            let args = vec!["cgx", "-j", "4", "ripgrep", "-i"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "-j", "4", "ripgrep"]);
-            assert_eq!(binary_args, vec!["-i"]);
-        }
-
-        #[test]
-        fn test_combined_short_flag_with_value() {
-            let args = vec!["cgx", "-F", "foo,bar", "ripgrep", "-A", "3"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "-F", "foo,bar", "ripgrep"]);
-            assert_eq!(binary_args, vec!["-A", "3"]);
-        }
-
-        #[test]
-        fn test_bundled_short_flags() {
-            let args = vec!["cgx", "-vvv", "ripgrep", "-i"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "-vvv", "ripgrep"]);
-            assert_eq!(binary_args, vec!["-i"]);
-        }
-
-        #[test]
-        fn test_equals_syntax() {
-            let args = vec!["cgx", "--features=foo,bar", "ripgrep", "--color=always"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--features=foo,bar", "ripgrep"]);
-            assert_eq!(binary_args, vec!["--color=always"]);
-        }
-
-        #[test]
-        fn test_version_with_value() {
-            let args = vec!["cgx", "ripgrep", "--version", "14"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "ripgrep"]);
-            assert_eq!(binary_args, vec!["--version", "14"]);
-        }
-
-        #[test]
-        fn test_version_flag_before_crate_with_value() {
-            let args = vec!["cgx", "--version", "14", "ripgrep"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--version", "14", "ripgrep"]);
-            assert_eq!(binary_args, Vec::<String>::new());
-        }
-
-        #[test]
-        fn test_version_flag_before_crate_without_value() {
-            let args = vec!["cgx", "--version", "ripgrep"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "--version", "ripgrep"]);
-            assert_eq!(binary_args, Vec::<String>::new());
-        }
-
-        #[test]
-        fn test_crate_with_version_suffix() {
-            let args = vec!["cgx", "eza@=0.23.1", "--version"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "eza@=0.23.1"]);
-            assert_eq!(binary_args, vec!["--version"]);
-        }
-
-        #[test]
-        fn test_cargo_subcommand() {
-            let args = vec!["cgx", "cargo", "deny", "--help"];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "cargo"]);
-            assert_eq!(binary_args, vec!["deny", "--help"]);
-        }
-
-        #[test]
-        fn test_multiple_binary_flags() {
-            let args = vec![
-                "cgx",
-                "ripgrep",
-                "--color=always",
-                "-i",
-                "--no-heading",
-                "pattern",
-                "file.txt",
-            ];
-            let (cgx_args, binary_args) = CliArgs::split_at_crate_spec(args);
-
-            assert_eq!(cgx_args, vec!["cgx", "ripgrep"]);
+            let Cli::PrefetchAll(prefetch_all) = cli else {
+                panic!("expected a prefetch-all command");
+            };
+            assert!(prefetch_all.offline);
+            assert!(prefetch_all.refresh);
+            assert_eq!(prefetch_all.jobs, Some(2));
+            assert!(prefetch_all.ignore_rust_version);
+            assert_eq!(prefetch_all.http.http_timeout.as_deref(), Some("5s"));
             assert_eq!(
-                binary_args,
-                vec!["--color=always", "-i", "--no-heading", "pattern", "file.txt"]
+                prefetch_all.config.system_config_dir,
+                Some(PathBuf::from("/tmp/system"))
             );
+            assert_eq!(prefetch_all.config.app_dir, Some(PathBuf::from("/tmp/app")));
+            assert_eq!(
+                prefetch_all.config.user_config_dir,
+                Some(PathBuf::from("/tmp/user"))
+            );
+        }
+
+        #[test]
+        fn prefetch_all_rejects_crate_source_build_and_trailing_args() {
+            for args in [
+                vec!["--prefetch-all", "timestamp"],
+                vec!["--prefetch-all", "--path", "."],
+                vec!["--prefetch-all", "--features", "frobnulator"],
+                vec!["--prefetch-all", "--all-features"],
+                vec!["--prefetch-all", "--locked"],
+                vec!["--prefetch-all", "--prebuilt-binary", "never"],
+                vec!["--prefetch-all", "--", "--help"],
+            ] {
+                let result = Cli::try_parse_from_test_args(args);
+                assert_matches!(result, Err(_));
+            }
+        }
+
+        #[test]
+        fn list_tools_accepts_config_discovery_and_message_format() {
+            let cli = Cli::try_parse_from_test_args([
+                "--list-tools",
+                "--config-file",
+                "cgx.toml",
+                "--message-format",
+                "json",
+            ])
+            .unwrap();
+
+            let Cli::ListTools(list_tools) = cli else {
+                panic!("expected a list-tools command");
+            };
+            assert_eq!(list_tools.config.config_file, Some(PathBuf::from("cgx.toml")));
+            assert_matches!(list_tools.reporting.message_format, Some(MessageFormat::Json));
+
+            let cli = Cli::try_parse_from_test_args([
+                "--list-tools",
+                "--system-config-dir",
+                "/tmp/system",
+                "--app-dir",
+                "/tmp/app",
+                "--user-config-dir",
+                "/tmp/user",
+                "--message-format",
+                "json",
+            ])
+            .unwrap();
+
+            let Cli::ListTools(list_tools) = cli else {
+                panic!("expected a list-tools command");
+            };
+            assert_eq!(
+                list_tools.config.system_config_dir,
+                Some(PathBuf::from("/tmp/system"))
+            );
+            assert_eq!(list_tools.config.app_dir, Some(PathBuf::from("/tmp/app")));
+            assert_eq!(
+                list_tools.config.user_config_dir,
+                Some(PathBuf::from("/tmp/user"))
+            );
+            assert_matches!(list_tools.reporting.message_format, Some(MessageFormat::Json));
+        }
+
+        #[test]
+        fn list_tools_rejects_operational_flags() {
+            for args in [
+                vec!["--list-tools", "timestamp"],
+                vec!["--list-tools", "--offline"],
+                vec!["--list-tools", "--features", "frobnulator"],
+                vec!["--list-tools", "--prefetch"],
+            ] {
+                let result = Cli::try_parse_from_test_args(args);
+                assert_matches!(result, Err(_));
+            }
+        }
+
+        #[test]
+        fn config_features_apply_when_cli_features_absent() {
+            let cli = Cli::parse_from_test_args(["timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_tool_name(
+                &config,
+                &cli.crate_invocation().build_options,
+                cli.verbose(),
+                Some("timestamp"),
+            )
+            .unwrap();
+
+            assert_eq!(options.features, vec!["frobnulator"]);
+        }
+
+        #[test]
+        fn cli_features_replace_config_features() {
+            let cli = Cli::parse_from_test_args(["--features", "gonkolator", "timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_tool_name(
+                &config,
+                &cli.crate_invocation().build_options,
+                cli.verbose(),
+                Some("timestamp"),
+            )
+            .unwrap();
+
+            assert_eq!(options.features, vec!["gonkolator"]);
+        }
+    }
+
+    mod run_invocation {
+        use super::*;
+
+        /// Parse run-path args (without the leading executable name) into a [`Cli`].
+        fn run(args: &[&str]) -> Cli {
+            Cli::parse_from_test_args(args)
+        }
+
+        /// The forwarded tool arguments, as owned strings for convenient comparison.
+        fn tool_args(cli: &Cli) -> Vec<String> {
+            cli.tool_args()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect()
+        }
+
+        #[test]
+        fn crate_then_tool_args_pass_through_without_dashdash() {
+            let cli = run(&["ripgrep", "--color=always", "-i"]);
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(tool_args(&cli), ["--color=always", "-i"]);
+        }
+
+        #[test]
+        fn cgx_flags_before_crate_are_not_tool_args() {
+            let cli = run(&["--features", "foo", "ripgrep", "--color=always", "-i"]);
+            let invocation = cli.crate_invocation();
+            assert_eq!(invocation.crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(invocation.build_options.features.as_deref(), Some("foo"));
+            assert_eq!(tool_args(&cli), ["--color=always", "-i"]);
+        }
+
+        #[test]
+        fn same_flag_before_and_after_crate_is_split_by_position() {
+            // `-F x` is cgx's features flag; `-F y` after the crate is forwarded to the tool.
+            let cli = run(&["-F", "x", "ripgrep", "-F", "y"]);
+            assert_eq!(
+                cli.crate_invocation().build_options.features.as_deref(),
+                Some("x")
+            );
+            assert_eq!(tool_args(&cli), ["-F", "y"]);
+        }
+
+        #[test]
+        fn version_flag_after_crate_is_a_tool_arg() {
+            // The hard requirement: `cgx <crate> --version` runs the tool with `--version` and must
+            // NOT print cgx's own version.
+            let cli = run(&["ripgrep", "--version"]);
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(tool_args(&cli), ["--version"]);
+
+            let cli = run(&["ripgrep", "-V"]);
+            assert_eq!(tool_args(&cli), ["-V"]);
+        }
+
+        #[test]
+        fn explicit_dashdash_forwards_following_args() {
+            let cli = run(&["ripgrep", "--", "--version"]);
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("ripgrep"));
+            assert_eq!(tool_args(&cli), ["--version"]);
+        }
+
+        #[test]
+        fn at_version_suffix_with_tool_version_flag() {
+            let cli = run(&["eza@=0.23.1", "--version"]);
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("eza@=0.23.1"));
+            assert_eq!(tool_args(&cli), ["--version"]);
+        }
+
+        #[test]
+        fn cargo_subcommand_is_normalized_and_remaining_args_forwarded() {
+            let cli = run(&["cargo", "deny", "--all"]);
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("cargo-deny"));
+            assert_eq!(tool_args(&cli), ["--all"]);
+        }
+
+        #[test]
+        fn crate_named_like_a_mode_flag_runs_that_crate() {
+            // `prefetch` (no dashes) is a crate name, not the `--prefetch` mode.
+            let cli = run(&["prefetch"]);
+            assert_matches!(&cli, Cli::Run { .. });
+            assert_eq!(cli.crate_invocation().crate_spec.as_deref(), Some("prefetch"));
         }
     }
 
@@ -1669,36 +2154,39 @@ mod tests {
 
         #[test]
         fn test_http_timeout_cli_arg() {
-            let cli = CliArgs::parse_from_test_args(["--http-timeout", "2m", "test-crate"]);
-            assert_eq!(cli.http_timeout, Some("2m".to_string()));
+            let cli = Cli::parse_from_test_args(["--http-timeout", "2m", "test-crate"]);
+            assert_eq!(cli.crate_invocation().http.http_timeout, Some("2m".to_string()));
         }
 
         #[test]
         fn test_http_retries_cli_arg() {
-            let cli = CliArgs::parse_from_test_args(["--http-retries", "5", "test-crate"]);
-            assert_eq!(cli.http_retries, Some(5));
+            let cli = Cli::parse_from_test_args(["--http-retries", "5", "test-crate"]);
+            assert_eq!(cli.crate_invocation().http.http_retries, Some(5));
         }
 
         #[test]
         fn test_http_proxy_cli_arg() {
-            let cli =
-                CliArgs::parse_from_test_args(["--http-proxy", "socks5://localhost:1080", "test-crate"]);
-            assert_eq!(cli.http_proxy, Some("socks5://localhost:1080".to_string()));
+            let cli = Cli::parse_from_test_args(["--http-proxy", "socks5://localhost:1080", "test-crate"]);
+            assert_eq!(
+                cli.crate_invocation().http.http_proxy,
+                Some("socks5://localhost:1080".to_string())
+            );
         }
 
         #[test]
         fn test_http_args_default_none() {
-            let cli = CliArgs::parse_from_test_args(["test-crate"]);
-            assert_eq!(cli.http_timeout, None);
-            assert_eq!(cli.http_retries, None);
-            assert_eq!(cli.http_proxy, None);
+            let cli = Cli::parse_from_test_args(["test-crate"]);
+            assert_eq!(cli.crate_invocation().http.http_timeout, None);
+            assert_eq!(cli.crate_invocation().http.http_retries, None);
+            assert_eq!(cli.crate_invocation().http.http_proxy, None);
         }
 
         #[test]
         fn test_http_args_after_crate_spec_are_binary_args() {
-            let cli = CliArgs::parse_from_test_args(["test-crate", "--http-timeout", "5s"]);
-            assert_eq!(cli.http_timeout, None);
-            assert_eq!(cli.args, vec!["--http-timeout", "5s"]);
+            let cli = Cli::parse_from_test_args(["test-crate", "--http-timeout", "5s"]);
+            assert_eq!(cli.crate_invocation().http.http_timeout, None);
+            let tool_args: Vec<&str> = cli.tool_args().iter().map(|arg| arg.to_str().unwrap()).collect();
+            assert_eq!(tool_args, ["--http-timeout", "5s"]);
         }
     }
 
@@ -1708,28 +2196,28 @@ mod tests {
         #[test]
         fn test_leaves_normal_invocation_unchanged() {
             let args = vec!["cgx", "ripgrep", "--help"];
-            let result = CliArgs::strip_cargo_subcommand_arg(args.clone());
+            let result = Cli::strip_cargo_subcommand_arg(args.clone());
             assert_eq!(result, args);
         }
 
         #[test]
         fn test_leaves_cargo_without_cgx_unchanged() {
             let args = vec!["cargo-cgx", "ripgrep", "--help"];
-            let result = CliArgs::strip_cargo_subcommand_arg(args.clone());
+            let result = Cli::strip_cargo_subcommand_arg(args.clone());
             assert_eq!(result, args);
         }
 
         #[test]
         fn test_empty_args() {
             let args: Vec<String> = vec![];
-            let result = CliArgs::strip_cargo_subcommand_arg(args.clone());
+            let result = Cli::strip_cargo_subcommand_arg(args.clone());
             assert_eq!(result, args);
         }
 
         #[test]
         fn test_single_arg() {
             let args = vec!["cargo-cgx"];
-            let result = CliArgs::strip_cargo_subcommand_arg(args.clone());
+            let result = Cli::strip_cargo_subcommand_arg(args.clone());
             assert_eq!(result, args);
         }
     }

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -2107,6 +2107,7 @@ mod tests {
             config.tools.insert(
                 "timestamp".to_string(),
                 ToolConfig::Detailed {
+                    default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
                     registry: None,
@@ -2140,6 +2141,7 @@ mod tests {
             config.tools.insert(
                 "timestamp".to_string(),
                 ToolConfig::Detailed {
+                    default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
                     registry: None,
@@ -2162,6 +2164,112 @@ mod tests {
             .unwrap();
 
             assert_eq!(options.features, vec!["gonkolator"]);
+        }
+
+        /// `default-features = false` in the `[tools]` config disables default features, the same
+        /// as passing `--no-default-features`.
+        #[test]
+        fn config_default_features_false_disables_defaults() {
+            let cli = Cli::parse_from_test_args(["timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: false,
+                    version: None,
+                    features: None,
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            assert!(options.no_default_features);
+        }
+
+        /// The default `default-features = true` (the same as omitting the key) leaves default
+        /// features enabled.
+        #[test]
+        fn config_default_features_true_keeps_defaults() {
+            let cli = Cli::parse_from_test_args(["timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: true,
+                    version: None,
+                    features: None,
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            assert!(!options.no_default_features);
+        }
+
+        /// Config `default-features` is independent of the feature list: overriding `--features` on
+        /// the CLI replaces the configured features but leaves the configured `default-features =
+        /// false` in effect.
+        #[test]
+        fn config_default_features_independent_of_cli_features() {
+            let cli = Cli::parse_from_test_args(["--features", "gonkolator", "timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: false,
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            // CLI replaced the feature list, but the configured `default-features = false` still
+            // applies.
+            assert_eq!(options.features, vec!["gonkolator"]);
+            assert!(options.no_default_features);
         }
     }
 

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -275,12 +275,25 @@ impl CrateArgs {
     pub fn crate_request(&self) -> crate::Result<CrateRequest> {
         // Split the CLI-only `name@version` convention into name and version-suffix string.
         let (name, at_version) = match &self.crate_spec {
-            Some(spec) => match spec.split_once('@') {
-                Some((name, version)) => (Some(name.to_string()), Some(version.to_string())),
-                None => (Some(spec.clone()), None),
-            },
+            Some(spec) => {
+                let (name, at_version) = match spec.split_once('@') {
+                    Some((name, version)) => (name.to_string(), Some(version.to_string())),
+                    None => (spec.clone(), None),
+                };
+                if name.is_empty() {
+                    return crate::error::MissingCrateNameSnafu { spec: spec.clone() }.fail();
+                }
+                (Some(name), at_version)
+            }
             None => (None, None),
         };
+
+        // `cgx cargo <subcommand>` is normalized to the `cargo-<subcommand>` plugin crate during
+        // invocation splitting, so a crate spec still named `cargo` means the user is trying to
+        // run cargo itself, which cgx cannot do.
+        if name.as_deref() == Some("cargo") {
+            return crate::error::CargoNotRunnableSnafu.fail();
+        }
 
         // Users can either specify a semver version req with the `name@version` syntax in the
         // crate name, or they can specify the version with `--crate-version`, but they cannot
@@ -402,6 +415,7 @@ impl PrefetchAll {
             http_proxy: self.http.http_proxy.clone(),
             offline: self.offline,
             refresh: self.refresh,
+            verbosity: Verbosity::from_count(self.reporting.verbose),
             ..self.config.to_config_overrides()
         }
     }
@@ -784,9 +798,24 @@ impl RawCli {
         }
 
         let crate_spec = parts.remove(0).to_string_lossy().into_owned();
-        let (crate_spec, mut tool_args) = if crate_spec == "cargo" && !parts.is_empty() {
-            let subcommand = parts.remove(0);
-            (format!("cargo-{}", subcommand.to_string_lossy()), parts)
+        let (crate_spec, mut tool_args) = if crate_spec == "cargo" {
+            // A `--` may also separate `cargo` from its subcommand; drop it before deciding
+            // whether a subcommand follows.
+            if matches!(parts.first().and_then(|arg| arg.to_str()), Some("--")) {
+                parts.remove(0);
+            }
+            // Glue only a plausible subcommand name into the `cargo-<subcommand>` plugin crate
+            // name. A flag (or nothing) leaves the spec as bare `cargo`, which
+            // [`CrateArgs::crate_request`] rejects as unrunnable.
+            if parts
+                .first()
+                .is_some_and(|arg| !arg.to_string_lossy().starts_with('-'))
+            {
+                let subcommand = parts.remove(0);
+                (format!("cargo-{}", subcommand.to_string_lossy()), parts)
+            } else {
+                (crate_spec, parts)
+            }
         } else {
             (crate_spec, parts)
         };
@@ -932,6 +961,7 @@ impl RawCli {
             Self::ensure_no_crate_args(&tool_args, "--list-targets")?;
             Ok(Cli::ListTargets(crate_args))
         } else if no_exec {
+            Self::ensure_no_crate_args(&tool_args, "--no-exec")?;
             Ok(Cli::NoExec(crate_args))
         } else {
             Ok(Cli::Run {
@@ -1190,6 +1220,18 @@ mod tests {
         }
 
         #[test]
+        fn test_at_version_without_crate_name() {
+            let result = parse_cratespec_from_args(&["@1.0"]);
+            assert_matches!(result, Err(crate::error::Error::MissingCrateName { .. }));
+        }
+
+        #[test]
+        fn test_empty_crate_spec() {
+            let result = parse_cratespec_from_args(&[""]);
+            assert_matches!(result, Err(crate::error::Error::MissingCrateName { .. }));
+        }
+
+        #[test]
         fn test_cargo_subcommand() {
             let cr = parse_cratespec_from_args(&["cargo", "deny"]).unwrap();
             assert_matches!(
@@ -1206,6 +1248,24 @@ mod tests {
                 CrateSpec::CratesIo { ref name, version: Some(ref v) }
                 if name == "cargo-deny" && v == &semver::VersionReq::parse("1").unwrap()
             );
+        }
+
+        #[test]
+        fn test_cargo_without_subcommand() {
+            let result = parse_cratespec_from_args(&["cargo"]);
+            assert_matches!(result, Err(crate::error::Error::CargoNotRunnable));
+        }
+
+        #[test]
+        fn test_cargo_with_flag_argument() {
+            let result = parse_cratespec_from_args(&["cargo", "--help"]);
+            assert_matches!(result, Err(crate::error::Error::CargoNotRunnable));
+        }
+
+        #[test]
+        fn test_cargo_with_version() {
+            let result = parse_cratespec_from_args(&["cargo@1.0"]);
+            assert_matches!(result, Err(crate::error::Error::CargoNotRunnable));
         }
 
         #[test]
@@ -1671,6 +1731,19 @@ mod tests {
             assert_eq!(opts.features, vec!["foo", "bar"]);
         }
 
+        /// An explicit empty `--features` value (which cargo itself accepts) is an empty feature
+        /// list, distinct from the flag being absent entirely.
+        #[test]
+        fn empty_features_value_is_distinct_from_absent_flag() {
+            for empty in ["", ","] {
+                let cli = Cli::parse_from_test_args(["--features", empty, "ripgrep"]);
+                assert_eq!(cli.crate_args().to_build_overrides().features, Some(vec![]));
+            }
+
+            let cli = Cli::parse_from_test_args(["ripgrep"]);
+            assert_eq!(cli.crate_args().to_build_overrides().features, None);
+        }
+
         #[test]
         fn test_all_features() {
             let opts = parse_build_options_from_args(&["--all-features", "ripgrep"]).unwrap();
@@ -1944,6 +2017,17 @@ mod tests {
         }
 
         #[test]
+        fn no_exec_rejects_trailing_args() {
+            for args in [
+                vec!["--no-exec", "timestamp", "--help"],
+                vec!["--no-exec", "timestamp", "--", "--help"],
+            ] {
+                let result = Cli::try_parse_from_test_args(args);
+                assert_matches!(result, Err(_));
+            }
+        }
+
+        #[test]
         fn prefetch_rejects_no_exec() {
             let result = Cli::try_parse_from_test_args(["--prefetch", "--no-exec", "timestamp"]);
             assert_matches!(result, Err(_));
@@ -2021,6 +2105,18 @@ mod tests {
             let config = Config::load_from_dir(temp.path(), &overrides).unwrap();
             assert!(config.offline);
             assert!(config.refresh);
+        }
+
+        #[test]
+        fn prefetch_all_verbosity_reaches_config_overrides() {
+            let cli = Cli::parse_from_test_args(["--prefetch-all", "-vv"]);
+            let Cli::PrefetchAll(prefetch_all) = &cli else {
+                panic!("expected a prefetch-all command");
+            };
+            assert_eq!(
+                prefetch_all.to_config_overrides().verbosity,
+                Verbosity::VeryVerbose
+            );
         }
 
         #[test]
@@ -2166,6 +2262,41 @@ mod tests {
             assert_eq!(options.features, vec!["gonkolator"]);
         }
 
+        /// An explicit empty `--features` value (accepted by cargo as "no features") is still an
+        /// explicit CLI override, so configured `[tools]` features are not applied.
+        #[test]
+        fn empty_cli_features_override_config_features() {
+            let cli = Cli::parse_from_test_args(["--features", "", "timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: true,
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(options.features, Vec::<String>::new());
+            assert!(!options.all_features);
+        }
+
         /// `default-features = false` in the `[tools]` config disables default features, the same
         /// as passing `--no-default-features`.
         #[test]
@@ -2271,6 +2402,114 @@ mod tests {
             assert_eq!(options.features, vec!["gonkolator"]);
             assert!(options.no_default_features);
         }
+
+        /// With `--all-features`, configured `[tools]` features and `default-features` are
+        /// overridden (cargo is invoked with `--all-features` alone), so the loaded options are
+        /// identical to those of a tool with no config entry and the two builds can share a cache
+        /// entry.
+        ///
+        /// This test simply verifies that the `--all-features` flag sufficiently overrides the
+        /// [`tools`] config that the resulting `BuildOptions` has the same hash as it does when
+        /// there is not `[tools]` entry for the crate.
+        #[test]
+        fn all_features_yields_same_options_as_unconfigured_tool() {
+            let cli = Cli::parse_from_test_args(["--all-features", "timestamp"]);
+            let mut configured = Config::default();
+            configured.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: false,
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+            let spec = CrateSpec::CratesIo {
+                name: "timestamp".to_string(),
+                version: None,
+            };
+
+            let overrides = cli.crate_args().to_build_overrides();
+            let with_config = BuildOptions::load_for_crate(&configured, &overrides, &spec).unwrap();
+            let without_config = BuildOptions::load_for_crate(&Config::default(), &overrides, &spec).unwrap();
+
+            assert_eq!(with_config, without_config);
+        }
+
+        /// `--all-features` supersedes a configured `[tools]` feature list, which cannot affect a
+        /// build that already enables every feature.
+        #[test]
+        fn all_features_leaves_config_features_unapplied() {
+            let cli = Cli::parse_from_test_args(["--all-features", "timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: true,
+                    version: None,
+                    features: Some(vec!["frobnulator".to_string()]),
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            assert!(options.all_features);
+            assert_eq!(options.features, Vec::<String>::new());
+        }
+
+        /// `--all-features` supersedes configured `default-features = false`, which has no effect
+        /// when every feature is enabled anyway.
+        #[test]
+        fn all_features_leaves_config_default_features_unapplied() {
+            let cli = Cli::parse_from_test_args(["--all-features", "timestamp"]);
+            let mut config = Config::default();
+            config.tools.insert(
+                "timestamp".to_string(),
+                ToolConfig::Detailed {
+                    default_features: false,
+                    version: None,
+                    features: None,
+                    registry: None,
+                    git: None,
+                    branch: None,
+                    tag: None,
+                    rev: None,
+                    path: None,
+                },
+            );
+
+            let options = BuildOptions::load_for_crate(
+                &config,
+                &cli.crate_args().to_build_overrides(),
+                &CrateSpec::CratesIo {
+                    name: "timestamp".to_string(),
+                    version: None,
+                },
+            )
+            .unwrap();
+
+            assert!(options.all_features);
+            assert!(!options.no_default_features);
+        }
     }
 
     mod run_invocation {
@@ -2344,6 +2583,33 @@ mod tests {
             let cli = run(&["cargo", "deny", "--all"]);
             assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("cargo-deny"));
             assert_eq!(tool_args(&cli), ["--all"]);
+        }
+
+        /// A `--` separator between `cargo` and the subcommand is permitted; the subcommand is
+        /// still normalized into the plugin crate name.
+        #[test]
+        fn cargo_separator_then_subcommand_is_normalized() {
+            let cli = run(&["cargo", "--", "deny"]);
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("cargo-deny"));
+            assert_eq!(tool_args(&cli), Vec::<String>::new());
+        }
+
+        /// A flag after `cargo` is not a subcommand name; it stays a tool argument for the
+        /// (unrunnable) `cargo` crate spec rather than being glued into the crate name.
+        #[test]
+        fn cargo_followed_by_flag_keeps_flag_as_tool_arg() {
+            let cli = run(&["cargo", "--help"]);
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("cargo"));
+            assert_eq!(tool_args(&cli), ["--help"]);
+        }
+
+        /// The `--` separator between the cargo subcommand and the tool's own flags is dropped,
+        /// matching the behavior for ordinary crate specs.
+        #[test]
+        fn cargo_subcommand_separator_then_flags_forwards_flags() {
+            let cli = run(&["cargo", "deny", "--", "--flag"]);
+            assert_eq!(cli.crate_args().crate_spec.as_deref(), Some("cargo-deny"));
+            assert_eq!(tool_args(&cli), ["--flag"]);
         }
 
         #[test]

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -832,7 +832,8 @@ impl RawCli {
 
     /// Validate the raw parse and render it into a typed [`Cli`] command.
     ///
-    /// This is the single place semantic rules live: the mode arg-group already guarantees at most
+    /// This is the single location where advanced CLI validation (which `clap` is not expressive
+    /// enough to represent/enforce itself) happens: the mode arg-group already guarantees at most
     /// one mode flag, and here we enforce which other flags each mode permits, whether a crate is
     /// required or forbidden, and whether trailing tool arguments are allowed.
     ///
@@ -863,18 +864,16 @@ impl RawCli {
 
         if prefetch_all {
             let mode = "--prefetch-all";
-            Self::ensure_no_crate(&crate_spec, &tool_args, mode)?;
-            if source.is_present() {
-                return Err(Self::forbidden(mode, "source selectors"));
-            }
-            if prebuilt.is_present() {
-                return Err(Self::forbidden(mode, "--prebuilt-binary options"));
-            }
+            Self::ensure_config_mode_common(
+                mode,
+                &crate_spec,
+                &tool_args,
+                &source,
+                &prebuilt,
+                &crate_version,
+            )?;
             if cargo.locked || cargo.frozen || cargo.unlocked {
                 return Err(Self::forbidden(mode, "--locked/--frozen/--unlocked"));
-            }
-            if crate_version.is_some() {
-                return Err(Self::forbidden(mode, "--crate-version"));
             }
             if build_options.has_compilation_options() {
                 return Err(Self::forbidden(mode, "build/compilation options"));
@@ -893,18 +892,21 @@ impl RawCli {
 
         if list_tools {
             let mode = "--list-tools";
-            Self::ensure_no_crate(&crate_spec, &tool_args, mode)?;
-            if source.is_present() {
-                return Err(Self::forbidden(mode, "source selectors"));
-            }
-            if prebuilt.is_present() {
-                return Err(Self::forbidden(mode, "--prebuilt-binary options"));
-            }
+            Self::ensure_config_mode_common(
+                mode,
+                &crate_spec,
+                &tool_args,
+                &source,
+                &prebuilt,
+                &crate_version,
+            )?;
+
+            // `--list-tools` is purely local: it only reads the merged config, never resolving,
+            // downloading, or building. It therefore additionally forbids everything network- or
+            // toolchain-related (offline/refresh, --http-*, +toolchain) that `--prefetch-all`
+            // legitimately permits.
             if cargo.locked || cargo.frozen || cargo.unlocked || cargo.offline || cargo.refresh {
                 return Err(Self::forbidden(mode, "cargo behavior flags"));
-            }
-            if crate_version.is_some() {
-                return Err(Self::forbidden(mode, "--crate-version"));
             }
             if build_options.is_present() {
                 return Err(Self::forbidden(mode, "build options"));
@@ -977,6 +979,31 @@ impl RawCli {
             ErrorKind::ArgumentConflict,
             format!("{what} cannot be used with {mode}\n"),
         )
+    }
+
+    /// Run the flag guards shared by the config-driven modes (`--prefetch-all` and `--list-tools`):
+    /// they accept no crate or trailing arguments, no source selectors, no `--prebuilt-binary`
+    /// options, and no `--crate-version`. Each mode then layers its own additional, intentionally
+    /// differing guards on top of these.
+    fn ensure_config_mode_common(
+        mode: &str,
+        crate_spec: &Option<String>,
+        tool_args: &[OsString],
+        source: &SourceArgs,
+        prebuilt: &PrebuiltBinaryArgs,
+        crate_version: &Option<String>,
+    ) -> Result<(), clap::Error> {
+        Self::ensure_no_crate(crate_spec, tool_args, mode)?;
+        if source.is_present() {
+            return Err(Self::forbidden(mode, "source selectors"));
+        }
+        if prebuilt.is_present() {
+            return Err(Self::forbidden(mode, "--prebuilt-binary options"));
+        }
+        if crate_version.is_some() {
+            return Err(Self::forbidden(mode, "--crate-version"));
+        }
+        Ok(())
     }
 
     /// Reject a crate spec or trailing arguments for the config-level commands that take neither.
@@ -1141,7 +1168,7 @@ mod tests {
     use crate::{
         Result,
         builder::{BuildOptions, BuildTarget},
-        config::{Config, ToolConfig},
+        config::{Config, ToolConfig, ToolConfigDetailed},
         cratespec::{CrateSpec, Forge, RegistrySource},
         git::GitSelector,
     };
@@ -2202,7 +2229,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2212,7 +2239,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2236,7 +2263,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2246,7 +2273,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2270,7 +2297,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2280,7 +2307,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2305,7 +2332,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: false,
                     version: None,
                     features: None,
@@ -2315,7 +2342,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2339,7 +2366,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: None,
                     features: None,
@@ -2349,7 +2376,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2374,7 +2401,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: false,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2384,7 +2411,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2417,7 +2444,7 @@ mod tests {
             let mut configured = Config::default();
             configured.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: false,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2427,7 +2454,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
             let spec = CrateSpec::CratesIo {
                 name: "timestamp".to_string(),
@@ -2449,7 +2476,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: None,
                     features: Some(vec!["frobnulator".to_string()]),
@@ -2459,7 +2486,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(
@@ -2484,7 +2511,7 @@ mod tests {
             let mut config = Config::default();
             config.tools.insert(
                 "timestamp".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: false,
                     version: None,
                     features: None,
@@ -2494,7 +2521,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             );
 
             let options = BuildOptions::load_for_crate(

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use strum::{Display, EnumIter, EnumString, IntoStaticStr, VariantNames};
 
-use crate::{Result, cli::CliArgs};
+use crate::{
+    Result,
+    cli::{ConfigArgs, ConfigInputs, HttpArgs},
+};
 
 const DEFAULT_RESOLVE_CACHE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -212,6 +215,16 @@ pub enum ToolConfig {
     },
 }
 
+impl ToolConfig {
+    /// Return configured features for a [`ToolConfig::Detailed`] tool.
+    pub fn features(&self) -> Option<&[String]> {
+        match self {
+            ToolConfig::Version(_) => None,
+            ToolConfig::Detailed { features, .. } => features.as_deref(),
+        }
+    }
+}
+
 /// Intermediate structure for deserializing config files from TOML.
 ///
 /// This matches the structure of cgx.toml files and is used during the deserialization
@@ -403,21 +416,64 @@ impl Config {
     /// 3. User config file
     /// 4. Directory hierarchy config files (from root to current directory)
     /// 5. Command-line arguments (highest priority)
-    pub fn load(args: &CliArgs) -> Result<Self> {
+    pub fn load(inputs: &ConfigInputs) -> Result<Self> {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-        Self::load_from_dir(&cwd, args)
+        Self::load_from_dir(&cwd, inputs)
+    }
+
+    /// Render the merged configured tools and aliases as deterministic TOML.
+    pub fn tools_toml(&self) -> Result<String> {
+        #[derive(Serialize)]
+        struct ToolsToml {
+            tools: BTreeMap<String, ToolConfig>,
+            aliases: BTreeMap<String, String>,
+        }
+
+        let tools = self
+            .tools
+            .iter()
+            .map(|(name, config)| (name.clone(), config.clone()))
+            .collect();
+        let aliases = self
+            .aliases
+            .iter()
+            .map(|(name, target)| (name.clone(), target.clone()))
+            .collect();
+
+        let mut rendered = toml::to_string_pretty(&ToolsToml { tools, aliases })
+            .context(crate::error::TomlSerializeSnafu)?;
+
+        if !rendered.lines().any(|line| line.trim() == "[tools]") {
+            rendered = format!("[tools]\n\n{}", rendered);
+        }
+
+        if !rendered.lines().any(|line| line.trim() == "[aliases]") {
+            if !rendered.ends_with('\n') {
+                rendered.push('\n');
+            }
+            rendered.push_str("\n[aliases]\n");
+        }
+
+        Ok(rendered)
     }
 
     /// Load config from the CLI args and a specified directory which may or may not contain config
     /// files.
-    pub fn load_from_dir(cwd: &Path, args: &CliArgs) -> Result<Self> {
+    pub fn load_from_dir(cwd: &Path, inputs: &ConfigInputs) -> Result<Self> {
+        let ConfigInputs {
+            config: config_args,
+            http,
+            prebuilt,
+            cargo,
+            toolchain,
+        } = inputs;
         let strategy = Self::get_user_dirs()?;
 
         // Start with base config defaults, then merge config files
         let mut figment = Figment::new().merge(Serialized::defaults(ConfigFile::base_config()));
 
-        for config_file in Self::discover_config_files(cwd, args)? {
+        for config_file in Self::discover_config_files(cwd, config_args)? {
             figment = figment.merge(Toml::file(config_file));
         }
 
@@ -427,42 +483,42 @@ impl Config {
         // Override the config file values using any CLI args that were specified
 
         // locked: --unlocked > --locked/--frozen > config > default(true)
-        let locked = if args.unlocked {
+        let locked = if cargo.unlocked {
             false
-        } else if args.locked || args.frozen {
+        } else if cargo.locked || cargo.frozen {
             true
         } else {
             config_file.locked.unwrap_or(true)
         };
 
         // offline: --offline/--frozen > config > default(false)
-        let offline = if args.offline || args.frozen {
+        let offline = if cargo.offline || cargo.frozen {
             true
         } else {
             config_file.offline.unwrap_or(false)
         };
 
         // toolchain: CLI > config
-        let toolchain = args.toolchain.clone().or(config_file.toolchain);
+        let toolchain = toolchain.clone().or(config_file.toolchain);
 
         // Determine config_dir based on override precedence
-        let config_dir = if let Some(user_config_dir) = &args.user_config_dir {
+        let config_dir = if let Some(user_config_dir) = &config_args.user_config_dir {
             user_config_dir.clone()
-        } else if let Some(app_dir) = &args.app_dir {
+        } else if let Some(app_dir) = &config_args.app_dir {
             app_dir.join("config")
         } else {
             strategy.config_dir()
         };
 
         // Determine cache_dir: CLI (app-dir) > config file > strategy
-        let cache_dir = if let Some(app_dir) = &args.app_dir {
+        let cache_dir = if let Some(app_dir) = &config_args.app_dir {
             app_dir.join("cache")
         } else {
             config_file.cache_dir.unwrap_or_else(|| strategy.cache_dir())
         };
 
         // Determine bin_dir: CLI (app-dir) > config file > strategy
-        let bin_dir = if let Some(app_dir) = &args.app_dir {
+        let bin_dir = if let Some(app_dir) = &config_args.app_dir {
             app_dir.join("bins")
         } else {
             config_file
@@ -471,7 +527,7 @@ impl Config {
         };
 
         // Determine build_dir: CLI (app-dir) > config file > strategy
-        let build_dir = if let Some(app_dir) = &args.app_dir {
+        let build_dir = if let Some(app_dir) = &config_args.app_dir {
             app_dir.join("build")
         } else {
             config_file
@@ -482,16 +538,16 @@ impl Config {
         let mut prebuilt_binaries = config_file.prebuilt_binaries.unwrap_or_default();
 
         // Apply CLI overrides for prebuilt binaries
-        if let Some(mode) = args.prebuilt_binary {
+        if let Some(mode) = prebuilt.prebuilt_binary {
             prebuilt_binaries.use_prebuilt_binaries = mode;
         }
-        if let Some(ref providers) = args.prebuilt_binary_sources {
+        if let Some(ref providers) = prebuilt.prebuilt_binary_sources {
             prebuilt_binaries.binary_providers = providers.clone();
         }
-        if args.prebuilt_binary_no_verify_checksums {
+        if prebuilt.prebuilt_binary_no_verify_checksums {
             prebuilt_binaries.verify_checksums = false;
         }
-        if args.prebuilt_binary_no_verify_signatures {
+        if prebuilt.prebuilt_binary_no_verify_signatures {
             prebuilt_binaries.verify_signatures = false;
         }
 
@@ -504,7 +560,7 @@ impl Config {
 
         // Build HTTP config with precedence: CLI > config file > Cargo env vars > defaults
         let http_config_file = config_file.http.unwrap_or_default();
-        let http = Self::build_http_config(&http_config_file, args)?;
+        let http = Self::build_http_config(&http_config_file, http)?;
 
         Ok(Self {
             config_dir,
@@ -516,7 +572,7 @@ impl Config {
                 .unwrap_or(DEFAULT_RESOLVE_CACHE_TIMEOUT),
             offline,
             locked,
-            refresh: args.refresh,
+            refresh: cargo.refresh,
             toolchain,
             log_level: config_file.log_level,
             default_registry: config_file.default_registry,
@@ -536,16 +592,16 @@ impl Config {
     /// 2. User config: `$XDG_CONFIG_HOME/cgx/cgx.toml` or platform equivalent (or override
     ///    location)
     /// 3. Directory hierarchy: All `cgx.toml` files from filesystem root to current directory
-    fn discover_config_files(cwd: &Path, args: &CliArgs) -> Result<Vec<PathBuf>> {
+    fn discover_config_files(cwd: &Path, config_args: &ConfigArgs) -> Result<Vec<PathBuf>> {
         let mut config_files = Vec::new();
 
         // If the user explicitly specified a config file, read ONLY that file
-        if let Some(config_path) = &args.config_file {
+        if let Some(config_path) = &config_args.config_file {
             return Ok(vec![config_path.clone()]);
         }
 
         // System config (can be overridden)
-        if let Some(system_config_dir) = &args.system_config_dir {
+        if let Some(system_config_dir) = &config_args.system_config_dir {
             let system_config = system_config_dir.join("cgx.toml");
             if system_config.exists() {
                 config_files.push(system_config);
@@ -571,10 +627,10 @@ impl Config {
         }
 
         // User config (can be overridden via user-config-dir or app-dir)
-        let user_config = if let Some(user_config_dir) = &args.user_config_dir {
+        let user_config = if let Some(user_config_dir) = &config_args.user_config_dir {
             // Most specific: explicit user config directory
             user_config_dir.join("cgx.toml")
-        } else if let Some(app_dir) = &args.app_dir {
+        } else if let Some(app_dir) = &config_args.app_dir {
             // App dir provides a base for config
             app_dir.join("config").join("cgx.toml")
         } else {
@@ -614,11 +670,11 @@ impl Config {
     /// 2. Config file values
     /// 3. Cargo environment variable fallbacks
     /// 4. Defaults (lowest priority)
-    fn build_http_config(config_file: &HttpConfigFile, args: &CliArgs) -> Result<HttpConfig> {
+    fn build_http_config(config_file: &HttpConfigFile, http: &HttpArgs) -> Result<HttpConfig> {
         // Determine if CLI args were provided (they override everything)
-        let cli_timeout = args.http_timeout.as_ref();
-        let cli_retries = args.http_retries;
-        let cli_proxy = args.http_proxy.as_ref();
+        let cli_timeout = http.http_timeout.as_ref();
+        let cli_retries = http.http_retries;
+        let cli_proxy = http.http_proxy.as_ref();
 
         // timeout: CLI > config > CARGO_HTTP_TIMEOUT > default
         let timeout = if let Some(timeout_str) = cli_timeout {
@@ -709,16 +765,19 @@ pub(crate) fn create_test_env() -> (tempfile::TempDir, Config) {
 mod tests {
     use std::path::Path;
 
+    use assert_matches::assert_matches;
+
     use super::*;
+    use crate::cli::Cli;
 
     /// Apply test-local config directory overrides so config loading cannot read
     /// host-level `/etc/cgx.toml` or user-level cgx config on the machine running tests.
     ///
     /// This keeps tests deterministic on developer systems that actively use cgx.
-    fn with_isolated_global_config(mut args: CliArgs, root: &Path) -> CliArgs {
-        args.system_config_dir = Some(root.join("system"));
-        args.user_config_dir = Some(root.join("user"));
-        args
+    fn with_isolated_global_config(mut inputs: ConfigInputs, root: &Path) -> ConfigInputs {
+        inputs.config.system_config_dir = Some(root.join("system"));
+        inputs.config.user_config_dir = Some(root.join("user"));
+        inputs
     }
 
     #[test]
@@ -829,8 +888,56 @@ mod tests {
     }
 
     #[test]
+    fn test_tools_toml_is_sorted_and_valid() {
+        let mut config = Config::default();
+        config
+            .tools
+            .insert("zeta".to_string(), ToolConfig::Version("2".to_string()));
+        config
+            .tools
+            .insert("alpha".to_string(), ToolConfig::Version("1".to_string()));
+        config.tools.insert(
+            "beta".to_string(),
+            ToolConfig::Detailed {
+                version: Some("1.5".to_string()),
+                features: Some(vec!["frobnulator".to_string()]),
+                registry: None,
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                path: None,
+            },
+        );
+        config.aliases.insert("zz".to_string(), "zeta".to_string());
+        config.aliases.insert("aa".to_string(), "alpha".to_string());
+
+        let rendered = config.tools_toml().unwrap();
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+
+        let tools = parsed.tools.unwrap();
+        assert_eq!(tools.get("alpha"), Some(&ToolConfig::Version("1".to_string())));
+        assert_eq!(tools.get("zeta"), Some(&ToolConfig::Version("2".to_string())));
+        assert_matches!(
+            tools.get("beta"),
+            Some(ToolConfig::Detailed {
+                version: Some(version),
+                features: Some(features),
+                ..
+            }) if version == "1.5" && features == &vec!["frobnulator".to_string()]
+        );
+
+        let aliases = parsed.aliases.unwrap();
+        assert_eq!(aliases.get("aa"), Some(&"alpha".to_string()));
+        assert_eq!(aliases.get("zz"), Some(&"zeta".to_string()));
+
+        assert!(rendered.find("alpha").unwrap() < rendered.find("zeta").unwrap());
+        assert!(rendered.find("aa").unwrap() < rendered.find("zz").unwrap());
+    }
+
+    #[test]
     fn test_config_defaults() {
-        let args = CliArgs::parse_from_test_args(["test-crate"]);
+        let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
         let config = Config::load(&args).unwrap();
 
         assert!(!config.offline);
@@ -841,7 +948,8 @@ mod tests {
 
     #[test]
     fn test_cli_overrides() {
-        let args = CliArgs::parse_from_test_args(["+nightly", "--offline", "--locked", "test-crate"]);
+        let args =
+            Cli::parse_from_test_args(["+nightly", "--offline", "--locked", "test-crate"]).config_inputs();
         let config = Config::load(&args).unwrap();
 
         assert!(config.offline);
@@ -851,7 +959,7 @@ mod tests {
 
     #[test]
     fn test_frozen_implies_locked_and_offline() {
-        let args = CliArgs::parse_from_test_args(["--frozen", "test-crate"]);
+        let args = Cli::parse_from_test_args(["--frozen", "test-crate"]).config_inputs();
         let config = Config::load(&args).unwrap();
 
         assert!(config.offline);
@@ -932,7 +1040,7 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let result = Config::load_from_dir(temp_dir.path(), &args);
             assert_matches!(result, Err(crate::error::Error::NoProvidersConfigured));
         }
@@ -946,7 +1054,7 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let result = Config::load_from_dir(temp_dir.path(), &args);
             assert_matches!(result, Err(crate::error::Error::NoProvidersConfigured));
         }
@@ -960,7 +1068,7 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let result = Config::load_from_dir(temp_dir.path(), &args);
             assert!(result.is_ok(), "Empty providers with 'never' mode should succeed");
         }
@@ -986,7 +1094,7 @@ mod tests {
         fn test_config_hierarchy_project1() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project1();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(3 * 60));
@@ -1014,7 +1122,7 @@ mod tests {
         fn test_config_hierarchy_project2() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project2();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(5 * 60));
@@ -1041,7 +1149,7 @@ mod tests {
         fn test_config_hierarchy_work() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_work();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(2 * 60));
@@ -1067,7 +1175,7 @@ mod tests {
         fn test_config_hierarchy_root() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_root();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(60));
@@ -1093,8 +1201,8 @@ mod tests {
         fn test_explicit_config_file() {
             let test_case = crate::testdata::ConfigTestCase::explicit_non_standard_name();
 
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(test_case.path().to_path_buf());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(test_case.path().to_path_buf());
 
             let config = Config::load(&args).unwrap();
 
@@ -1119,7 +1227,7 @@ mod tests {
         fn test_tools_detailed_config_preserved() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_root();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             let taplo_tool = config.tools.get("taplo-cli").unwrap();
@@ -1142,7 +1250,8 @@ mod tests {
         fn test_cli_args_override_config_files() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project1();
 
-            let args = CliArgs::parse_from_test_args(["+stable", "--offline", "--locked", "test-crate"]);
+            let args =
+                Cli::parse_from_test_args(["+stable", "--offline", "--locked", "test-crate"]).config_inputs();
             let config = Config::load_from_dir(test_case.path(), &args).unwrap();
 
             assert!(config.offline);
@@ -1164,8 +1273,8 @@ mod tests {
             let explicit_config = crate::testdata::ConfigTestCase::explicit_non_standard_name();
 
             // Load config from project1 directory but with --config-file pointing to explicit config
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(explicit_config.path().to_path_buf());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(explicit_config.path().to_path_buf());
 
             let config = Config::load_from_dir(hierarchy_dir.path(), &args).unwrap();
 
@@ -1248,10 +1357,10 @@ mod tests {
             };
 
             // Test with --config-file
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(explicit_config.clone());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(explicit_config.clone());
 
-            let discovered = Config::discover_config_files(&sub_dir, &args).unwrap();
+            let discovered = Config::discover_config_files(&sub_dir, &args.config).unwrap();
 
             // Should contain ONLY the explicit config file (no system, user, or hierarchy configs)
             // This will FAIL if the bug exists, showing [user_config, explicit_config]
@@ -1280,8 +1389,8 @@ mod tests {
             let sub_config = sub_dir.join("cgx.toml");
             fs::write(&sub_config, "resolve_cache_timeout = \"2m\"").unwrap();
 
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let discovered = Config::discover_config_files(&sub_dir, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let discovered = Config::discover_config_files(&sub_dir, &args.config).unwrap();
 
             // Should contain both hierarchy configs (and possibly system/user if they exist)
             // We check that at least our two configs are present
@@ -1319,9 +1428,9 @@ mod tests {
                 let user_config_dir = temp_dir.path().join("user");
                 fs::create_dir_all(&user_config_dir).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.system_config_dir = Some(system_config_dir);
-                args.user_config_dir = Some(user_config_dir);
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.system_config_dir = Some(system_config_dir);
+                args.config.user_config_dir = Some(user_config_dir);
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(5 * 60));
@@ -1352,9 +1461,9 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.system_config_dir = Some(system_config_dir);
-                args.user_config_dir = Some(user_config_dir);
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.system_config_dir = Some(system_config_dir);
+                args.config.user_config_dir = Some(user_config_dir);
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 // User config should override system config
@@ -1376,8 +1485,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(7 * 60));
@@ -1391,8 +1500,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.cache_dir, app_dir.join("cache"));
@@ -1405,8 +1514,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.bin_dir, app_dir.join("bins"));
@@ -1419,8 +1528,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.build_dir, app_dir.join("build"));
@@ -1433,8 +1542,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
 
@@ -1459,8 +1568,8 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.user_config_dir = Some(user_config_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.user_config_dir = Some(user_config_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(8 * 60));
@@ -1489,9 +1598,9 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
-                args.user_config_dir = Some(user_config_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
+                args.config.user_config_dir = Some(user_config_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
 
@@ -1541,10 +1650,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.system_config_dir = Some(system_config_dir);
-                args.app_dir = Some(app_dir.clone());
-                args.user_config_dir = Some(user_config_dir.clone());
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.system_config_dir = Some(system_config_dir);
+                args.config.app_dir = Some(app_dir.clone());
+                args.config.user_config_dir = Some(user_config_dir.clone());
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
 
@@ -1581,8 +1690,8 @@ mod tests {
                 fs::create_dir_all(&sub).unwrap();
                 fs::write(sub.join("cgx.toml"), "[tools]\nsub_tool = \"1\"").unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir);
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir);
 
                 let config = Config::load_from_dir(&sub, &args).unwrap();
 
@@ -1614,9 +1723,9 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-                args.app_dir = Some(app_dir.clone());
-                args.config_file = Some(config_file);
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                args.config.app_dir = Some(app_dir.clone());
+                args.config.config_file = Some(config_file);
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
 
@@ -1643,9 +1752,9 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = CliArgs::parse_from_test_args(["test-crate"]);
+                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
                 // No --app-dir specified
-                args.config_file = Some(config_file);
+                args.config.config_file = Some(config_file);
 
                 let config = Config::load_from_dir(&cwd, &args).unwrap();
 
@@ -1752,9 +1861,9 @@ mod tests {
         #[test]
         fn test_http_config_all_defaults() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(30));
@@ -1773,9 +1882,9 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(120));
@@ -1792,7 +1901,7 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = CliArgs::parse_from_test_args([
+            let mut args = Cli::parse_from_test_args([
                 "--http-timeout",
                 "10s",
                 "--http-retries",
@@ -1800,9 +1909,10 @@ mod tests {
                 "--http-proxy",
                 "socks5://other:1080",
                 "test-crate",
-            ]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            ])
+            .config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(10));
@@ -1819,9 +1929,9 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = CliArgs::parse_from_test_args(["--http-timeout", "10s", "test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(10));
@@ -1832,9 +1942,10 @@ mod tests {
         #[test]
         fn test_http_config_invalid_timeout_duration() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args = CliArgs::parse_from_test_args(["--http-timeout", "not-a-duration", "test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args =
+                Cli::parse_from_test_args(["--http-timeout", "not-a-duration", "test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let result = Config::load_from_dir(temp_dir.path(), &args);
             assert_matches!(result, Err(crate::error::Error::InvalidHttpTimeout { .. }));
@@ -1843,9 +1954,9 @@ mod tests {
         #[test]
         fn test_http_config_zero_retries() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args = CliArgs::parse_from_test_args(["--http-retries", "0", "test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.retries, 0);
@@ -1859,9 +1970,9 @@ mod tests {
                 backoff_max = "60s"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.backoff_base, Duration::from_secs(2));
@@ -1875,9 +1986,9 @@ mod tests {
                 timeout = "45s"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.backoff_base, Duration::from_millis(500));
@@ -1913,8 +2024,10 @@ mod tests {
             )
             .unwrap();
 
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(&child, &args).unwrap();
             // Timeout comes from the child, overriding the parent, but since retries wasn't
@@ -1953,8 +2066,10 @@ mod tests {
             )
             .unwrap();
 
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(&child, &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(45));
@@ -1981,8 +2096,10 @@ mod tests {
         /// Verifies `CARGO_HTTP_TIMEOUT` is used when neither CLI nor config file sets timeout.
         fn test_env_timeout_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(45));
@@ -1992,8 +2109,10 @@ mod tests {
         /// Verifies `CARGO_NET_RETRY` is used when neither CLI nor config file sets retries.
         fn test_env_retries_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.retries, 7);
@@ -2003,8 +2122,10 @@ mod tests {
         /// Verifies `CARGO_HTTP_PROXY` is used when neither CLI nor config file sets proxy.
         fn test_env_proxy_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.proxy, Some("socks5://env-proxy:1080".to_string()));
@@ -2019,7 +2140,7 @@ mod tests {
         fn test_cli_overrides_env() {
             let temp_dir = tempfile::tempdir().unwrap();
             let args = with_isolated_global_config(
-                CliArgs::parse_from_test_args([
+                Cli::parse_from_test_args([
                     "--http-timeout",
                     "10s",
                     "--http-retries",
@@ -2027,7 +2148,8 @@ mod tests {
                     "--http-proxy",
                     "socks5://cli-proxy:1080",
                     "test-crate",
-                ]),
+                ])
+                .config_inputs(),
                 temp_dir.path(),
             );
 
@@ -2051,8 +2173,10 @@ mod tests {
                 proxy = "http://config-proxy:8080"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(120));
@@ -2064,8 +2188,10 @@ mod tests {
         /// Verifies invalid `CARGO_HTTP_TIMEOUT` falls back to the built-in default timeout.
         fn test_invalid_env_timeout_falls_back_to_default() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.timeout, DEFAULT_HTTP_TIMEOUT);
@@ -2075,8 +2201,10 @@ mod tests {
         /// Verifies invalid `CARGO_NET_RETRY` falls back to the built-in default retries value.
         fn test_invalid_env_retries_falls_back_to_default() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args =
-                with_isolated_global_config(CliArgs::parse_from_test_args(["test-crate"]), temp_dir.path());
+            let args = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+                temp_dir.path(),
+            );
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
             assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
@@ -2092,8 +2220,8 @@ mod tests {
                 timeout: Some(Duration::from_secs(120)),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.timeout, Duration::from_secs(120));
             assert_eq!(http.retries, DEFAULT_HTTP_RETRIES);
         }
@@ -2104,8 +2232,8 @@ mod tests {
                 retries: Some(10),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.retries, 10);
         }
 
@@ -2115,8 +2243,8 @@ mod tests {
                 proxy: Some("http://proxy:3128".to_string()),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.proxy, Some("http://proxy:3128".to_string()));
         }
 
@@ -2126,8 +2254,8 @@ mod tests {
                 timeout: Some(Duration::from_secs(120)),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["--http-timeout", "10s", "test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.timeout, Duration::from_secs(10));
         }
 
@@ -2137,8 +2265,8 @@ mod tests {
                 retries: Some(10),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["--http-retries", "0", "test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.retries, 0);
         }
 
@@ -2148,16 +2276,17 @@ mod tests {
                 proxy: Some("http://old:3128".to_string()),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["--http-proxy", "socks5://new:1080", "test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["--http-proxy", "socks5://new:1080", "test-crate"])
+                .config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.proxy, Some("socks5://new:1080".to_string()));
         }
 
         #[test]
         fn test_empty_config_file_yields_defaults() {
             let config_file = HttpConfigFile::default();
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.timeout, DEFAULT_HTTP_TIMEOUT);
             assert_eq!(http.retries, DEFAULT_HTTP_RETRIES);
             assert_eq!(http.backoff_base, DEFAULT_HTTP_BACKOFF_BASE);
@@ -2172,8 +2301,8 @@ mod tests {
                 backoff_max: Some(Duration::from_secs(60)),
                 ..Default::default()
             };
-            let args = CliArgs::parse_from_test_args(["test-crate"]);
-            let http = Config::build_http_config(&config_file, &args).unwrap();
+            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let http = Config::build_http_config(&config_file, &args.http).unwrap();
             assert_eq!(http.backoff_base, Duration::from_secs(2));
             assert_eq!(http.backoff_max, Duration::from_secs(60));
         }
@@ -2188,8 +2317,8 @@ mod tests {
         fn test_invalid_toml_syntax() {
             let test_case = crate::testdata::ConfigTestCase::invalid_toml();
 
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(test_case.path().to_path_buf());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(test_case.path().to_path_buf());
 
             let result = Config::load(&args);
             assert_matches!(result, Err(crate::error::Error::ConfigExtract { .. }));
@@ -2199,8 +2328,8 @@ mod tests {
         fn test_invalid_config_options_raise_error() {
             let test_case = crate::testdata::ConfigTestCase::invalid_options();
 
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(test_case.path().to_path_buf());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(test_case.path().to_path_buf());
 
             let result = Config::load(&args);
             assert_matches!(result, Err(crate::error::Error::ConfigExtract { .. }));
@@ -2210,8 +2339,8 @@ mod tests {
         fn test_nonexistent_explicit_config_file() {
             let test_case = crate::testdata::ConfigTestCase::nonexistent();
 
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
-            args.config_file = Some(test_case.path().to_path_buf());
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            args.config.config_file = Some(test_case.path().to_path_buf());
 
             let config = Config::load(&args).unwrap();
 
@@ -2222,12 +2351,12 @@ mod tests {
         fn test_no_config_files_uses_defaults() {
             let temp_dir = tempfile::tempdir().unwrap();
 
-            let mut args = CliArgs::parse_from_test_args(["test-crate"]);
+            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
             // Ensure isolation from developer's real cgx config on their system.
             // Without these overrides, this test would load ~/.config/cgx/cgx.toml if it exists,
             // causing the test to fail with config values from the developer's actual config.
-            args.system_config_dir = Some(temp_dir.path().join("system"));
-            args.user_config_dir = Some(temp_dir.path().join("user"));
+            args.config.system_config_dir = Some(temp_dir.path().join("system"));
+            args.config.user_config_dir = Some(temp_dir.path().join("user"));
 
             let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
 

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fmt,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -9,7 +10,10 @@ use figment::{
     Figment,
     providers::{Format, Serialized, Toml},
 };
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Serialize,
+    de::{self, MapAccess, Visitor, value::MapAccessDeserializer},
+};
 use snafu::ResultExt;
 use strum::{Display, EnumIter, EnumString, IntoStaticStr, VariantNames};
 
@@ -186,39 +190,84 @@ pub struct HttpConfigFile {
 ///
 /// This can be a simple version string like `"1.0"` or a more complex specification
 /// with version, features, registry, git repo, etc.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, untagged)]
+///
+/// Serialization uses serde's `untagged` representation (a bare string or a bare table).
+/// Deserialization is hand-written (see the [`Deserialize`] impl) rather than derived
+/// `untagged` so that a typo'd or mistyped key in a detailed table produces a precise error naming
+/// the offending field, instead of the opaque `data did not match any variant` that `untagged`
+/// derive emits.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
 pub enum ToolConfig {
     /// Simple version specification (e.g., "1.0", "*")
     Version(String),
     /// Detailed configuration with version, features, registry, etc.
-    Detailed {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        features: Option<Vec<String>>,
-        /// Whether to enable the crate's default features, matching Cargo's `default-features`
-        /// dependency key. Defaults to `true`; set to `false` to build with
-        /// `--no-default-features`.
-        #[serde(
-            rename = "default-features",
-            default = "default_true",
-            skip_serializing_if = "is_true"
-        )]
-        default_features: bool,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        registry: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        git: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        branch: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        tag: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        rev: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        path: Option<PathBuf>,
-    },
+    Detailed(ToolConfigDetailed),
+}
+
+/// The detailed (table) form of a [`ToolConfig`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ToolConfigDetailed {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub features: Option<Vec<String>>,
+    /// Whether to enable the crate's default features, matching Cargo's `default-features`
+    /// dependency key. Defaults to `true`; set to `false` to build with `--no-default-features`.
+    #[serde(
+        rename = "default-features",
+        default = "default_true",
+        skip_serializing_if = "is_true"
+    )]
+    pub default_features: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+}
+
+impl<'de> Deserialize<'de> for ToolConfig {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ToolConfigVisitor;
+
+        impl<'de> Visitor<'de> for ToolConfigVisitor {
+            type Value = ToolConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a version string or a detailed tool table")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(ToolConfig::Version(value.to_string()))
+            }
+
+            fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                Ok(ToolConfig::Detailed(ToolConfigDetailed::deserialize(
+                    MapAccessDeserializer::new(map),
+                )?))
+            }
+        }
+
+        deserializer.deserialize_any(ToolConfigVisitor)
+    }
 }
 
 impl ToolConfig {
@@ -226,7 +275,7 @@ impl ToolConfig {
     pub fn features(&self) -> Option<&[String]> {
         match self {
             ToolConfig::Version(_) => None,
-            ToolConfig::Detailed { features, .. } => features.as_deref(),
+            ToolConfig::Detailed(ToolConfigDetailed { features, .. }) => features.as_deref(),
         }
     }
 
@@ -237,15 +286,9 @@ impl ToolConfig {
     pub fn default_features(&self) -> bool {
         match self {
             ToolConfig::Version(_) => true,
-            ToolConfig::Detailed { default_features, .. } => *default_features,
+            ToolConfig::Detailed(ToolConfigDetailed { default_features, .. }) => *default_features,
         }
     }
-}
-
-/// Default for the `default-features` field of [`ToolConfig::Detailed`]; named because serde's
-/// `default` attribute requires a function path.
-fn default_true() -> bool {
-    true
 }
 
 /// Predicate for `skip_serializing_if` on the `default-features` field, so the default `true` is
@@ -255,6 +298,15 @@ fn default_true() -> bool {
 /// but unfortunately it's necessary here.
 fn is_true(value: &bool) -> bool {
     *value
+}
+
+/// Default for the `default-features` field of [`ToolConfig::Detailed`]; named because serde's
+/// `default` attribute requires a function path.
+///
+/// This maybe even dumber than [`is_true`], but again this needs to be in a form of a function not
+/// a constant so here we are.
+fn default_true() -> bool {
+    true
 }
 
 /// Intermediate structure for deserializing config files from TOML.
@@ -544,6 +596,17 @@ pub struct ConfigOverrides {
     pub verbosity: Verbosity,
 }
 
+/// One distinct tool referenced in the config TOML `[tools]` and possibly also `[aliases]`
+/// sections
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct ConfiguredTool {
+    /// The crate name as it appeared in the `[tools]` section
+    pub(crate) name: String,
+    /// The aliases that resolve to this tool (from the `[aliases]` section), sorted, excluding the
+    /// name itself.
+    pub(crate) aliases: Vec<String>,
+}
+
 impl Config {
     /// Load the configuration, honoring config files and command line arguments.
     ///
@@ -561,39 +624,91 @@ impl Config {
     }
 
     /// Render the merged configured tools and aliases as deterministic TOML.
+    ///
+    /// Both the `[tools]` and `[aliases]` headers are always present (even when empty), so the
+    /// output is a stable template a user can copy and edit. Each section's presence is decided
+    /// from the data (whether the map is empty), not by scanning the serializer's output.
     pub fn tools_toml(&self) -> Result<String> {
         #[derive(Serialize)]
-        struct ToolsToml {
-            tools: BTreeMap<String, ToolConfig>,
-            aliases: BTreeMap<String, String>,
+        struct ToolsSection<'a> {
+            tools: BTreeMap<&'a String, &'a ToolConfig>,
+        }
+        #[derive(Serialize)]
+        struct AliasesSection<'a> {
+            aliases: BTreeMap<&'a String, &'a String>,
         }
 
-        let tools = self
-            .tools
-            .iter()
-            .map(|(name, config)| (name.clone(), config.clone()))
-            .collect();
-        let aliases = self
-            .aliases
-            .iter()
-            .map(|(name, target)| (name.clone(), target.clone()))
-            .collect();
-
-        let mut rendered = toml::to_string_pretty(&ToolsToml { tools, aliases })
-            .context(crate::error::TomlSerializeSnafu)?;
-
-        if !rendered.lines().any(|line| line.trim() == "[tools]") {
-            rendered = format!("[tools]\n\n{}", rendered);
-        }
-
-        if !rendered.lines().any(|line| line.trim() == "[aliases]") {
-            if !rendered.ends_with('\n') {
-                rendered.push('\n');
+        /// Guarantee that a serialized section starts with its bare `[section]` header.
+        ///
+        /// `toml` only emits the bare `[tools]`/`[aliases]` line when a section has at least one
+        /// scalar entry; a section whose entries are all subtables (only detailed tool tables)
+        /// would otherwise start at `[tools.<name>]`. Prepending keeps the section visible and the
+        /// output a stable, editable template, without depending on how the serializer orders or
+        /// omits empty tables.
+        fn ensure_section_header(section: &str, body: String) -> String {
+            let header = format!("[{section}]");
+            if body.starts_with(&header) {
+                body
+            } else {
+                format!("{header}\n{body}")
             }
-            rendered.push_str("\n[aliases]\n");
         }
 
-        Ok(rendered)
+        let tools = if self.tools.is_empty() {
+            "[tools]\n".to_string()
+        } else {
+            let body = toml::to_string_pretty(&ToolsSection {
+                tools: self.sorted_tools(),
+            })
+            .context(crate::error::TomlSerializeSnafu)?;
+            ensure_section_header("tools", body)
+        };
+
+        let aliases = if self.aliases.is_empty() {
+            "[aliases]\n".to_string()
+        } else {
+            let body = toml::to_string_pretty(&AliasesSection {
+                aliases: self.sorted_aliases(),
+            })
+            .context(crate::error::TomlSerializeSnafu)?;
+            ensure_section_header("aliases", body)
+        };
+
+        Ok(format!("{tools}\n{aliases}"))
+    }
+
+    /// The configured tools in deterministic (key-sorted) order.
+    ///
+    /// The single source of ordering for both [`Config::tools_toml`] and `--list-tools` message
+    /// emission.
+    pub(crate) fn sorted_tools(&self) -> BTreeMap<&String, &ToolConfig> {
+        self.tools.iter().collect()
+    }
+
+    /// The configured aliases in deterministic (key-sorted) order.
+    pub(crate) fn sorted_aliases(&self) -> BTreeMap<&String, &String> {
+        self.aliases.iter().collect()
+    }
+
+    /// Group every configured tool and alias by the tool it resolves to, applying the same
+    /// single-step alias resolution as [`crate::cratespec::CrateSpec::load`].
+    ///
+    /// Each distinct resolved crate appears once, so `--prefetch-all` prefetches it a single time
+    /// regardless of how many aliases point at it.
+    pub(crate) fn configured_tools(&self) -> Vec<ConfiguredTool> {
+        let mut groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        for name in self.tools.keys().chain(self.aliases.keys()) {
+            let resolved = self.aliases.get(name).unwrap_or(name);
+            groups.entry(resolved.clone()).or_default().insert(name.clone());
+        }
+
+        groups
+            .into_iter()
+            .map(|(name, members)| {
+                let aliases = members.into_iter().filter(|member| *member != name).collect();
+                ConfiguredTool { name, aliases }
+            })
+            .collect()
     }
 
     /// Load config from the CLI args and a specified directory which may or may not contain config
@@ -627,7 +742,9 @@ impl Config {
             config_file.offline.unwrap_or(false)
         };
 
-        // toolchain: CLI > config
+        // The toolchain comes only from the config file here. The CLI `+toolchain` token is
+        // applied later as a `BuildOverride`, not a `ConfigOverride` (`ConfigOverrides` has no
+        // toolchain field), so there is no CLI value to consider at this point.
         let toolchain = config_file.toolchain;
 
         // Determine config_dir based on override precedence
@@ -993,9 +1110,9 @@ mod tests {
         let tools = config.tools.unwrap();
 
         match tools.get("taplo-cli") {
-            Some(ToolConfig::Detailed {
+            Some(ToolConfig::Detailed(ToolConfigDetailed {
                 version, features, ..
-            }) => {
+            })) => {
                 assert_eq!(*version, Some("1.11.0".to_string()));
                 assert_eq!(*features, Some(vec!["schema".to_string()]));
             }
@@ -1034,7 +1151,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "no-defaults".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: false,
                 version: Some("1.0".to_string()),
                 features: None,
@@ -1044,11 +1161,11 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
         config.tools.insert(
             "with-defaults".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("1.0".to_string()),
                 features: None,
@@ -1058,7 +1175,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let rendered = config.tools_toml().unwrap();
@@ -1100,7 +1217,7 @@ mod tests {
             .insert("alpha".to_string(), ToolConfig::Version("1".to_string()));
         config.tools.insert(
             "beta".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("1.5".to_string()),
                 features: Some(vec!["frobnulator".to_string()]),
@@ -1110,7 +1227,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
         config.aliases.insert("zz".to_string(), "zeta".to_string());
         config.aliases.insert("aa".to_string(), "alpha".to_string());
@@ -1123,11 +1240,11 @@ mod tests {
         assert_eq!(tools.get("zeta"), Some(&ToolConfig::Version("2".to_string())));
         assert_matches!(
             tools.get("beta"),
-            Some(ToolConfig::Detailed {
+            Some(ToolConfig::Detailed(ToolConfigDetailed {
                 version: Some(version),
                 features: Some(features),
                 ..
-            }) if version == "1.5" && features == &vec!["frobnulator".to_string()]
+            })) if version == "1.5" && features == &vec!["frobnulator".to_string()]
         );
 
         let aliases = parsed.aliases.unwrap();
@@ -1136,6 +1253,188 @@ mod tests {
 
         assert!(rendered.find("alpha").unwrap() < rendered.find("zeta").unwrap());
         assert!(rendered.find("aa").unwrap() < rendered.find("zz").unwrap());
+    }
+
+    fn config_with(tools: &[&str], aliases: &[(&str, &str)]) -> Config {
+        let mut config = Config::default();
+        for &tool in tools {
+            config
+                .tools
+                .insert(tool.to_string(), ToolConfig::Version("*".to_string()));
+        }
+        for &(name, target) in aliases {
+            config.aliases.insert(name.to_string(), target.to_string());
+        }
+        config
+    }
+
+    #[test]
+    fn configured_tools_groups_alias_with_its_tool() {
+        let config = config_with(&["eza"], &[("e", "eza")]);
+        assert_eq!(
+            config.configured_tools(),
+            [ConfiguredTool {
+                name: "eza".to_string(),
+                aliases: vec!["e".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn configured_tools_alias_to_unconfigured_crate_yields_its_target() {
+        let config = config_with(&[], &[("x", "ripgrep")]);
+        assert_eq!(
+            config.configured_tools(),
+            [ConfiguredTool {
+                name: "ripgrep".to_string(),
+                aliases: vec!["x".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn configured_tools_groups_multiple_aliases_under_one_tool() {
+        let config = config_with(&["eza"], &[("e", "eza"), ("ez", "eza")]);
+        assert_eq!(
+            config.configured_tools(),
+            [ConfiguredTool {
+                name: "eza".to_string(),
+                aliases: vec!["e".to_string(), "ez".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn configured_tools_are_deterministically_ordered() {
+        let config = config_with(&["zoxide", "eza"], &[("a", "zoxide")]);
+        let names: Vec<_> = config
+            .configured_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert_eq!(names, ["eza", "zoxide"]);
+    }
+
+    #[test]
+    fn configured_tools_keep_independent_tools_separate() {
+        let config = config_with(&["eza", "ripgrep"], &[]);
+        assert_eq!(
+            config.configured_tools(),
+            [
+                ConfiguredTool {
+                    name: "eza".to_string(),
+                    aliases: Vec::new(),
+                },
+                ConfiguredTool {
+                    name: "ripgrep".to_string(),
+                    aliases: Vec::new(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn tools_toml_empty_config_still_renders_both_headers() {
+        let rendered = Config::default().tools_toml().unwrap();
+        assert!(rendered.contains("[tools]"), "missing [tools] in:\n{rendered}");
+        assert!(
+            rendered.contains("[aliases]"),
+            "missing [aliases] in:\n{rendered}"
+        );
+
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+        assert!(parsed.tools.unwrap_or_default().is_empty());
+        assert!(parsed.aliases.unwrap_or_default().is_empty());
+    }
+
+    #[test]
+    fn tools_toml_tools_only_still_renders_aliases_header() {
+        let config = config_with(&["ripgrep"], &[]);
+        let rendered = config.tools_toml().unwrap();
+        assert!(rendered.contains("[tools]"));
+        assert!(rendered.contains("[aliases]"));
+
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+        assert!(parsed.tools.unwrap().contains_key("ripgrep"));
+    }
+
+    #[test]
+    fn tools_toml_aliases_only_still_renders_tools_header() {
+        let config = config_with(&[], &[("rg", "ripgrep")]);
+        let rendered = config.tools_toml().unwrap();
+        assert!(rendered.contains("[tools]"));
+        assert!(rendered.contains("[aliases]"));
+
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+        assert_eq!(parsed.aliases.unwrap().get("rg"), Some(&"ripgrep".to_string()));
+    }
+
+    #[test]
+    fn tools_toml_all_detailed_entries_still_render_bare_tools_header() {
+        let mut config = Config::default();
+        config.tools.insert(
+            "only-detailed".to_string(),
+            ToolConfig::Detailed(ToolConfigDetailed {
+                version: Some("1.0".to_string()),
+                features: Some(vec!["x".to_string()]),
+                default_features: true,
+                registry: None,
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                path: None,
+            }),
+        );
+
+        let rendered = config.tools_toml().unwrap();
+
+        // Even when every tool is a subtable (`[tools.only-detailed]`), the bare `[tools]` header
+        // is present so the section is always visible and the output is a stable template.
+        assert!(
+            rendered.lines().any(|line| line.trim() == "[tools]"),
+            "missing bare [tools] header in:\n{rendered}"
+        );
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+        assert!(parsed.tools.unwrap().contains_key("only-detailed"));
+    }
+
+    #[test]
+    fn tool_config_unknown_key_error_names_the_field() {
+        let toml_content = r#"
+            [tools]
+            ripgrep = { versio = "14" }
+        "#;
+        let error = toml::from_str::<ConfigFile>(toml_content)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("versio"),
+            "error did not name the bad key:\n{error}"
+        );
+        assert!(
+            !error.contains("did not match any variant"),
+            "error was the opaque untagged message:\n{error}"
+        );
+    }
+
+    #[test]
+    fn tool_config_type_mismatch_error_is_precise() {
+        let toml_content = r#"
+            [tools]
+            ripgrep = { default-features = "false" }
+        "#;
+        let error = toml::from_str::<ConfigFile>(toml_content)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("boolean"),
+            "error did not describe the expected type:\n{error}"
+        );
+        assert!(
+            !error.contains("did not match any variant"),
+            "error was the opaque untagged message:\n{error}"
+        );
     }
 
     #[test]
@@ -1447,11 +1746,11 @@ mod tests {
             let taplo_tool = config.tools.get("taplo-cli").unwrap();
             assert_matches!(
                 taplo_tool,
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     version: Some(v),
                     features: Some(f),
                     ..
-                } if v == "1.11.0" && f == &vec!["schema".to_string()]
+                }) if v == "1.11.0" && f == &vec!["schema".to_string()]
             );
         }
 

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -13,10 +13,7 @@ use serde::{Deserialize, Serialize};
 use snafu::ResultExt;
 use strum::{Display, EnumIter, EnumString, IntoStaticStr, VariantNames};
 
-use crate::{
-    Result,
-    cli::{ConfigArgs, ConfigInputs, HttpArgs},
-};
+use crate::Result;
 
 const DEFAULT_RESOLVE_CACHE_TIMEOUT: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
@@ -332,7 +329,6 @@ where
 #[derive(Debug, Clone)]
 pub struct Config {
     /// Directory where config files are stored
-    #[allow(dead_code)]
     pub config_dir: PathBuf,
 
     /// The cache directory where various levels of cache are located
@@ -359,8 +355,13 @@ pub struct Config {
     /// Rust toolchain to use for building (e.g., "nightly", "1.70.0", "stable")
     pub toolchain: Option<String>,
 
-    /// Logging verbosity level (e.g., "info", "debug", "trace")
+    /// Logging filter expression from the config file (e.g., "info", "debug", "cgx=debug,info").
     pub log_level: Option<String>,
+
+    /// Logging/build verbosity from the repeated `-v` CLI flag.
+    ///
+    /// The single source from which both the tracing level and cargo's `-v` count are derived.
+    pub verbosity: Verbosity,
 
     /// Default registry to use instead of crates.io when no registry is explicitly specified
     pub default_registry: Option<String>,
@@ -397,6 +398,7 @@ impl Default for Config {
             refresh: false,
             toolchain: None,
             log_level: None,
+            verbosity: Verbosity::default(),
             default_registry: None,
             prebuilt_binaries: PrebuiltBinariesConfig::default(),
             http: HttpConfig::default(),
@@ -404,6 +406,107 @@ impl Default for Config {
             aliases: HashMap::default(),
         }
     }
+}
+
+/// How the lockfile should be treated, collapsed from the mutually-exclusive
+/// `--locked`/`--frozen`/`--unlocked` command-line flags.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LockMode {
+    /// No lockfile flag was given; fall back to the config-file setting (default locked).
+    #[default]
+    Default,
+    /// `--locked`: honor `Cargo.lock`.
+    Locked,
+    /// `--frozen`: equivalent to `--locked` plus `--offline`.
+    Frozen,
+    /// `--unlocked`: ignore `Cargo.lock` and resolve dependencies fresh.
+    Unlocked,
+}
+
+/// Logging/build verbosity
+///
+/// Represents both how verbose `cgx`'s own log output should be, and also how verbose the `cargo
+/// build` output should be.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Verbosity {
+    /// Default: warnings and errors only (no `-v`).
+    #[default]
+    Normal,
+    /// `-v`: informational logging; one `-v` to cargo.
+    Verbose,
+    /// `-vv`: debug logging; two `-v`s to cargo.
+    VeryVerbose,
+    /// `-vvv` or more: trace logging; three `-v`s to cargo.
+    ExtremelyVerbose,
+}
+
+impl Verbosity {
+    /// Construct a [`Verbosity`] from the repeated-`-v` counter (clap's `ArgAction::Count`).
+    pub fn from_count(count: u8) -> Self {
+        match count {
+            0 => Self::Normal,
+            1 => Self::Verbose,
+            2 => Self::VeryVerbose,
+            _ => Self::ExtremelyVerbose,
+        }
+    }
+}
+
+/// Configuration overrides supplied on the command line.
+///
+/// This is the config-layer input to [`Config::load`]: it carries the subset of parsed arguments
+/// that influence configuration loading.  This is meant to be populated from the CLI arguments,
+/// without coupling this layer to the actual CLI or `clap`.
+#[derive(Clone, Debug, Default)]
+pub struct ConfigOverrides {
+    /// Read configuration from this TOML file only, bypassing the usual search paths
+    /// (`--config-file`).
+    pub config_file: Option<PathBuf>,
+
+    /// Override the system config directory location (`--system-config-dir`).
+    pub system_config_dir: Option<PathBuf>,
+
+    /// Override the base application directory (`--app-dir`).
+    pub app_dir: Option<PathBuf>,
+
+    /// Override the user config directory location (`--user-config-dir`).
+    pub user_config_dir: Option<PathBuf>,
+
+    /// HTTP request timeout as a raw string (e.g. `"30s"`, `"2m"`), parsed by [`Config`]
+    /// (`--http-timeout`).
+    pub http_timeout: Option<String>,
+
+    /// Maximum number of retries for transient HTTP failures (`--http-retries`).
+    pub http_retries: Option<usize>,
+
+    /// HTTP or SOCKS5 proxy URL for all HTTP requests (`--http-proxy`).
+    pub http_proxy: Option<String>,
+
+    /// How the lockfile should be treated (`--locked`/`--frozen`/`--unlocked`).
+    pub lockfile: LockMode,
+
+    /// Run without accessing the network (`--offline`); combines with [`Self::lockfile`].
+    pub offline: bool,
+
+    /// Force refresh of all cached data for this crate (`--refresh`).
+    pub refresh: bool,
+
+    /// Control use of pre-built binaries: never, always, or auto (`--prebuilt-binary`).
+    pub prebuilt_binary: Option<UsePrebuiltBinaries>,
+
+    /// Override the binary providers to check for pre-built binaries (`--prebuilt-binary-sources`).
+    pub prebuilt_binary_sources: Option<Vec<BinaryProvider>>,
+
+    /// Disable checksum verification when downloading pre-built binaries
+    /// (`--prebuilt-binary-no-verify-checksums`).
+    pub prebuilt_binary_no_verify_checksums: bool,
+
+    /// Disable signature verification when downloading pre-built binaries
+    /// (`--prebuilt-binary-no-verify-signatures`).
+    pub prebuilt_binary_no_verify_signatures: bool,
+
+    /// Logging/build verbosity from the repeated `-v` flag.
+    pub verbosity: Verbosity,
 }
 
 impl Config {
@@ -416,10 +519,10 @@ impl Config {
     /// 3. User config file
     /// 4. Directory hierarchy config files (from root to current directory)
     /// 5. Command-line arguments (highest priority)
-    pub fn load(inputs: &ConfigInputs) -> Result<Self> {
+    pub fn load(overrides: &ConfigOverrides) -> Result<Self> {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
-        Self::load_from_dir(&cwd, inputs)
+        Self::load_from_dir(&cwd, overrides)
     }
 
     /// Render the merged configured tools and aliases as deterministic TOML.
@@ -460,20 +563,13 @@ impl Config {
 
     /// Load config from the CLI args and a specified directory which may or may not contain config
     /// files.
-    pub fn load_from_dir(cwd: &Path, inputs: &ConfigInputs) -> Result<Self> {
-        let ConfigInputs {
-            config: config_args,
-            http,
-            prebuilt,
-            cargo,
-            toolchain,
-        } = inputs;
+    pub fn load_from_dir(cwd: &Path, overrides: &ConfigOverrides) -> Result<Self> {
         let strategy = Self::get_user_dirs()?;
 
         // Start with base config defaults, then merge config files
         let mut figment = Figment::new().merge(Serialized::defaults(ConfigFile::base_config()));
 
-        for config_file in Self::discover_config_files(cwd, config_args)? {
+        for config_file in Self::discover_config_files(cwd, overrides)? {
             figment = figment.merge(Toml::file(config_file));
         }
 
@@ -483,42 +579,40 @@ impl Config {
         // Override the config file values using any CLI args that were specified
 
         // locked: --unlocked > --locked/--frozen > config > default(true)
-        let locked = if cargo.unlocked {
-            false
-        } else if cargo.locked || cargo.frozen {
-            true
-        } else {
-            config_file.locked.unwrap_or(true)
+        let locked = match overrides.lockfile {
+            LockMode::Unlocked => false,
+            LockMode::Locked | LockMode::Frozen => true,
+            LockMode::Default => config_file.locked.unwrap_or(true),
         };
 
         // offline: --offline/--frozen > config > default(false)
-        let offline = if cargo.offline || cargo.frozen {
+        let offline = if overrides.offline || overrides.lockfile == LockMode::Frozen {
             true
         } else {
             config_file.offline.unwrap_or(false)
         };
 
         // toolchain: CLI > config
-        let toolchain = toolchain.clone().or(config_file.toolchain);
+        let toolchain = config_file.toolchain;
 
         // Determine config_dir based on override precedence
-        let config_dir = if let Some(user_config_dir) = &config_args.user_config_dir {
+        let config_dir = if let Some(user_config_dir) = &overrides.user_config_dir {
             user_config_dir.clone()
-        } else if let Some(app_dir) = &config_args.app_dir {
+        } else if let Some(app_dir) = &overrides.app_dir {
             app_dir.join("config")
         } else {
             strategy.config_dir()
         };
 
         // Determine cache_dir: CLI (app-dir) > config file > strategy
-        let cache_dir = if let Some(app_dir) = &config_args.app_dir {
+        let cache_dir = if let Some(app_dir) = &overrides.app_dir {
             app_dir.join("cache")
         } else {
             config_file.cache_dir.unwrap_or_else(|| strategy.cache_dir())
         };
 
         // Determine bin_dir: CLI (app-dir) > config file > strategy
-        let bin_dir = if let Some(app_dir) = &config_args.app_dir {
+        let bin_dir = if let Some(app_dir) = &overrides.app_dir {
             app_dir.join("bins")
         } else {
             config_file
@@ -527,7 +621,7 @@ impl Config {
         };
 
         // Determine build_dir: CLI (app-dir) > config file > strategy
-        let build_dir = if let Some(app_dir) = &config_args.app_dir {
+        let build_dir = if let Some(app_dir) = &overrides.app_dir {
             app_dir.join("build")
         } else {
             config_file
@@ -538,16 +632,16 @@ impl Config {
         let mut prebuilt_binaries = config_file.prebuilt_binaries.unwrap_or_default();
 
         // Apply CLI overrides for prebuilt binaries
-        if let Some(mode) = prebuilt.prebuilt_binary {
+        if let Some(mode) = overrides.prebuilt_binary {
             prebuilt_binaries.use_prebuilt_binaries = mode;
         }
-        if let Some(ref providers) = prebuilt.prebuilt_binary_sources {
+        if let Some(ref providers) = overrides.prebuilt_binary_sources {
             prebuilt_binaries.binary_providers = providers.clone();
         }
-        if prebuilt.prebuilt_binary_no_verify_checksums {
+        if overrides.prebuilt_binary_no_verify_checksums {
             prebuilt_binaries.verify_checksums = false;
         }
-        if prebuilt.prebuilt_binary_no_verify_signatures {
+        if overrides.prebuilt_binary_no_verify_signatures {
             prebuilt_binaries.verify_signatures = false;
         }
 
@@ -560,7 +654,7 @@ impl Config {
 
         // Build HTTP config with precedence: CLI > config file > Cargo env vars > defaults
         let http_config_file = config_file.http.unwrap_or_default();
-        let http = Self::build_http_config(&http_config_file, http)?;
+        let http = Self::build_http_config(&http_config_file, overrides)?;
 
         Ok(Self {
             config_dir,
@@ -572,9 +666,10 @@ impl Config {
                 .unwrap_or(DEFAULT_RESOLVE_CACHE_TIMEOUT),
             offline,
             locked,
-            refresh: cargo.refresh,
+            refresh: overrides.refresh,
             toolchain,
             log_level: config_file.log_level,
+            verbosity: overrides.verbosity,
             default_registry: config_file.default_registry,
             prebuilt_binaries,
             http,
@@ -592,16 +687,16 @@ impl Config {
     /// 2. User config: `$XDG_CONFIG_HOME/cgx/cgx.toml` or platform equivalent (or override
     ///    location)
     /// 3. Directory hierarchy: All `cgx.toml` files from filesystem root to current directory
-    fn discover_config_files(cwd: &Path, config_args: &ConfigArgs) -> Result<Vec<PathBuf>> {
+    fn discover_config_files(cwd: &Path, overrides: &ConfigOverrides) -> Result<Vec<PathBuf>> {
         let mut config_files = Vec::new();
 
         // If the user explicitly specified a config file, read ONLY that file
-        if let Some(config_path) = &config_args.config_file {
+        if let Some(config_path) = &overrides.config_file {
             return Ok(vec![config_path.clone()]);
         }
 
         // System config (can be overridden)
-        if let Some(system_config_dir) = &config_args.system_config_dir {
+        if let Some(system_config_dir) = &overrides.system_config_dir {
             let system_config = system_config_dir.join("cgx.toml");
             if system_config.exists() {
                 config_files.push(system_config);
@@ -627,10 +722,10 @@ impl Config {
         }
 
         // User config (can be overridden via user-config-dir or app-dir)
-        let user_config = if let Some(user_config_dir) = &config_args.user_config_dir {
+        let user_config = if let Some(user_config_dir) = &overrides.user_config_dir {
             // Most specific: explicit user config directory
             user_config_dir.join("cgx.toml")
-        } else if let Some(app_dir) = &config_args.app_dir {
+        } else if let Some(app_dir) = &overrides.app_dir {
             // App dir provides a base for config
             app_dir.join("config").join("cgx.toml")
         } else {
@@ -666,15 +761,15 @@ impl Config {
     }
 
     /// Build [`HttpConfig`] with proper precedence:
-    /// 1. CLI args (highest priority)
+    /// 1. CLI config overrides (highest priority)
     /// 2. Config file values
     /// 3. Cargo environment variable fallbacks
     /// 4. Defaults (lowest priority)
-    fn build_http_config(config_file: &HttpConfigFile, http: &HttpArgs) -> Result<HttpConfig> {
+    fn build_http_config(config_file: &HttpConfigFile, overrides: &ConfigOverrides) -> Result<HttpConfig> {
         // Determine if CLI args were provided (they override everything)
-        let cli_timeout = http.http_timeout.as_ref();
-        let cli_retries = http.http_retries;
-        let cli_proxy = http.http_proxy.as_ref();
+        let cli_timeout = overrides.http_timeout.as_ref();
+        let cli_retries = overrides.http_retries;
+        let cli_proxy = overrides.http_proxy.as_ref();
 
         // timeout: CLI > config > CARGO_HTTP_TIMEOUT > default
         let timeout = if let Some(timeout_str) = cli_timeout {
@@ -774,10 +869,10 @@ mod tests {
     /// host-level `/etc/cgx.toml` or user-level cgx config on the machine running tests.
     ///
     /// This keeps tests deterministic on developer systems that actively use cgx.
-    fn with_isolated_global_config(mut inputs: ConfigInputs, root: &Path) -> ConfigInputs {
-        inputs.config.system_config_dir = Some(root.join("system"));
-        inputs.config.user_config_dir = Some(root.join("user"));
-        inputs
+    fn with_isolated_global_config(mut overrides: ConfigOverrides, root: &Path) -> ConfigOverrides {
+        overrides.system_config_dir = Some(root.join("system"));
+        overrides.user_config_dir = Some(root.join("user"));
+        overrides
     }
 
     #[test]
@@ -937,8 +1032,8 @@ mod tests {
 
     #[test]
     fn test_config_defaults() {
-        let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-        let config = Config::load(&args).unwrap();
+        let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+        let config = Config::load(&config_overrides).unwrap();
 
         assert!(!config.offline);
         assert!(config.locked); // Default is true per issue #55
@@ -948,19 +1043,29 @@ mod tests {
 
     #[test]
     fn test_cli_overrides() {
-        let args =
-            Cli::parse_from_test_args(["+nightly", "--offline", "--locked", "test-crate"]).config_inputs();
-        let config = Config::load(&args).unwrap();
+        let cli = Cli::parse_from_test_args(["+nightly", "--offline", "--locked", "test-crate"]);
+        let config_overrides = cli.to_config_overrides();
+        let config = Config::load(&config_overrides).unwrap();
+        let build_overrides = if let Cli::Run { args, .. } = cli {
+            args.to_build_overrides()
+        } else {
+            panic!("Expected Run command")
+        };
 
         assert!(config.offline);
         assert!(config.locked);
-        assert_eq!(config.toolchain, Some("nightly".to_string()));
+        // NOTE: In `config`, the +nightly toolchain from the command line isn't specified, as this
+        // is considered to be a build override and not a config option.  Since these tests run
+        // without any config files, `config.toolchain` is expected to be the default of `None`,
+        // whiel the CLI-provided toolchain is reflected in the build options.
+        assert_eq!(config.toolchain, None);
+        assert_eq!(build_overrides.toolchain, Some("nightly".to_string()));
     }
 
     #[test]
     fn test_frozen_implies_locked_and_offline() {
-        let args = Cli::parse_from_test_args(["--frozen", "test-crate"]).config_inputs();
-        let config = Config::load(&args).unwrap();
+        let config_overrides = Cli::parse_from_test_args(["--frozen", "test-crate"]).to_config_overrides();
+        let config = Config::load(&config_overrides).unwrap();
 
         assert!(config.offline);
         assert!(config.locked);
@@ -1040,8 +1145,8 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let result = Config::load_from_dir(temp_dir.path(), &args);
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let result = Config::load_from_dir(temp_dir.path(), &config_overrides);
             assert_matches!(result, Err(crate::error::Error::NoProvidersConfigured));
         }
 
@@ -1054,8 +1159,8 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let result = Config::load_from_dir(temp_dir.path(), &args);
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let result = Config::load_from_dir(temp_dir.path(), &config_overrides);
             assert_matches!(result, Err(crate::error::Error::NoProvidersConfigured));
         }
 
@@ -1068,8 +1173,8 @@ mod tests {
             "#;
 
             let temp_dir = create_temp_config(toml_content);
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let result = Config::load_from_dir(temp_dir.path(), &args);
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let result = Config::load_from_dir(temp_dir.path(), &config_overrides);
             assert!(result.is_ok(), "Empty providers with 'never' mode should succeed");
         }
     }
@@ -1083,6 +1188,7 @@ mod tests {
         use assert_matches::assert_matches;
 
         use super::*;
+        use crate::builder::BuildOptions;
 
         /// Test loading config from a 3-level hierarchy (root → work → project1).
         ///
@@ -1094,8 +1200,8 @@ mod tests {
         fn test_config_hierarchy_project1() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project1();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(3 * 60));
 
@@ -1122,8 +1228,8 @@ mod tests {
         fn test_config_hierarchy_project2() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project2();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(5 * 60));
 
@@ -1149,8 +1255,8 @@ mod tests {
         fn test_config_hierarchy_work() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_work();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(2 * 60));
 
@@ -1175,8 +1281,8 @@ mod tests {
         fn test_config_hierarchy_root() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_root();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(60));
 
@@ -1201,10 +1307,10 @@ mod tests {
         fn test_explicit_config_file() {
             let test_case = crate::testdata::ConfigTestCase::explicit_non_standard_name();
 
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(test_case.path().to_path_buf());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(test_case.path().to_path_buf());
 
-            let config = Config::load(&args).unwrap();
+            let config = Config::load(&config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(6 * 60));
 
@@ -1227,8 +1333,8 @@ mod tests {
         fn test_tools_detailed_config_preserved() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_root();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
 
             let taplo_tool = config.tools.get("taplo-cli").unwrap();
             assert_matches!(
@@ -1250,13 +1356,25 @@ mod tests {
         fn test_cli_args_override_config_files() {
             let test_case = crate::testdata::ConfigTestCase::hierarchy_project1();
 
-            let args =
-                Cli::parse_from_test_args(["+stable", "--offline", "--locked", "test-crate"]).config_inputs();
-            let config = Config::load_from_dir(test_case.path(), &args).unwrap();
+            // NOTE: `+stable` is the toolchain specification; this doesn't go in config overrides
+            // but in build overrides.
+            let cli = Cli::parse_from_test_args(["+stable", "--offline", "--locked", "test-crate"]);
+            let config_overrides = cli.to_config_overrides();
+            let build_overrides = if let Cli::Run { args, .. } = cli {
+                args.to_build_overrides()
+            } else {
+                panic!("Expected Run command")
+            };
+            let config = Config::load_from_dir(test_case.path(), &config_overrides).unwrap();
+            let build_options = BuildOptions::load(&config, &build_overrides).unwrap();
 
             assert!(config.offline);
             assert!(config.locked);
-            assert_eq!(config.toolchain, Some("stable".to_string()));
+
+            // `+stable` doesn't override the config (because we don't consider the toolchain a
+            // config override), but it overrides the build options
+            assert_eq!(config.toolchain, None);
+            assert_eq!(build_options.toolchain, Some("stable".to_string()));
         }
 
         /// Test that --config-file reads only the specified file.
@@ -1273,10 +1391,10 @@ mod tests {
             let explicit_config = crate::testdata::ConfigTestCase::explicit_non_standard_name();
 
             // Load config from project1 directory but with --config-file pointing to explicit config
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(explicit_config.path().to_path_buf());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(explicit_config.path().to_path_buf());
 
-            let config = Config::load_from_dir(hierarchy_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(hierarchy_dir.path(), &config_overrides).unwrap();
 
             // Should have the explicit config's timeout (6m), not any from the hierarchy (1m/2m/3m)
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(6 * 60));
@@ -1357,10 +1475,10 @@ mod tests {
             };
 
             // Test with --config-file
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(explicit_config.clone());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(explicit_config.clone());
 
-            let discovered = Config::discover_config_files(&sub_dir, &args.config).unwrap();
+            let discovered = Config::discover_config_files(&sub_dir, &config_overrides).unwrap();
 
             // Should contain ONLY the explicit config file (no system, user, or hierarchy configs)
             // This will FAIL if the bug exists, showing [user_config, explicit_config]
@@ -1389,8 +1507,8 @@ mod tests {
             let sub_config = sub_dir.join("cgx.toml");
             fs::write(&sub_config, "resolve_cache_timeout = \"2m\"").unwrap();
 
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let discovered = Config::discover_config_files(&sub_dir, &args.config).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let discovered = Config::discover_config_files(&sub_dir, &config_overrides).unwrap();
 
             // Should contain both hierarchy configs (and possibly system/user if they exist)
             // We check that at least our two configs are present
@@ -1428,11 +1546,11 @@ mod tests {
                 let user_config_dir = temp_dir.path().join("user");
                 fs::create_dir_all(&user_config_dir).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.system_config_dir = Some(system_config_dir);
-                args.config.user_config_dir = Some(user_config_dir);
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.system_config_dir = Some(system_config_dir);
+                config_overrides.user_config_dir = Some(user_config_dir);
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(5 * 60));
             }
 
@@ -1461,11 +1579,11 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.system_config_dir = Some(system_config_dir);
-                args.config.user_config_dir = Some(user_config_dir);
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.system_config_dir = Some(system_config_dir);
+                config_overrides.user_config_dir = Some(user_config_dir);
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 // User config should override system config
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(20 * 60));
             }
@@ -1485,10 +1603,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(7 * 60));
                 assert_eq!(config.config_dir, config_dir);
             }
@@ -1500,10 +1618,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.cache_dir, app_dir.join("cache"));
             }
 
@@ -1514,10 +1632,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.bin_dir, app_dir.join("bins"));
             }
 
@@ -1528,10 +1646,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.build_dir, app_dir.join("build"));
             }
 
@@ -1542,10 +1660,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
 
                 // All directories should be under app_dir
                 assert!(config.config_dir.starts_with(&app_dir));
@@ -1568,10 +1686,10 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.user_config_dir = Some(user_config_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.user_config_dir = Some(user_config_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(8 * 60));
                 assert_eq!(config.config_dir, user_config_dir);
             }
@@ -1598,11 +1716,11 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
-                args.config.user_config_dir = Some(user_config_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
+                config_overrides.user_config_dir = Some(user_config_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
 
                 // user_config_dir should override app_dir for config location
                 assert_eq!(config.resolve_cache_timeout, Duration::from_secs(11 * 60));
@@ -1650,12 +1768,12 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.system_config_dir = Some(system_config_dir);
-                args.config.app_dir = Some(app_dir.clone());
-                args.config.user_config_dir = Some(user_config_dir.clone());
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.system_config_dir = Some(system_config_dir);
+                config_overrides.app_dir = Some(app_dir.clone());
+                config_overrides.user_config_dir = Some(user_config_dir.clone());
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
 
                 // Should have merged tools from all configs
                 assert!(config.tools.contains_key("system_tool"));
@@ -1690,10 +1808,10 @@ mod tests {
                 fs::create_dir_all(&sub).unwrap();
                 fs::write(sub.join("cgx.toml"), "[tools]\nsub_tool = \"1\"").unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir);
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir);
 
-                let config = Config::load_from_dir(&sub, &args).unwrap();
+                let config = Config::load_from_dir(&sub, &config_overrides).unwrap();
 
                 // Should have tools from both hierarchy configs
                 assert!(config.tools.contains_key("root_tool"));
@@ -1723,11 +1841,11 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-                args.config.app_dir = Some(app_dir.clone());
-                args.config.config_file = Some(config_file);
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+                config_overrides.app_dir = Some(app_dir.clone());
+                config_overrides.config_file = Some(config_file);
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
 
                 // CLI --app-dir should win over config file settings
                 assert_eq!(config.cache_dir, app_dir.join("cache"));
@@ -1752,11 +1870,11 @@ mod tests {
                 let cwd = temp_dir.path().join("work");
                 fs::create_dir_all(&cwd).unwrap();
 
-                let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+                let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
                 // No --app-dir specified
-                args.config.config_file = Some(config_file);
+                config_overrides.config_file = Some(config_file);
 
-                let config = Config::load_from_dir(&cwd, &args).unwrap();
+                let config = Config::load_from_dir(&cwd, &config_overrides).unwrap();
 
                 // Config file paths should be used when --app-dir is not specified
                 assert_eq!(config.cache_dir, temp_dir.path().join("my-cache"));
@@ -1861,11 +1979,11 @@ mod tests {
         #[test]
         fn test_http_config_all_defaults() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(30));
             assert_eq!(config.http.retries, 2);
             assert_eq!(config.http.backoff_base, Duration::from_millis(500));
@@ -1882,11 +2000,11 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(120));
             assert_eq!(config.http.retries, 5);
             assert_eq!(config.http.proxy, Some("http://proxy:3128".to_string()));
@@ -1901,7 +2019,7 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = Cli::parse_from_test_args([
+            let mut config_overrides = Cli::parse_from_test_args([
                 "--http-timeout",
                 "10s",
                 "--http-retries",
@@ -1910,11 +2028,11 @@ mod tests {
                 "socks5://other:1080",
                 "test-crate",
             ])
-            .config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            .to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(10));
             assert_eq!(config.http.retries, 0);
             assert_eq!(config.http.proxy, Some("socks5://other:1080".to_string()));
@@ -1929,11 +2047,12 @@ mod tests {
                 proxy = "http://proxy:3128"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides =
+                Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(10));
             assert_eq!(config.http.retries, 5);
             assert_eq!(config.http.proxy, Some("http://proxy:3128".to_string()));
@@ -1942,23 +2061,25 @@ mod tests {
         #[test]
         fn test_http_config_invalid_timeout_duration() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args =
-                Cli::parse_from_test_args(["--http-timeout", "not-a-duration", "test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides =
+                Cli::parse_from_test_args(["--http-timeout", "not-a-duration", "test-crate"])
+                    .to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let result = Config::load_from_dir(temp_dir.path(), &args);
+            let result = Config::load_from_dir(temp_dir.path(), &config_overrides);
             assert_matches!(result, Err(crate::error::Error::InvalidHttpTimeout { .. }));
         }
 
         #[test]
         fn test_http_config_zero_retries() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let mut args = Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides =
+                Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.retries, 0);
         }
 
@@ -1970,11 +2091,11 @@ mod tests {
                 backoff_max = "60s"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.backoff_base, Duration::from_secs(2));
             assert_eq!(config.http.backoff_max, Duration::from_secs(60));
         }
@@ -1986,11 +2107,11 @@ mod tests {
                 timeout = "45s"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.backoff_base, Duration::from_millis(500));
             assert_eq!(config.http.backoff_max, Duration::from_secs(5));
         }
@@ -2024,12 +2145,12 @@ mod tests {
             )
             .unwrap();
 
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(&child, &args).unwrap();
+            let config = Config::load_from_dir(&child, &config_overrides).unwrap();
             // Timeout comes from the child, overriding the parent, but since retries wasn't
             // specified in the child, it should be inherited from the parent config
             assert_eq!(config.http.timeout, Duration::from_secs(45));
@@ -2066,12 +2187,12 @@ mod tests {
             )
             .unwrap();
 
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(&child, &args).unwrap();
+            let config = Config::load_from_dir(&child, &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(45));
             assert_eq!(config.http.retries, 5);
         }
@@ -2096,12 +2217,12 @@ mod tests {
         /// Verifies `CARGO_HTTP_TIMEOUT` is used when neither CLI nor config file sets timeout.
         fn test_env_timeout_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(45));
         }
 
@@ -2109,12 +2230,12 @@ mod tests {
         /// Verifies `CARGO_NET_RETRY` is used when neither CLI nor config file sets retries.
         fn test_env_retries_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.retries, 7);
         }
 
@@ -2122,12 +2243,12 @@ mod tests {
         /// Verifies `CARGO_HTTP_PROXY` is used when neither CLI nor config file sets proxy.
         fn test_env_proxy_used_when_no_cli_or_config() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.proxy, Some("socks5://env-proxy:1080".to_string()));
         }
 
@@ -2139,7 +2260,7 @@ mod tests {
         /// Verifies CLI HTTP flags take precedence over Cargo HTTP environment variables.
         fn test_cli_overrides_env() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
+            let config_overrides = with_isolated_global_config(
                 Cli::parse_from_test_args([
                     "--http-timeout",
                     "10s",
@@ -2149,11 +2270,11 @@ mod tests {
                     "socks5://cli-proxy:1080",
                     "test-crate",
                 ])
-                .config_inputs(),
+                .to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(10));
             assert_eq!(config.http.retries, 1);
             assert_eq!(config.http.proxy, Some("socks5://cli-proxy:1080".to_string()));
@@ -2173,12 +2294,12 @@ mod tests {
                 proxy = "http://config-proxy:8080"
             "#;
             let temp_dir = create_temp_config(toml_content);
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, Duration::from_secs(120));
             assert_eq!(config.http.retries, 5);
             assert_eq!(config.http.proxy, Some("http://config-proxy:8080".to_string()));
@@ -2188,12 +2309,12 @@ mod tests {
         /// Verifies invalid `CARGO_HTTP_TIMEOUT` falls back to the built-in default timeout.
         fn test_invalid_env_timeout_falls_back_to_default() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.timeout, DEFAULT_HTTP_TIMEOUT);
         }
 
@@ -2201,12 +2322,12 @@ mod tests {
         /// Verifies invalid `CARGO_NET_RETRY` falls back to the built-in default retries value.
         fn test_invalid_env_retries_falls_back_to_default() {
             let temp_dir = tempfile::tempdir().unwrap();
-            let args = with_isolated_global_config(
-                Cli::parse_from_test_args(["test-crate"]).config_inputs(),
+            let config_overrides = with_isolated_global_config(
+                Cli::parse_from_test_args(["test-crate"]).to_config_overrides(),
                 temp_dir.path(),
             );
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
             assert_eq!(config.http.retries, DEFAULT_HTTP_RETRIES);
         }
     }
@@ -2220,8 +2341,8 @@ mod tests {
                 timeout: Some(Duration::from_secs(120)),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.timeout, Duration::from_secs(120));
             assert_eq!(http.retries, DEFAULT_HTTP_RETRIES);
         }
@@ -2232,8 +2353,8 @@ mod tests {
                 retries: Some(10),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.retries, 10);
         }
 
@@ -2243,8 +2364,8 @@ mod tests {
                 proxy: Some("http://proxy:3128".to_string()),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.proxy, Some("http://proxy:3128".to_string()));
         }
 
@@ -2254,8 +2375,9 @@ mod tests {
                 timeout: Some(Duration::from_secs(120)),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides =
+                Cli::parse_from_test_args(["--http-timeout", "10s", "test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.timeout, Duration::from_secs(10));
         }
 
@@ -2265,8 +2387,9 @@ mod tests {
                 retries: Some(10),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides =
+                Cli::parse_from_test_args(["--http-retries", "0", "test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.retries, 0);
         }
 
@@ -2276,17 +2399,18 @@ mod tests {
                 proxy: Some("http://old:3128".to_string()),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["--http-proxy", "socks5://new:1080", "test-crate"])
-                .config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides =
+                Cli::parse_from_test_args(["--http-proxy", "socks5://new:1080", "test-crate"])
+                    .to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.proxy, Some("socks5://new:1080".to_string()));
         }
 
         #[test]
         fn test_empty_config_file_yields_defaults() {
             let config_file = HttpConfigFile::default();
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.timeout, DEFAULT_HTTP_TIMEOUT);
             assert_eq!(http.retries, DEFAULT_HTTP_RETRIES);
             assert_eq!(http.backoff_base, DEFAULT_HTTP_BACKOFF_BASE);
@@ -2301,8 +2425,8 @@ mod tests {
                 backoff_max: Some(Duration::from_secs(60)),
                 ..Default::default()
             };
-            let args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            let http = Config::build_http_config(&config_file, &args.http).unwrap();
+            let config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            let http = Config::build_http_config(&config_file, &config_overrides).unwrap();
             assert_eq!(http.backoff_base, Duration::from_secs(2));
             assert_eq!(http.backoff_max, Duration::from_secs(60));
         }
@@ -2317,10 +2441,10 @@ mod tests {
         fn test_invalid_toml_syntax() {
             let test_case = crate::testdata::ConfigTestCase::invalid_toml();
 
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(test_case.path().to_path_buf());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(test_case.path().to_path_buf());
 
-            let result = Config::load(&args);
+            let result = Config::load(&config_overrides);
             assert_matches!(result, Err(crate::error::Error::ConfigExtract { .. }));
         }
 
@@ -2328,10 +2452,10 @@ mod tests {
         fn test_invalid_config_options_raise_error() {
             let test_case = crate::testdata::ConfigTestCase::invalid_options();
 
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(test_case.path().to_path_buf());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(test_case.path().to_path_buf());
 
-            let result = Config::load(&args);
+            let result = Config::load(&config_overrides);
             assert_matches!(result, Err(crate::error::Error::ConfigExtract { .. }));
         }
 
@@ -2339,10 +2463,10 @@ mod tests {
         fn test_nonexistent_explicit_config_file() {
             let test_case = crate::testdata::ConfigTestCase::nonexistent();
 
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
-            args.config.config_file = Some(test_case.path().to_path_buf());
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
+            config_overrides.config_file = Some(test_case.path().to_path_buf());
 
-            let config = Config::load(&args).unwrap();
+            let config = Config::load(&config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(60 * 60));
         }
@@ -2351,14 +2475,14 @@ mod tests {
         fn test_no_config_files_uses_defaults() {
             let temp_dir = tempfile::tempdir().unwrap();
 
-            let mut args = Cli::parse_from_test_args(["test-crate"]).config_inputs();
+            let mut config_overrides = Cli::parse_from_test_args(["test-crate"]).to_config_overrides();
             // Ensure isolation from developer's real cgx config on their system.
             // Without these overrides, this test would load ~/.config/cgx/cgx.toml if it exists,
             // causing the test to fail with config values from the developer's actual config.
-            args.config.system_config_dir = Some(temp_dir.path().join("system"));
-            args.config.user_config_dir = Some(temp_dir.path().join("user"));
+            config_overrides.system_config_dir = Some(temp_dir.path().join("system"));
+            config_overrides.user_config_dir = Some(temp_dir.path().join("user"));
 
-            let config = Config::load_from_dir(temp_dir.path(), &args).unwrap();
+            let config = Config::load_from_dir(temp_dir.path(), &config_overrides).unwrap();
 
             assert_eq!(config.resolve_cache_timeout, Duration::from_secs(60 * 60));
             assert!(!config.offline);

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -197,6 +197,15 @@ pub enum ToolConfig {
         version: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         features: Option<Vec<String>>,
+        /// Whether to enable the crate's default features, matching Cargo's `default-features`
+        /// dependency key. Defaults to `true`; set to `false` to build with
+        /// `--no-default-features`.
+        #[serde(
+            rename = "default-features",
+            default = "default_true",
+            skip_serializing_if = "is_true"
+        )]
+        default_features: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         registry: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -220,6 +229,32 @@ impl ToolConfig {
             ToolConfig::Detailed { features, .. } => features.as_deref(),
         }
     }
+
+    /// Return the configured `default-features` setting for this tool.
+    ///
+    /// `true` (the default) means the crate's default features are enabled; `false` means
+    /// building with default features disabled, equivalent to `--no-default-features`.
+    pub fn default_features(&self) -> bool {
+        match self {
+            ToolConfig::Version(_) => true,
+            ToolConfig::Detailed { default_features, .. } => *default_features,
+        }
+    }
+}
+
+/// Default for the `default-features` field of [`ToolConfig::Detailed`]; named because serde's
+/// `default` attribute requires a function path.
+fn default_true() -> bool {
+    true
+}
+
+/// Predicate for `skip_serializing_if` on the `default-features` field, so the default `true` is
+/// omitted from rendered config; named because serde's attribute requires a function path.
+///
+/// Yes, an `is_true(bool) -> bool` function is like a particularly stupid Daily WTF episode,
+/// but unfortunately it's necessary here.
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 /// Intermediate structure for deserializing config files from TOML.
@@ -969,6 +1004,78 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_tools_default_features() {
+        // `default-features` (hyphenated, matching Cargo) is accepted and parsed.
+        let toml_content = r#"
+            [tools]
+            no-defaults = { version = "1.0", default-features = false }
+            with-defaults = { version = "1.0" }
+        "#;
+
+        let config: ConfigFile = toml::from_str(toml_content).unwrap();
+        let tools = config.tools.unwrap();
+
+        // Explicit `default-features = false` is captured.
+        assert!(!tools.get("no-defaults").unwrap().default_features());
+
+        // When the key is absent it defaults to `true`, matching Cargo's default.
+        assert!(tools.get("with-defaults").unwrap().default_features());
+
+        // The legacy underscore spelling is rejected; we accept only the hyphenated Cargo form.
+        let underscore = r#"
+            [tools]
+            nope = { version = "1.0", default_features = false }
+        "#;
+        assert_matches!(toml::from_str::<ConfigFile>(underscore), Err(_));
+    }
+
+    #[test]
+    fn test_default_features_round_trips_via_tools_toml() {
+        let mut config = Config::default();
+        config.tools.insert(
+            "no-defaults".to_string(),
+            ToolConfig::Detailed {
+                default_features: false,
+                version: Some("1.0".to_string()),
+                features: None,
+                registry: None,
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                path: None,
+            },
+        );
+        config.tools.insert(
+            "with-defaults".to_string(),
+            ToolConfig::Detailed {
+                default_features: true,
+                version: Some("1.0".to_string()),
+                features: None,
+                registry: None,
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                path: None,
+            },
+        );
+
+        let rendered = config.tools_toml().unwrap();
+
+        // `default-features = false` is rendered with the hyphenated Cargo key, while the default
+        // `true` is omitted entirely thanks to `skip_serializing_if`.
+        assert!(rendered.contains("default-features = false"));
+        assert!(!rendered.contains("default-features = true"));
+
+        // The setting survives a round-trip back through the parser.
+        let parsed: ConfigFile = toml::from_str(&rendered).unwrap();
+        let tools = parsed.tools.unwrap();
+        assert!(!tools.get("no-defaults").unwrap().default_features());
+        assert!(tools.get("with-defaults").unwrap().default_features());
+    }
+
+    #[test]
     fn test_deserialize_aliases() {
         let toml_content = r#"
             [aliases]
@@ -994,6 +1101,7 @@ mod tests {
         config.tools.insert(
             "beta".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: Some("1.5".to_string()),
                 features: Some(vec!["frobnulator".to_string()]),
                 registry: None,

--- a/cgx-core/src/crate_resolver.rs
+++ b/cgx-core/src/crate_resolver.rs
@@ -429,7 +429,7 @@ mod tests {
         let resolver = DefaultCrateResolver::new(
             config.clone(),
             git_client,
-            Arc::new(crate::cargo::find_cargo(reporter).unwrap()),
+            Arc::new(crate::cargo::create_cargo_runner(config.clone(), reporter).unwrap()),
             http_client,
         );
         (CachingResolver::new(resolver, cache), temp_dir)

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use crate::{
     Result,
-    cli::CliArgs,
+    cli::{CrateInvocation, Source},
     config::{Config, ToolConfig},
     error,
     git::GitSelector,
@@ -103,23 +103,17 @@ impl CrateSpec {
     /// 3. Default registry: Uses config's default registry when no registry specified
     ///
     /// Priority order for version selection:
-    /// 1. CLI `--version` flag (highest)
+    /// 1. CLI `--crate-version` flag (highest)
     /// 2. `@version` suffix in crate name
     /// 3. Config tool pinning
     /// 4. Latest version (lowest)
-    pub fn load(config: &Config, args: &CliArgs) -> Result<Self> {
-        // Parse the base crate spec from CLI args, including special cargo handling
-        let (name, at_version) = if let Some(crate_spec) = &args.crate_spec {
-            if crate_spec == "cargo" && !args.args.is_empty() {
-                // Special case: `cgx cargo deny` -> crate name is `cargo-deny`
-                let subcommand = &args.args[0];
-                let (subcommand_name, subcommand_version) = Self::parse_crate_name_and_version(subcommand)?;
-                let cargo_crate_name = format!("cargo-{}", subcommand_name);
-                (Some(cargo_crate_name), subcommand_version)
-            } else {
-                let (n, v) = Self::parse_crate_name_and_version(crate_spec)?;
-                (Some(n), v)
-            }
+    pub fn load(config: &Config, invocation: &CrateInvocation) -> Result<Self> {
+        // Parse the base crate spec. The `cgx cargo <sub>` -> `cargo-<sub>` normalization already
+        // happened during CLI resolution, so the spec here is the final crate name (plus optional
+        // `@VERSION`).
+        let (name, at_version) = if let Some(crate_spec) = &invocation.crate_spec {
+            let (n, v) = Self::parse_crate_name_and_version(crate_spec)?;
+            (Some(n), v)
         } else {
             (None, None)
         };
@@ -127,12 +121,8 @@ impl CrateSpec {
         // Apply alias resolution from config
         let name = name.map(|n| config.aliases.get(&n).cloned().unwrap_or(n));
 
-        // Reconcile version from @version syntax and --version flag
-        let flag_version = args
-            .version
-            .as_ref()
-            .filter(|v| !v.is_empty())
-            .map(|s| s.as_str());
+        // Reconcile version from @version syntax and --crate-version flag
+        let flag_version = invocation.crate_version.as_deref();
 
         let cli_version = match (at_version.as_deref(), flag_version) {
             (Some(at_ver), Some(flag_ver)) => {
@@ -178,175 +168,184 @@ impl CrateSpec {
             cli_version
         };
 
-        // Construct GitSelector from CLI flags
-        let git_selector = match (&args.branch, &args.tag, &args.rev) {
-            (Some(branch), None, None) => GitSelector::Branch(branch.clone()),
-            (None, Some(tag), None) => GitSelector::Tag(tag.clone()),
-            (None, None, Some(rev)) => GitSelector::Commit(rev.clone()),
-            (None, None, None) => GitSelector::DefaultBranch,
-            _ => unreachable!("BUG: clap should enforce mutual exclusivity"),
-        };
+        // The git ref was already collapsed from --branch/--tag/--rev during CLI resolution.
+        let git_selector = invocation.git_selector.clone();
 
-        let is_git_source = args.git.is_some() || args.github.is_some() || args.gitlab.is_some();
-
-        if !matches!(git_selector, GitSelector::DefaultBranch) && !is_git_source {
+        if !matches!(git_selector, GitSelector::DefaultBranch) && !invocation.source.is_git() {
             return error::GitSelectorWithoutGitSourceSnafu.fail();
         }
 
-        // Construct the appropriate CrateSpec variant based on source flags
-        if let Some(git_url) = &args.git {
-            if let Some(forge) = Forge::try_parse_from_url(git_url) {
-                Ok(CrateSpec::Forge {
-                    forge,
-                    selector: git_selector.clone(),
-                    name,
-                    version,
-                })
-            } else {
-                Ok(CrateSpec::Git {
-                    repo: git_url.clone(),
-                    selector: git_selector.clone(),
+        // Construct the appropriate CrateSpec variant based on the resolved source.
+        match &invocation.source {
+            Source::Git { url } => {
+                if let Some(forge) = Forge::try_parse_from_url(url) {
+                    Ok(CrateSpec::Forge {
+                        forge,
+                        selector: git_selector,
+                        name,
+                        version,
+                    })
+                } else {
+                    Ok(CrateSpec::Git {
+                        repo: url.clone(),
+                        selector: git_selector,
+                        name,
+                        version,
+                    })
+                }
+            }
+            Source::Registry { name: registry } => {
+                let name = name.context(error::MissingCrateParameterSnafu)?;
+                Ok(CrateSpec::Registry {
+                    source: RegistrySource::Named(registry.clone()),
                     name,
                     version,
                 })
             }
-        } else if let Some(registry) = &args.registry {
-            let name = name.context(error::MissingCrateParameterSnafu)?;
-            Ok(CrateSpec::Registry {
-                source: RegistrySource::Named(registry.clone()),
-                name,
-                version,
-            })
-        } else if let Some(index_str) = &args.index {
-            let name = name.context(error::MissingCrateParameterSnafu)?;
-            let index_url =
-                Url::parse(index_str).with_context(|_| error::InvalidUrlSnafu { url: index_str })?;
-            Ok(CrateSpec::Registry {
-                source: RegistrySource::IndexUrl(index_url),
-                name,
-                version,
-            })
-        } else if let Some(path) = &args.path {
-            Ok(CrateSpec::LocalDir {
+            Source::Index { url } => {
+                let name = name.context(error::MissingCrateParameterSnafu)?;
+                let index_url = Url::parse(url).with_context(|_| error::InvalidUrlSnafu { url })?;
+                Ok(CrateSpec::Registry {
+                    source: RegistrySource::IndexUrl(index_url),
+                    name,
+                    version,
+                })
+            }
+            Source::Path { path } => Ok(CrateSpec::LocalDir {
                 path: path.clone(),
                 name,
                 version,
-            })
-        } else if let Some(github_repo) = &args.github {
-            let (owner, repo) = Self::parse_owner_repo(github_repo)?;
-            let custom_url = if let Some(url_str) = &args.github_url {
-                Some(Url::parse(url_str).with_context(|_| error::InvalidUrlSnafu { url: url_str })?)
-            } else {
-                None
-            };
-            Ok(CrateSpec::Forge {
-                forge: Forge::GitHub {
-                    custom_url,
-                    owner,
-                    repo,
-                },
-                selector: git_selector.clone(),
-                name,
-                version,
-            })
-        } else if let Some(gitlab_repo) = &args.gitlab {
-            let (owner, repo) = Self::parse_owner_repo(gitlab_repo)?;
-            let custom_url = if let Some(url_str) = &args.gitlab_url {
-                Some(Url::parse(url_str).with_context(|_| error::InvalidUrlSnafu { url: url_str })?)
-            } else {
-                None
-            };
-            Ok(CrateSpec::Forge {
-                forge: Forge::GitLab {
-                    custom_url,
-                    owner,
-                    repo,
-                },
-                selector: git_selector.clone(),
-                name,
-                version,
-            })
-        } else {
-            // No CLI source flags - check tool config, then default_registry, then crates.io
+            }),
+            Source::GitHub { repo, custom_url } => {
+                let (owner, repo) = Self::parse_owner_repo(repo)?;
+                let custom_url = if let Some(url_str) = custom_url {
+                    Some(Url::parse(url_str).with_context(|_| error::InvalidUrlSnafu { url: url_str })?)
+                } else {
+                    None
+                };
+                Ok(CrateSpec::Forge {
+                    forge: Forge::GitHub {
+                        custom_url,
+                        owner,
+                        repo,
+                    },
+                    selector: git_selector,
+                    name,
+                    version,
+                })
+            }
+            Source::GitLab { repo, custom_url } => {
+                let (owner, repo) = Self::parse_owner_repo(repo)?;
+                let custom_url = if let Some(url_str) = custom_url {
+                    Some(Url::parse(url_str).with_context(|_| error::InvalidUrlSnafu { url: url_str })?)
+                } else {
+                    None
+                };
+                Ok(CrateSpec::Forge {
+                    forge: Forge::GitLab {
+                        custom_url,
+                        owner,
+                        repo,
+                    },
+                    selector: git_selector,
+                    name,
+                    version,
+                })
+            }
+            Source::Default => {
+                // No CLI source flag - check tool config, then default_registry, then crates.io.
 
-            // First check if tool config specifies a source
-            if let Some(ref tool_name) = name {
-                if let Some(tool_config) = config.tools.get(tool_name) {
-                    match tool_config {
-                        ToolConfig::Detailed {
-                            git: Some(git_url),
-                            branch,
-                            tag,
-                            rev,
-                            ..
-                        } => {
-                            // Tool config specifies git source
-                            let selector = match (branch.as_ref(), tag.as_ref(), rev.as_ref()) {
-                                (Some(b), None, None) => GitSelector::Branch(b.clone()),
-                                (None, Some(t), None) => GitSelector::Tag(t.clone()),
-                                (None, None, Some(r)) => GitSelector::Commit(r.clone()),
-                                _ => GitSelector::DefaultBranch,
-                            };
+                // First check if tool config specifies a source
+                if let Some(ref tool_name) = name {
+                    if let Some(tool_config) = config.tools.get(tool_name) {
+                        match tool_config {
+                            ToolConfig::Detailed {
+                                git: Some(git_url),
+                                branch,
+                                tag,
+                                rev,
+                                ..
+                            } => {
+                                // Tool config specifies git source
+                                let selector = match (branch.as_ref(), tag.as_ref(), rev.as_ref()) {
+                                    (Some(b), None, None) => GitSelector::Branch(b.clone()),
+                                    (None, Some(t), None) => GitSelector::Tag(t.clone()),
+                                    (None, None, Some(r)) => GitSelector::Commit(r.clone()),
+                                    _ => GitSelector::DefaultBranch,
+                                };
 
-                            if let Some(forge) = Forge::try_parse_from_url(git_url) {
-                                return Ok(CrateSpec::Forge {
-                                    forge,
-                                    selector,
-                                    name,
-                                    version,
-                                });
-                            } else {
-                                return Ok(CrateSpec::Git {
-                                    repo: git_url.clone(),
-                                    selector,
+                                if let Some(forge) = Forge::try_parse_from_url(git_url) {
+                                    return Ok(CrateSpec::Forge {
+                                        forge,
+                                        selector,
+                                        name,
+                                        version,
+                                    });
+                                } else {
+                                    return Ok(CrateSpec::Git {
+                                        repo: git_url.clone(),
+                                        selector,
+                                        name,
+                                        version,
+                                    });
+                                }
+                            }
+                            ToolConfig::Detailed {
+                                registry: Some(reg), ..
+                            } => {
+                                // Tool config specifies registry
+                                let name = name.context(error::MissingCrateParameterSnafu)?;
+                                return Ok(CrateSpec::Registry {
+                                    source: RegistrySource::Named(reg.clone()),
                                     name,
                                     version,
                                 });
                             }
-                        }
-                        ToolConfig::Detailed {
-                            registry: Some(reg), ..
-                        } => {
-                            // Tool config specifies registry
-                            let name = name.context(error::MissingCrateParameterSnafu)?;
-                            return Ok(CrateSpec::Registry {
-                                source: RegistrySource::Named(reg.clone()),
-                                name,
-                                version,
-                            });
-                        }
-                        ToolConfig::Detailed { path: Some(p), .. } => {
-                            // Tool config specifies local path
-                            return Ok(CrateSpec::LocalDir {
-                                path: p.clone(),
-                                name,
-                                version,
-                            });
-                        }
-                        _ => {
-                            // Tool config doesn't specify source - fall through to defaults
+                            ToolConfig::Detailed { path: Some(p), .. } => {
+                                // Tool config specifies local path
+                                return Ok(CrateSpec::LocalDir {
+                                    path: p.clone(),
+                                    name,
+                                    version,
+                                });
+                            }
+                            _ => {
+                                // Tool config doesn't specify source - fall through to defaults
+                            }
                         }
                     }
                 }
+
+                // At this point all of the configurations in which an explicit crate name is
+                // optional have been eliminated, so we require a crate name.
+                let name = name.context(error::MissingCrateParameterSnafu)?;
+
+                if let Some(ref default_registry) = config.default_registry {
+                    // Use config's default registry
+                    Ok(CrateSpec::Registry {
+                        source: RegistrySource::Named(default_registry.clone()),
+                        name,
+                        version,
+                    })
+                } else {
+                    // Use crates.io
+                    Ok(CrateSpec::CratesIo { name, version })
+                }
             }
+        }
+    }
 
-            // No tool config source - use default_registry or crates.io
-
-            // At this point all of the possible configurations in which an explicit crate name is
-            // optional have been eliminated, so we require a crate name.
-            let name = name.context(error::MissingCrateParameterSnafu)?;
-
-            if let Some(ref default_registry) = config.default_registry {
-                // Use config's default registry
-                Ok(CrateSpec::Registry {
-                    source: RegistrySource::Named(default_registry.clone()),
-                    name,
-                    version,
-                })
-            } else {
-                // Use crates.io
-                Ok(CrateSpec::CratesIo { name, version })
-            }
+    /// Return the crate name used for configured tool lookup, when one is known.
+    pub fn configured_tool_name(&self) -> Option<&str> {
+        match self {
+            CrateSpec::CratesIo { name, .. }
+            | CrateSpec::Registry { name, .. }
+            | CrateSpec::Git { name: Some(name), .. }
+            | CrateSpec::Forge { name: Some(name), .. }
+            | CrateSpec::LocalDir { name: Some(name), .. } => Some(name.as_str()),
+            CrateSpec::Git { name: None, .. }
+            | CrateSpec::Forge { name: None, .. }
+            | CrateSpec::LocalDir { name: None, .. } => None,
         }
     }
 
@@ -373,26 +372,6 @@ impl CrateSpec {
         } else {
             error::InvalidRepoFormatSnafu { repo: repo_str }.fail()
         }
-    }
-
-    /// Get the arguments that should be passed to the executed binary.
-    ///
-    /// For the special case of `cgx cargo <subcommand>`, the first argument is consumed
-    /// as part of the crate spec (to form `cargo-<subcommand>`), so we skip it.
-    /// Otherwise, all trailing args are passed to the binary.
-    pub fn get_binary_args(args: &CliArgs) -> Vec<std::ffi::OsString> {
-        let skip = if args.crate_spec.as_deref() == Some("cargo") && !args.args.is_empty() {
-            // Skip the first arg (the cargo subcommand name)
-            1
-        } else {
-            0
-        };
-
-        args.args
-            .iter()
-            .skip(skip)
-            .map(std::ffi::OsString::from)
-            .collect()
     }
 }
 
@@ -520,7 +499,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        cli::CliArgs,
+        cli::Cli,
         config::{Config, ToolConfig},
     };
 
@@ -540,8 +519,8 @@ mod tests {
         let mut config = Config::default();
         config.aliases.insert("rg".to_string(), "ripgrep".to_string());
 
-        let args = CliArgs::parse_from_test_args(["rg"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["rg"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -567,8 +546,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = CliArgs::parse_from_test_args(["ripgrep"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["ripgrep"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -605,8 +584,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["ripgrep"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["ripgrep"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -645,8 +624,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -687,8 +666,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -730,8 +709,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -773,8 +752,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -816,8 +795,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -858,8 +837,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -901,8 +880,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -944,8 +923,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -976,8 +955,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = CliArgs::parse_from_test_args(["--version", "13.0", "ripgrep"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["--crate-version", "13.0", "ripgrep"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1004,8 +983,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = CliArgs::parse_from_test_args(["ripgrep@13.0"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["ripgrep@13.0"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1043,8 +1022,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["--registry", "other-registry", "my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["--registry", "other-registry", "my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1087,8 +1066,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["--git", "https://example.com/repo.git", "my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["--git", "https://example.com/repo.git", "my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1126,8 +1105,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = CliArgs::parse_from_test_args(["rg"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["rg"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1161,8 +1140,8 @@ mod tests {
             ..Default::default()
         };
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1211,8 +1190,8 @@ mod tests {
             ..Default::default()
         };
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,
@@ -1305,8 +1284,8 @@ mod tests {
             },
         );
 
-        let args = CliArgs::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, &args).unwrap();
+        let args = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
 
         assert_matches!(
             spec,

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -618,6 +618,7 @@ mod tests {
         config.tools.insert(
             "ripgrep".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: Some("14.0".to_string()),
                 features: None,
                 registry: None,
@@ -658,6 +659,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: Some("1.0".to_string()),
                 registry: Some("my-registry".to_string()),
                 features: None,
@@ -700,6 +702,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
                 branch: None,
@@ -743,6 +746,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://github.com/owner/repo.git".to_string()),
                 tag: None,
@@ -786,6 +790,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://gitlab.com/owner/repo.git".to_string()),
                 tag: None,
@@ -829,6 +834,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 path: Some(PathBuf::from("/some/path")),
                 registry: None,
@@ -871,6 +877,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
                 branch: Some("develop".to_string()),
@@ -914,6 +921,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
                 tag: Some("v1.0.0".to_string()),
@@ -957,6 +965,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
                 rev: Some("abc123".to_string()),
@@ -1056,6 +1065,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: Some("1.0".to_string()),
                 git: Some("https://github.com/owner/repo.git".to_string()),
                 registry: None,
@@ -1100,6 +1110,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: Some("1.0".to_string()),
                 registry: Some("my-registry".to_string()),
                 git: None,
@@ -1220,6 +1231,7 @@ mod tests {
             tools: [(
                 "my-tool".to_string(),
                 ToolConfig::Detailed {
+                    default_features: true,
                     version: Some("1.0".to_string()),
                     registry: Some("tool-registry".to_string()),
                     features: None,
@@ -1318,6 +1330,7 @@ mod tests {
         config.tools.insert(
             "my-tool".to_string(),
             ToolConfig::Detailed {
+                default_features: true,
                 version: None,
                 features: Some(vec!["feat1".to_string(), "feat2".to_string()]),
                 registry: None,

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -7,11 +7,89 @@ use url::Url;
 
 use crate::{
     Result,
-    cli::{CrateInvocation, Source},
     config::{Config, ToolConfig},
     error,
     git::GitSelector,
 };
+
+/// The source from which to obtain a crate.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Source {
+    /// No explicit source selector; resolve via config if present, ultimately defaulting to
+    /// crates.io absent explicit config override.
+    #[default]
+    Default,
+    /// `--git <URL>`
+    Git { url: String },
+    /// `--registry <NAME>`
+    Registry { name: String },
+    /// `--index <URL>`
+    Index { url: String },
+    /// `--path <PATH>`
+    Path { path: PathBuf },
+    /// `--github <owner/repo>`, with optional `--github-url`
+    GitHub {
+        repo: String,
+        custom_url: Option<String>,
+    },
+    /// `--gitlab <owner/repo>`, with optional `--gitlab-url`
+    GitLab {
+        repo: String,
+        custom_url: Option<String>,
+    },
+}
+
+impl Source {
+    /// True for git-backed sources, the only sources a non-default [`GitSelector`] may accompany.
+    pub fn is_git(&self) -> bool {
+        matches!(
+            self,
+            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. }
+        )
+    }
+
+    /// True when a crate name can be discovered from the source itself, making an explicit crate
+    /// name optional.
+    pub fn allows_crate_discovery(&self) -> bool {
+        matches!(
+            self,
+            Source::Git { .. } | Source::GitHub { .. } | Source::GitLab { .. } | Source::Path { .. }
+        )
+    }
+}
+
+/// A request to resolve a single crate.
+///
+/// This is the cratespec-layer input to [`CrateSpec::load`].
+#[derive(Clone, Debug, Default)]
+pub struct CrateRequest {
+    /// The crate name, or `None` when it is discoverable from the source (e.g. `--git`/`--path`).
+    pub name: Option<String>,
+
+    /// The requested version requirement as a raw string, parsed into a [`VersionReq`] by
+    /// [`CrateSpec::load`]. `None` selects the latest version (or a config-pinned one).
+    pub version: Option<String>,
+
+    /// Where to obtain the crate.
+    pub source: Source,
+
+    /// Which git ref to use, for git-backed sources.
+    pub git_ref: GitSelector,
+}
+
+impl CrateRequest {
+    /// Build a request for a tool specified in the `cgx` config `[tools]` section, identified by
+    /// its name in that table.
+    pub fn for_configured_tool(name: &str) -> Self {
+        // TODO: This will leave all fields but `name` at their defaults; how can we be sure that's
+        // what's actually set in the `[tools]` config section?  Don't we need to look up the tool
+        // config entry and refer to that?
+        Self {
+            name: Some(name.to_string()),
+            ..Self::default()
+        }
+    }
+}
 
 /// A specification of a crate that the user wants to execute.
 ///
@@ -95,7 +173,7 @@ pub enum CrateSpec {
 }
 
 impl CrateSpec {
-    /// Load a crate spec from the command line, respecting config-based overrides.
+    /// Resolve a [`CrateRequest`] into a [`CrateSpec`], respecting config-based overrides.
     ///
     /// This method applies config-based transformations and overrides:
     /// 1. Alias resolution: Maps short names to full crate names (e.g., `rg` → `ripgrep`)
@@ -103,55 +181,28 @@ impl CrateSpec {
     /// 3. Default registry: Uses config's default registry when no registry specified
     ///
     /// Priority order for version selection:
-    /// 1. CLI `--crate-version` flag (highest)
-    /// 2. `@version` suffix in crate name
-    /// 3. Config tool pinning
-    /// 4. Latest version (lowest)
-    pub fn load(config: &Config, invocation: &CrateInvocation) -> Result<Self> {
-        // Parse the base crate spec. The `cgx cargo <sub>` -> `cargo-<sub>` normalization already
-        // happened during CLI resolution, so the spec here is the final crate name (plus optional
-        // `@VERSION`).
-        let (name, at_version) = if let Some(crate_spec) = &invocation.crate_spec {
-            let (n, v) = Self::parse_crate_name_and_version(crate_spec)?;
-            (Some(n), v)
-        } else {
-            (None, None)
-        };
+    /// 1. The user's explicitly specified version requirement in [`CrateRequest::version`]
+    /// 2. Config tool pinning
+    /// 3. Current/latest version of the crate at whatever source is being used
+    pub fn load(config: &Config, req: &CrateRequest) -> Result<Self> {
+        // Apply alias resolution from config.
+        let name = req
+            .name
+            .as_ref()
+            .map(|name| config.aliases.get(name).unwrap_or(name));
 
-        // Apply alias resolution from config
-        let name = name.map(|n| config.aliases.get(&n).cloned().unwrap_or(n));
-
-        // Reconcile version from @version syntax and --crate-version flag
-        let flag_version = invocation.crate_version.as_deref();
-
-        let cli_version = match (at_version.as_deref(), flag_version) {
-            (Some(at_ver), Some(flag_ver)) => {
-                if at_ver != flag_ver {
-                    return error::ConflictingVersionsSnafu {
-                        at_version: at_ver,
-                        flag_version: flag_ver,
-                    }
-                    .fail();
-                }
-                Some(
-                    VersionReq::parse(at_ver)
-                        .with_context(|_| error::InvalidVersionReqSnafu { version: at_ver })?,
-                )
-            }
-            (Some(at_ver), None) => Some(
-                VersionReq::parse(at_ver)
-                    .with_context(|_| error::InvalidVersionReqSnafu { version: at_ver })?,
-            ),
-            (None, Some(flag_ver)) => Some(
-                VersionReq::parse(flag_ver)
-                    .with_context(|_| error::InvalidVersionReqSnafu { version: flag_ver })?,
-            ),
-            (None, None) => None,
-        };
+        // Parse the reconciled CLI version requirement, if any. The `@VERSION` / `--crate-version`
+        // reconciliation already happened during CLI translation; this is the single place a CLI
+        // version string is turned into a `VersionReq`, shared with config tool pinning below.
+        let cli_version = req
+            .version
+            .as_deref()
+            .map(|v| VersionReq::parse(v).with_context(|_| error::InvalidVersionReqSnafu { version: v }))
+            .transpose()?;
 
         // Apply tool pinning from config if no CLI version specified
         let version = if cli_version.is_none() {
-            if let Some(ref tool_name) = name {
+            if let Some(tool_name) = name {
                 config
                     .tools
                     .get(tool_name)
@@ -168,28 +219,27 @@ impl CrateSpec {
             cli_version
         };
 
-        // The git ref was already collapsed from --branch/--tag/--rev during CLI resolution.
-        let git_selector = invocation.git_selector.clone();
+        let git_selector = req.git_ref.clone();
 
-        if !matches!(git_selector, GitSelector::DefaultBranch) && !invocation.source.is_git() {
+        if !matches!(git_selector, GitSelector::DefaultBranch) && !req.source.is_git() {
             return error::GitSelectorWithoutGitSourceSnafu.fail();
         }
 
         // Construct the appropriate CrateSpec variant based on the resolved source.
-        match &invocation.source {
+        match &req.source {
             Source::Git { url } => {
                 if let Some(forge) = Forge::try_parse_from_url(url) {
                     Ok(CrateSpec::Forge {
                         forge,
                         selector: git_selector,
-                        name,
+                        name: name.cloned(),
                         version,
                     })
                 } else {
                     Ok(CrateSpec::Git {
                         repo: url.clone(),
                         selector: git_selector,
-                        name,
+                        name: name.cloned(),
                         version,
                     })
                 }
@@ -198,7 +248,7 @@ impl CrateSpec {
                 let name = name.context(error::MissingCrateParameterSnafu)?;
                 Ok(CrateSpec::Registry {
                     source: RegistrySource::Named(registry.clone()),
-                    name,
+                    name: name.clone(),
                     version,
                 })
             }
@@ -207,13 +257,13 @@ impl CrateSpec {
                 let index_url = Url::parse(url).with_context(|_| error::InvalidUrlSnafu { url })?;
                 Ok(CrateSpec::Registry {
                     source: RegistrySource::IndexUrl(index_url),
-                    name,
+                    name: name.clone(),
                     version,
                 })
             }
             Source::Path { path } => Ok(CrateSpec::LocalDir {
                 path: path.clone(),
-                name,
+                name: name.cloned(),
                 version,
             }),
             Source::GitHub { repo, custom_url } => {
@@ -230,7 +280,7 @@ impl CrateSpec {
                         repo,
                     },
                     selector: git_selector,
-                    name,
+                    name: name.cloned(),
                     version,
                 })
             }
@@ -248,7 +298,7 @@ impl CrateSpec {
                         repo,
                     },
                     selector: git_selector,
-                    name,
+                    name: name.cloned(),
                     version,
                 })
             }
@@ -256,7 +306,7 @@ impl CrateSpec {
                 // No CLI source flag - check tool config, then default_registry, then crates.io.
 
                 // First check if tool config specifies a source
-                if let Some(ref tool_name) = name {
+                if let Some(tool_name) = name {
                     if let Some(tool_config) = config.tools.get(tool_name) {
                         match tool_config {
                             ToolConfig::Detailed {
@@ -278,14 +328,14 @@ impl CrateSpec {
                                     return Ok(CrateSpec::Forge {
                                         forge,
                                         selector,
-                                        name,
+                                        name: name.cloned(),
                                         version,
                                     });
                                 } else {
                                     return Ok(CrateSpec::Git {
                                         repo: git_url.clone(),
                                         selector,
-                                        name,
+                                        name: name.cloned(),
                                         version,
                                     });
                                 }
@@ -297,7 +347,7 @@ impl CrateSpec {
                                 let name = name.context(error::MissingCrateParameterSnafu)?;
                                 return Ok(CrateSpec::Registry {
                                     source: RegistrySource::Named(reg.clone()),
-                                    name,
+                                    name: name.clone(),
                                     version,
                                 });
                             }
@@ -305,7 +355,7 @@ impl CrateSpec {
                                 // Tool config specifies local path
                                 return Ok(CrateSpec::LocalDir {
                                     path: p.clone(),
-                                    name,
+                                    name: name.cloned(),
                                     version,
                                 });
                             }
@@ -324,18 +374,26 @@ impl CrateSpec {
                     // Use config's default registry
                     Ok(CrateSpec::Registry {
                         source: RegistrySource::Named(default_registry.clone()),
-                        name,
+                        name: name.clone(),
                         version,
                     })
                 } else {
                     // Use crates.io
-                    Ok(CrateSpec::CratesIo { name, version })
+                    Ok(CrateSpec::CratesIo {
+                        name: name.clone(),
+                        version,
+                    })
                 }
             }
         }
     }
 
-    /// Return the crate name used for configured tool lookup, when one is known.
+    /// Get the crate name used for looking up the crate in the `[tools]` TOML section,
+    /// if one is known.
+    ///
+    /// Not all `CrateSpec` variants have a known crate name; for those variants, unfortunatelly,
+    /// the contents of the `[tools]` section cannot be used to configure them, and this method
+    /// returns `None`.
     pub fn configured_tool_name(&self) -> Option<&str> {
         match self {
             CrateSpec::CratesIo { name, .. }
@@ -346,19 +404,6 @@ impl CrateSpec {
             CrateSpec::Git { name: None, .. }
             | CrateSpec::Forge { name: None, .. }
             | CrateSpec::LocalDir { name: None, .. } => None,
-        }
-    }
-
-    /// Parse a crate name that may include an @version suffix.
-    ///
-    /// Examples:
-    /// - `"ripgrep"` → `("ripgrep", None)`
-    /// - `"ripgrep@14"` → `("ripgrep", Some("14"))`
-    fn parse_crate_name_and_version(spec: &str) -> Result<(String, Option<String>)> {
-        if let Some((name, version)) = spec.split_once('@') {
-            Ok((name.to_string(), Some(version.to_string())))
-        } else {
-            Ok((spec.to_string(), None))
         }
     }
 
@@ -519,8 +564,8 @@ mod tests {
         let mut config = Config::default();
         config.aliases.insert("rg".to_string(), "ripgrep".to_string());
 
-        let args = Cli::parse_from_test_args(["rg"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["rg"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -546,8 +591,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = Cli::parse_from_test_args(["ripgrep"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["ripgrep"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -584,8 +629,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["ripgrep"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["ripgrep"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -624,8 +669,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -666,8 +711,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -709,8 +754,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -752,8 +797,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -795,8 +840,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -837,8 +882,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -880,8 +925,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -923,8 +968,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -955,8 +1000,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = Cli::parse_from_test_args(["--crate-version", "13.0", "ripgrep"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["--crate-version", "13.0", "ripgrep"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -983,8 +1028,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = Cli::parse_from_test_args(["ripgrep@13.0"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["ripgrep@13.0"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1022,8 +1067,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["--registry", "other-registry", "my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["--registry", "other-registry", "my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1066,8 +1111,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["--git", "https://example.com/repo.git", "my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["--git", "https://example.com/repo.git", "my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1105,8 +1150,8 @@ mod tests {
             .tools
             .insert("ripgrep".to_string(), ToolConfig::Version("14.0".to_string()));
 
-        let args = Cli::parse_from_test_args(["rg"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["rg"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1140,8 +1185,8 @@ mod tests {
             ..Default::default()
         };
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1190,8 +1235,8 @@ mod tests {
             ..Default::default()
         };
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,
@@ -1266,7 +1311,7 @@ mod tests {
     /// Command: `cgx my-tool`
     ///
     /// Expected: Produces [`CrateSpec::CratesIo`] (the default).
-    /// Features affect [`crate::cli::BuildOptions`], not [`CrateSpec`].
+    /// Features affect [`crate::builder::BuildOptions`], not [`CrateSpec`].
     #[test]
     fn test_tool_with_only_features() {
         let mut config = Config::default();
@@ -1284,8 +1329,8 @@ mod tests {
             },
         );
 
-        let args = Cli::parse_from_test_args(["my-tool"]);
-        let spec = CrateSpec::load(&config, args.crate_invocation()).unwrap();
+        let cli = Cli::parse_from_test_args(["my-tool"]);
+        let spec = CrateSpec::load(&config, &cli.crate_args().crate_request().unwrap()).unwrap();
 
         assert_matches!(
             spec,

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use crate::{
     Result,
-    config::{Config, ToolConfig},
+    config::{Config, ToolConfig, ToolConfigDetailed},
     error,
     git::GitSelector,
 };
@@ -81,9 +81,15 @@ impl CrateRequest {
     /// Build a request for a tool specified in the `cgx` config `[tools]` section, identified by
     /// its name in that table.
     pub fn for_configured_tool(name: &str) -> Self {
-        // TODO: This will leave all fields but `name` at their defaults; how can we be sure that's
-        // what's actually set in the `[tools]` config section?  Don't we need to look up the tool
-        // config entry and refer to that?
+        // Only `name` is set; `source`, `version`, and `git_ref` are intentionally left at their
+        // defaults. That is sufficient because [`CrateSpec::load`] will resolve this request with
+        // a default `source` by looking up the crate name in the  `[tools]` config section and
+        // applying its configured source and version — exactly the way a bare `cgx <name>`
+        // invocation resolves. Pre-filling those fields here would duplicate that lookup.
+        //
+        // Of course that assumes that the caller is already certain that `name` appears in the
+        // `[tools]` config section, but if that assumption doesn't hold it's a bug in the caller
+        // not here.
         Self {
             name: Some(name.to_string()),
             ..Self::default()
@@ -207,10 +213,11 @@ impl CrateSpec {
                     .tools
                     .get(tool_name)
                     .and_then(|tool_config| match tool_config {
-                        ToolConfig::Version(v) | ToolConfig::Detailed { version: Some(v), .. } => {
+                        ToolConfig::Version(v)
+                        | ToolConfig::Detailed(ToolConfigDetailed { version: Some(v), .. }) => {
                             VersionReq::parse(v).ok()
                         }
-                        ToolConfig::Detailed { version: None, .. } => None,
+                        ToolConfig::Detailed(ToolConfigDetailed { version: None, .. }) => None,
                     })
             } else {
                 None
@@ -309,13 +316,13 @@ impl CrateSpec {
                 if let Some(tool_name) = name {
                     if let Some(tool_config) = config.tools.get(tool_name) {
                         match tool_config {
-                            ToolConfig::Detailed {
+                            ToolConfig::Detailed(ToolConfigDetailed {
                                 git: Some(git_url),
                                 branch,
                                 tag,
                                 rev,
                                 ..
-                            } => {
+                            }) => {
                                 // Tool config specifies git source
                                 let selector = match (branch.as_ref(), tag.as_ref(), rev.as_ref()) {
                                     (Some(b), None, None) => GitSelector::Branch(b.clone()),
@@ -340,9 +347,9 @@ impl CrateSpec {
                                     });
                                 }
                             }
-                            ToolConfig::Detailed {
+                            ToolConfig::Detailed(ToolConfigDetailed {
                                 registry: Some(reg), ..
-                            } => {
+                            }) => {
                                 // Tool config specifies registry
                                 let name = name.context(error::MissingCrateParameterSnafu)?;
                                 return Ok(CrateSpec::Registry {
@@ -351,7 +358,7 @@ impl CrateSpec {
                                     version,
                                 });
                             }
-                            ToolConfig::Detailed { path: Some(p), .. } => {
+                            ToolConfig::Detailed(ToolConfigDetailed { path: Some(p), .. }) => {
                                 // Tool config specifies local path
                                 return Ok(CrateSpec::LocalDir {
                                     path: p.clone(),
@@ -545,7 +552,7 @@ mod tests {
     use super::*;
     use crate::{
         cli::Cli,
-        config::{Config, ToolConfig},
+        config::{Config, ToolConfig, ToolConfigDetailed},
     };
 
     /// Test that config aliases are resolved before processing the crate spec.
@@ -617,7 +624,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "ripgrep".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("14.0".to_string()),
                 features: None,
@@ -627,7 +634,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["ripgrep"]);
@@ -658,7 +665,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("1.0".to_string()),
                 registry: Some("my-registry".to_string()),
@@ -668,7 +675,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -701,7 +708,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
@@ -711,7 +718,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -745,7 +752,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://github.com/owner/repo.git".to_string()),
@@ -755,7 +762,7 @@ mod tests {
                 branch: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -789,7 +796,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://gitlab.com/owner/repo.git".to_string()),
@@ -799,7 +806,7 @@ mod tests {
                 branch: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -833,7 +840,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 path: Some(PathBuf::from("/some/path")),
@@ -843,7 +850,7 @@ mod tests {
                 branch: None,
                 tag: None,
                 rev: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -876,7 +883,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
@@ -886,7 +893,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -920,7 +927,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
@@ -930,7 +937,7 @@ mod tests {
                 branch: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -964,7 +971,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 git: Some("https://example.com/repo.git".to_string()),
@@ -974,7 +981,7 @@ mod tests {
                 branch: None,
                 tag: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);
@@ -1064,7 +1071,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("1.0".to_string()),
                 git: Some("https://github.com/owner/repo.git".to_string()),
@@ -1074,7 +1081,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["--registry", "other-registry", "my-tool"]);
@@ -1109,7 +1116,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: Some("1.0".to_string()),
                 registry: Some("my-registry".to_string()),
@@ -1119,7 +1126,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["--git", "https://example.com/repo.git", "my-tool"]);
@@ -1230,7 +1237,7 @@ mod tests {
             default_registry: Some("default-registry".to_string()),
             tools: [(
                 "my-tool".to_string(),
-                ToolConfig::Detailed {
+                ToolConfig::Detailed(ToolConfigDetailed {
                     default_features: true,
                     version: Some("1.0".to_string()),
                     registry: Some("tool-registry".to_string()),
@@ -1240,7 +1247,7 @@ mod tests {
                     tag: None,
                     rev: None,
                     path: None,
-                },
+                }),
             )]
             .into_iter()
             .collect(),
@@ -1329,7 +1336,7 @@ mod tests {
         let mut config = Config::default();
         config.tools.insert(
             "my-tool".to_string(),
-            ToolConfig::Detailed {
+            ToolConfig::Detailed(ToolConfigDetailed {
                 default_features: true,
                 version: None,
                 features: Some(vec!["feat1".to_string(), "feat2".to_string()]),
@@ -1339,7 +1346,7 @@ mod tests {
                 tag: None,
                 rev: None,
                 path: None,
-            },
+            }),
         );
 
         let cli = Cli::parse_from_test_args(["my-tool"]);

--- a/cgx-core/src/downloader.rs
+++ b/cgx-core/src/downloader.rs
@@ -393,7 +393,8 @@ mod tests {
     fn test_cargo_runner() -> impl CargoRunner {
         crate::logging::init_test_logging();
 
-        crate::cargo::find_cargo(crate::messages::MessageReporter::null()).unwrap()
+        crate::cargo::create_cargo_runner(Config::default(), crate::messages::MessageReporter::null())
+            .unwrap()
     }
 
     fn validate_downloaded_crate(downloaded: &DownloadedCrate) {

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -136,6 +136,9 @@ pub enum Error {
     #[snafu(display("JSON serialization error: {source}"))]
     Json { source: serde_json::Error },
 
+    #[snafu(display("TOML serialization error: {source}"))]
+    TomlSerialize { source: toml::ser::Error },
+
     #[snafu(display("Cannot download '{name}' v{version}: network required but offline mode enabled"))]
     OfflineMode { name: String, version: String },
 
@@ -257,6 +260,13 @@ pub enum Error {
 
     #[snafu(display("HTTP {status} from {url}"))]
     HttpStatus { url: String, status: u16 },
+
+    #[snafu(display(
+        "Failed to prefetch {} configured tool(s): {}",
+        failures.len(),
+        failures.join("; ")
+    ))]
+    PrefetchAllFailed { failures: Vec<String> },
 
     #[snafu(display("Invalid HTTP timeout duration '{value}': {source}"))]
     InvalidHttpTimeout {

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[snafu(display("Crate name is required"))]
     MissingCrateParameter,
 
+    #[snafu(display("Missing crate name in crate spec '{spec}'"))]
+    MissingCrateName { spec: String },
+
     #[snafu(display("Repository format must be 'owner/repo', got '{repo}'"))]
     InvalidRepoFormat { repo: String },
 
@@ -33,6 +36,13 @@ pub enum Error {
         at_version: String,
         flag_version: String,
     },
+
+    #[snafu(display(
+        "cgx cannot run cargo itself, and pinning a cargo version is not supported. To run a cargo \
+         subcommand through cgx, use `cgx cargo <subcommand>` (e.g. `cgx cargo deny`) or the plugin crate \
+         name directly (e.g. `cgx cargo-deny`)"
+    ))]
+    CargoNotRunnable,
 
     // Resolution errors
     #[snafu(display("Crate '{name}' not found in registry"))]
@@ -212,6 +222,16 @@ pub enum Error {
          '{name}' version '{version}'"
     ))]
     PrebuiltBinaryRequired { name: String, version: String },
+
+    #[snafu(display(
+        "Prebuilt binary required (--prebuilt-binary always) but {reason}, which requires building crate \
+         '{name}' version '{version}' from source"
+    ))]
+    PrebuiltBinaryDisqualified {
+        name: String,
+        version: String,
+        reason: String,
+    },
 
     #[snafu(display(
         "Checksum verification failed for downloaded binary: expected {expected}, got {actual}"

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -26,8 +26,8 @@ pub enum Error {
     InvalidUrl { url: String, source: url::ParseError },
 
     #[snafu(display(
-        "Conflicting version specifications: @{at_version} in crate name vs --version {flag_version}. \
-         Prefer using the @VERSION suffix in the crate name."
+        "Crate versions in the crate name ({at_version}) and the --crate-version flag ({flag_version}) are \
+         mutually exclusive; specify one or the other but not both"
     ))]
     ConflictingVersions {
         at_version: String,

--- a/cgx-core/src/git.rs
+++ b/cgx-core/src/git.rs
@@ -84,7 +84,7 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 /// from a git repository, matching cargo's `GitReference` semantics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GitSelector {
-    /// Use the remote's default branch (fetches HEAD).
+    /// No branch has been explicitly specified, so sse the remote's default branch (fetches HEAD).
     DefaultBranch,
     /// Explicit branch name.
     Branch(String),

--- a/cgx-core/src/git.rs
+++ b/cgx-core/src/git.rs
@@ -82,9 +82,10 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 ///
 /// This enum represents the different ways to specify which ref to checkout
 /// from a git repository, matching cargo's `GitReference` semantics.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum GitSelector {
     /// No branch has been explicitly specified, so sse the remote's default branch (fetches HEAD).
+    #[default]
     DefaultBranch,
     /// Explicit branch name.
     Branch(String),

--- a/cgx-core/src/lib.rs
+++ b/cgx-core/src/lib.rs
@@ -22,13 +22,13 @@ pub(crate) mod testdata;
 use std::sync::Arc;
 
 use bin_resolver::BinaryResolver;
-use builder::{BuildOptions, CrateBuilder};
+use builder::{BuildOptions, BuildOverrides, CrateBuilder};
 use cache::Cache;
 // Re-export this third-party crate type that is nonetheless part of this crate's public API
 pub use cargo_metadata::Target;
 use config::Config;
 use crate_resolver::CrateResolver;
-use cratespec::CrateSpec;
+use cratespec::{CrateRequest, CrateSpec};
 use downloader::CrateDownloader;
 use error::Result;
 use http::HttpClient;
@@ -41,6 +41,7 @@ use http::HttpClient;
 /// available to everyone using the project whether or not they previously installed `cgx` on their
 /// systems.
 pub struct Cgx {
+    config: Config,
     resolver: Arc<dyn CrateResolver>,
     bin_resolver: Arc<dyn BinaryResolver>,
     downloader: Arc<dyn CrateDownloader>,
@@ -84,9 +85,10 @@ impl Cgx {
             http_client,
         ));
 
-        let builder = Arc::new(builder::create_builder(config, cache, cargo_runner));
+        let builder = Arc::new(builder::create_builder(config.clone(), cache, cargo_runner));
 
         Ok(Self {
+            config,
             resolver,
             bin_resolver,
             downloader,
@@ -95,26 +97,26 @@ impl Cgx {
         })
     }
 
-    /// Run the cgx engine with the given crate spec and build options.
+    /// Resolve a crate request into its build plan and produce the path to its binary.
     ///
-    /// This is the main execution path that:
-    /// - Resolves the crate spec to a concrete version
-    /// - Downloads the crate source to the cache
-    /// - Attempts to find a pre-built binary (if enabled)
-    /// - If no pre-built binary, builds the crate binary from source
-    /// - Returns the path to the binary
+    /// This is the shared load-and-build impl that powers `cgx <crate>`, `--no-exec`, `--prefetch`,
+    /// and each crate prefetched by `--prefetch-all`:
+    /// - loads the [`CrateSpec`] and [`BuildOptions`] from the engine's config plus `overrides`,
+    /// - resolves the spec to a concrete version and downloads the source,
+    /// - returns a pre-built binary if one is available and enabled, otherwise builds from source.
     ///
-    /// This method does NOT execute the binary - that's left to the caller.
-    pub fn crate_to_bin(
+    /// Returns the fully-qualified path to the crate's binary. Does NOT execute it.
+    pub fn prepare_bin_crate(
         &self,
-        crate_spec: &CrateSpec,
-        build_options: &BuildOptions,
+        request: &CrateRequest,
+        overrides: &BuildOverrides,
     ) -> Result<std::path::PathBuf> {
-        let downloaded_crate = self.resolve_and_download_crate(crate_spec, build_options)?;
+        let (crate_spec, build_options) = self.resolve_crate_request(request, overrides)?;
+        let downloaded_crate = self.resolve_and_download_crate_spec(&crate_spec, &build_options)?;
 
         // Try to resolve a pre-built binary, now with access to the downloaded source
         tracing::debug!("Attempting to resolve pre-built binary");
-        if let Some(resolved_binary) = self.bin_resolver.resolve(&downloaded_crate, build_options)? {
+        if let Some(resolved_binary) = self.bin_resolver.resolve(&downloaded_crate, &build_options)? {
             let provider = resolved_binary.provider;
             tracing::info!(
                 "Found pre-built binary from {:?} at: {}",
@@ -125,7 +127,7 @@ impl Cgx {
                 messages::CgxMessage::crate_provenance_prebuilt(
                     &downloaded_crate.resolved,
                     &downloaded_crate.crate_path,
-                    build_options,
+                    &build_options,
                     provider,
                     &resolved_binary.path,
                 )
@@ -138,14 +140,14 @@ impl Cgx {
             "Pre-built binary not found, excluded by config, or disabled; building crate from source..."
         );
 
-        let (bin_path, target_binary) = self.builder.build(&downloaded_crate, build_options)?;
+        let (bin_path, target_binary) = self.builder.build(&downloaded_crate, &build_options)?;
 
         tracing::info!("Built crate binary at: {}", bin_path.display());
         self.reporter.report(|| {
             messages::CgxMessage::crate_provenance_built_from_source(
                 &downloaded_crate.resolved,
                 &downloaded_crate.crate_path,
-                build_options,
+                &build_options,
                 &bin_path,
                 target_binary,
             )
@@ -154,33 +156,116 @@ impl Cgx {
         Ok(bin_path)
     }
 
-    /// List the available targets (binaries and examples) in a crate.
+    /// Resolve a crate request and list its runnable targets without building or executing.
     ///
-    /// Downloads the crate source if it's not already cached, but does not attempt to build from
-    /// source or to find pre-built binaries.
+    /// Loads the [`CrateSpec`]/[`BuildOptions`] from config plus `overrides`  and downloads the
+    /// source if needed, but does not build from source or look for a pre-built binary.
     ///
-    /// Returns a tuple of:
-    /// - `String`: The crate name
-    /// - `Option<Target>`: The default target if one is specified
-    /// - `Vec<Target>`: All binary targets
-    /// - `Vec<Target>`: All example targets
+    /// Returns `(crate_name, default_target, bin_targets, example_targets)`.
     #[allow(clippy::type_complexity)]
     pub fn list_targets(
         &self,
-        crate_spec: &CrateSpec,
-        build_options: &BuildOptions,
+        request: &CrateRequest,
+        overrides: &BuildOverrides,
     ) -> Result<(String, Option<Target>, Vec<Target>, Vec<Target>)> {
-        let downloaded_crate = self.resolve_and_download_crate(crate_spec, build_options)?;
+        let (crate_spec, build_options) = self.resolve_crate_request(request, overrides)?;
+        let downloaded_crate = self.resolve_and_download_crate_spec(&crate_spec, &build_options)?;
         let crate_name = downloaded_crate.resolved.name.clone();
-        let (default, bins, examples) = self.builder.list_targets(&downloaded_crate, build_options)?;
+        let (default, bins, examples) = self.builder.list_targets(&downloaded_crate, &build_options)?;
         Ok((crate_name, default, bins, examples))
     }
 
-    /// Resolve and download a crate, producing a [`downloader::DownloadedCrate`].
+    /// Enumerate the configured tools and aliases in the config, then return the rendered
+    /// `[tools]`/`[aliases]` TOML.
+    pub fn list_configured_tools(&self) -> Result<String> {
+        // Emit appropriate messages as we enumerate the tools/aliases
+        for (name, tool_config) in self.config.sorted_tools() {
+            self.reporter
+                .report(|| messages::RunnerMessage::list_tool(name, tool_config));
+        }
+        for (name, target) in self.config.sorted_aliases() {
+            self.reporter
+                .report(|| messages::RunnerMessage::list_alias(name, target));
+        }
+
+        self.config.tools_toml()
+    }
+
+    /// Prefetch a single crate request: prepare its binary without executing it, reporting
+    /// progress via [`messages::RunnerMessage::PrefetchStarted`] and
+    /// [`messages::RunnerMessage::PrefetchCompleted`].
+    ///
+    /// This is the single-crate counterpart to [`Cgx::prefetch_all`]. `label` is the user-facing
+    /// identifier shown in those messages: the raw CLI crate spec (e.g. `ripgrep@1.0`), the
+    /// resolved crate name, or a `<source>` placeholder for source-only invocations.
+    pub fn prefetch(&self, label: &str, request: &CrateRequest, overrides: &BuildOverrides) -> Result<()> {
+        self.reporter
+            .report(|| messages::RunnerMessage::prefetch_started(label));
+
+        let bin_path = self.prepare_bin_crate(request, overrides)?;
+
+        self.reporter
+            .report(|| messages::RunnerMessage::prefetch_completed(label, &bin_path));
+
+        Ok(())
+    }
+
+    /// Prefetch every tool and alias configured in the `[tools]`/`[aliases]` config sections.
+    ///
+    /// Tools and aliases are grouped by the crate they resolve to, so each distinct crate is
+    /// prefetched exactly once no matter how many configured names point at it; the configured
+    /// names are reported alongside it. Every configured tool is attempted even if some fail; if
+    /// any failed, this returns [`error::Error::PrefetchAllFailed`] listing them.
+    pub fn prefetch_all(&self, overrides: &BuildOverrides) -> Result<()> {
+        let mut failures = Vec::new();
+
+        for tool in self.config.configured_tools() {
+            self.reporter
+                .report(|| messages::RunnerMessage::prefetch_all_started(&tool.name, &tool.aliases));
+
+            let request = CrateRequest::for_configured_tool(&tool.name);
+            match self.prepare_bin_crate(&request, overrides) {
+                Ok(bin_path) => {
+                    self.reporter.report(|| {
+                        messages::RunnerMessage::prefetch_all_completed(&tool.name, &tool.aliases, &bin_path)
+                    });
+                }
+                Err(err) => {
+                    self.reporter.report(|| {
+                        messages::RunnerMessage::prefetch_all_failed(&tool.name, &tool.aliases, &err)
+                    });
+                    failures.push(format!("{}: {}", tool.name, err));
+                }
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            error::PrefetchAllFailedSnafu { failures }.fail()
+        }
+    }
+
+    /// Load the resolved [`CrateSpec`] and [`BuildOptions`] for a crate request.
+    ///
+    /// Applies the engine's config and `overrides` to turn a [`CrateRequest`] into the concrete
+    /// crate spec and build options.
+    fn resolve_crate_request(
+        &self,
+        request: &CrateRequest,
+        overrides: &BuildOverrides,
+    ) -> Result<(CrateSpec, BuildOptions)> {
+        let crate_spec = CrateSpec::load(&self.config, request)?;
+        let build_options = BuildOptions::load_for_crate(&self.config, overrides, &crate_spec)?;
+        Ok((crate_spec, build_options))
+    }
+
+    /// Resolve and download a crate given an already-resolved [`CrateSpec`], producing a
+    /// [`downloader::DownloadedCrate`].
     ///
     /// NOTE: This is downloading the crate source code, which must be done even if we eventually
     /// end up selecting a prebuilt binary instead of building from source.
-    fn resolve_and_download_crate(
+    fn resolve_and_download_crate_spec(
         &self,
         crate_spec: &CrateSpec,
         build_options: &BuildOptions,

--- a/cgx-core/src/lib.rs
+++ b/cgx-core/src/lib.rs
@@ -45,6 +45,7 @@ pub struct Cgx {
     bin_resolver: Arc<dyn BinaryResolver>,
     downloader: Arc<dyn CrateDownloader>,
     builder: Arc<dyn CrateBuilder>,
+    reporter: messages::MessageReporter,
 }
 
 impl Cgx {
@@ -59,7 +60,7 @@ impl Cgx {
         let cache = Cache::new(config.clone(), reporter.clone());
         let git_client = git::GitClient::new(cache.clone(), reporter.clone(), config.http.clone());
 
-        let cargo_runner = Arc::new(cargo::find_cargo(reporter.clone())?);
+        let cargo_runner = Arc::new(cargo::create_cargo_runner(config.clone(), reporter.clone())?);
 
         let resolver = Arc::new(crate_resolver::create_resolver(
             config.clone(),
@@ -90,6 +91,7 @@ impl Cgx {
             bin_resolver,
             downloader,
             builder,
+            reporter,
         })
     }
 
@@ -108,45 +110,54 @@ impl Cgx {
         crate_spec: &CrateSpec,
         build_options: &BuildOptions,
     ) -> Result<std::path::PathBuf> {
-        tracing::debug!("Got crate spec: {:?}", crate_spec);
-
-        tracing::info!("Resolving crate...");
-        let resolved_crate = self.resolver.resolve(crate_spec)?;
-
-        tracing::info!(
-            "Resolved crate {}@{}",
-            resolved_crate.name,
-            resolved_crate.version
-        );
-
-        let downloaded_crate = self.downloader.download(resolved_crate)?;
-
-        tracing::debug!("Downloaded crate to cache: {:#?}", downloaded_crate);
+        let downloaded_crate = self.resolve_and_download_crate(crate_spec, build_options)?;
 
         // Try to resolve a pre-built binary, now with access to the downloaded source
         tracing::debug!("Attempting to resolve pre-built binary");
         if let Some(resolved_binary) = self.bin_resolver.resolve(&downloaded_crate, build_options)? {
+            let provider = resolved_binary.provider;
             tracing::info!(
                 "Found pre-built binary from {:?} at: {}",
-                resolved_binary.provider,
+                provider,
                 resolved_binary.path.display()
             );
+            self.reporter.report(|| {
+                messages::CgxMessage::crate_provenance_prebuilt(
+                    &downloaded_crate.resolved,
+                    &downloaded_crate.crate_path,
+                    build_options,
+                    provider,
+                    &resolved_binary.path,
+                )
+            });
             return Ok(resolved_binary.path);
         }
 
         // No pre-built binary available, fall back to building from source
         tracing::info!(
-            "Pre-built binary not found, excluded by config, or or disabled; building crate from source..."
+            "Pre-built binary not found, excluded by config, or disabled; building crate from source..."
         );
 
-        let bin_path = self.builder.build(&downloaded_crate, build_options)?;
+        let (bin_path, target_binary) = self.builder.build(&downloaded_crate, build_options)?;
 
         tracing::info!("Built crate binary at: {}", bin_path.display());
+        self.reporter.report(|| {
+            messages::CgxMessage::crate_provenance_built_from_source(
+                &downloaded_crate.resolved,
+                &downloaded_crate.crate_path,
+                build_options,
+                &bin_path,
+                target_binary,
+            )
+        });
 
         Ok(bin_path)
     }
 
     /// List the available targets (binaries and examples) in a crate.
+    ///
+    /// Downloads the crate source if it's not already cached, but does not attempt to build from
+    /// source or to find pre-built binaries.
     ///
     /// Returns a tuple of:
     /// - `String`: The crate name
@@ -159,10 +170,42 @@ impl Cgx {
         crate_spec: &CrateSpec,
         build_options: &BuildOptions,
     ) -> Result<(String, Option<Target>, Vec<Target>, Vec<Target>)> {
-        let resolved_crate = self.resolver.resolve(crate_spec)?;
-        let crate_name = resolved_crate.name.clone();
-        let downloaded_crate = self.downloader.download(resolved_crate)?;
+        let downloaded_crate = self.resolve_and_download_crate(crate_spec, build_options)?;
+        let crate_name = downloaded_crate.resolved.name.clone();
         let (default, bins, examples) = self.builder.list_targets(&downloaded_crate, build_options)?;
         Ok((crate_name, default, bins, examples))
+    }
+
+    /// Resolve and download a crate, producing a [`downloader::DownloadedCrate`].
+    ///
+    /// NOTE: This is downloading the crate source code, which must be done even if we eventually
+    /// end up selecting a prebuilt binary instead of building from source.
+    fn resolve_and_download_crate(
+        &self,
+        crate_spec: &CrateSpec,
+        build_options: &BuildOptions,
+    ) -> Result<downloader::DownloadedCrate> {
+        tracing::debug!("Got crate spec: {:?}", crate_spec);
+
+        tracing::info!("Resolving crate...");
+        let resolved_crate = self.resolver.resolve(crate_spec)?;
+        tracing::info!(
+            "Resolved crate {}@{}",
+            resolved_crate.name,
+            resolved_crate.version
+        );
+
+        let downloaded_crate = self.downloader.download(resolved_crate)?;
+        tracing::debug!("Downloaded crate to cache: {:#?}", downloaded_crate);
+
+        self.reporter.report(|| {
+            messages::CgxMessage::crate_plan(
+                &downloaded_crate.resolved,
+                &downloaded_crate.crate_path,
+                build_options,
+            )
+        });
+
+        Ok(downloaded_crate)
     }
 }

--- a/cgx-core/src/messages/cgx.rs
+++ b/cgx-core/src/messages/cgx.rs
@@ -1,0 +1,131 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::Message;
+use crate::{
+    builder::{BuildOptions, BuildTarget},
+    config::BinaryProvider,
+    crate_resolver::ResolvedCrate,
+};
+
+/// Engine-level messages emitted by [`crate::Cgx`] around the pre-built-vs-source decision.
+///
+/// These capture the full set of facts about a crate invocation — its resolved identity and source,
+/// where its code lives on disk, the chosen build options and target, and how its binary was
+/// obtained — so that callers (and tests) can observe what cgx decided without inspecting the built
+/// binary itself.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum CgxMessage {
+    /// The fully-resolved crate and chosen build options, emitted *before* checking for a pre-built
+    /// binary.
+    ///
+    /// Whether a pre-built binary will actually be found is not yet known, so this is the crate
+    /// that is planned to be used, although whether it's to be built from source or obtained
+    /// pre-built is not yet determined.
+    CratePlan {
+        /// The resolved crate identity (name, version, source).
+        resolved: ResolvedCrate,
+        /// Path to the crate's source code on disk (a cache path, or a local dir for `--path`).
+        crate_path: PathBuf,
+        /// The build options cgx chose for this invocation.
+        options: BuildOptions,
+        /// The Rust target triple this build targets (the explicit `--target`, or the host triple).
+        target_platform: String,
+    },
+    /// How the crate's binary was ultimately obtained, emitted *after* the pre-built-vs-source
+    /// decision.
+    CrateProvenance {
+        /// The resolved crate identity (name, version, source).
+        resolved: ResolvedCrate,
+        /// Path to the crate's source code on disk.
+        crate_path: PathBuf,
+        /// The build options cgx chose for this invocation.
+        options: BuildOptions,
+        /// The Rust target triple this binary is for (the explicit `--target`, or the host triple).
+        target_platform: String,
+        /// Whether the binary was built from source or downloaded pre-built, and where it is.
+        provenance: Provenance,
+    },
+}
+
+/// How a crate's runnable binary was obtained.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Provenance {
+    /// Compiled from source by cargo.
+    BuiltFromSource {
+        /// Path to the compiled binary.
+        binary_path: PathBuf,
+        /// The concrete bin/example that was built (a `DefaultBin` request is resolved to the
+        /// actual target).
+        target_binary: BuildTarget,
+    },
+    /// Downloaded as a pre-built binary from the given provider.
+    Prebuilt {
+        /// The provider the binary was obtained from.
+        provider: BinaryProvider,
+        /// Path to the downloaded binary.
+        binary_path: PathBuf,
+    },
+}
+
+impl CgxMessage {
+    /// Construct a [`Self::CratePlan`] from the resolved crate, its source path, chosen options,
+    /// and enabled pre-built sources.
+    pub fn crate_plan(resolved: &ResolvedCrate, crate_path: &Path, options: &BuildOptions) -> Self {
+        Self::CratePlan {
+            resolved: resolved.clone(),
+            crate_path: crate_path.to_path_buf(),
+            target_platform: options.target_platform(),
+            options: options.clone(),
+        }
+    }
+
+    /// Construct a [`Self::CrateProvenance`] recording that the binary was built from source.
+    pub fn crate_provenance_built_from_source(
+        resolved: &ResolvedCrate,
+        crate_path: &Path,
+        options: &BuildOptions,
+        binary_path: &Path,
+        target_binary: BuildTarget,
+    ) -> Self {
+        Self::CrateProvenance {
+            resolved: resolved.clone(),
+            crate_path: crate_path.to_path_buf(),
+            target_platform: options.target_platform(),
+            options: options.clone(),
+            provenance: Provenance::BuiltFromSource {
+                binary_path: binary_path.to_path_buf(),
+                target_binary,
+            },
+        }
+    }
+
+    /// Construct a [`Self::CrateProvenance`] recording that a pre-built binary was used.
+    pub fn crate_provenance_prebuilt(
+        resolved: &ResolvedCrate,
+        crate_path: &Path,
+        options: &BuildOptions,
+        provider: BinaryProvider,
+        binary_path: &Path,
+    ) -> Self {
+        Self::CrateProvenance {
+            resolved: resolved.clone(),
+            crate_path: crate_path.to_path_buf(),
+            target_platform: options.target_platform(),
+            options: options.clone(),
+            provenance: Provenance::Prebuilt {
+                provider,
+                binary_path: binary_path.to_path_buf(),
+            },
+        }
+    }
+}
+
+impl From<CgxMessage> for Message {
+    fn from(msg: CgxMessage) -> Self {
+        Message::Cgx(msg)
+    }
+}

--- a/cgx-core/src/messages/mod.rs
+++ b/cgx-core/src/messages/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod build_cache;
+pub mod cgx;
 pub mod crate_resolution;
 pub mod git;
 pub mod prebuilt_binary;
@@ -10,6 +11,7 @@ use std::sync::mpsc;
 
 pub use build::BuildMessage;
 pub use build_cache::BuildCacheMessage;
+pub use cgx::{CgxMessage, Provenance};
 pub use crate_resolution::CrateResolutionMessage;
 pub use git::GitMessage;
 pub use prebuilt_binary::PrebuiltBinaryMessage;
@@ -34,6 +36,7 @@ pub enum Message {
     Git(GitMessage),
     Build(BuildMessage),
     Runner(RunnerMessage),
+    Cgx(CgxMessage),
 }
 
 /// A reporter for diagnostic messages.

--- a/cgx-core/src/messages/runner.rs
+++ b/cgx-core/src/messages/runner.rs
@@ -9,35 +9,71 @@ use crate::config::ToolConfig;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum RunnerMessage {
+    /// The resolved binary and arguments cgx is about to execute, or would execute under
+    /// `--no-exec`.
     ExecutionPlan {
+        /// Path to the resolved binary.
         binary_path: PathBuf,
+        /// Arguments forwarded to the binary, lossily converted to UTF-8 for serialization.
         args: Vec<String>,
+        /// True when `--no-exec` was given, so the plan is reported without being executed.
         no_exec: bool,
     },
+    /// One configured `[tools]` entry, reported by `--list-tools`.
     ListTool {
+        /// The configured tool (crate) name.
         name: String,
+        /// The tool's merged configuration.
         config: ToolConfig,
     },
+    /// One configured `[aliases]` entry, reported by `--list-tools`.
     ListAlias {
+        /// The alias name.
         name: String,
+        /// The tool name the alias resolves to.
         target: String,
     },
+    /// `--prefetch` started preparing a crate.
     PrefetchStarted {
-        invocation: String,
+        /// The crate spec as requested on the command line (a crate name, `name@version`, or an
+        /// alias, unresolved), or the configured tool name or a `<source>` placeholder when the
+        /// crate is discovered from a source such as `--git` or `--path`.
+        crate_spec: String,
     },
+    /// `--prefetch` finished preparing a crate.
     PrefetchCompleted {
-        invocation: String,
+        /// The crate spec as requested on the command line (see [`Self::PrefetchStarted`]).
+        crate_spec: String,
+        /// Path to the prepared binary.
         binary_path: PathBuf,
     },
+    /// `--prefetch-all` started prefetching one configured tool.
     PrefetchAllStarted {
-        invocation: String,
+        /// The name of the crate in the `[tools]` config section.
+        tool: String,
+        /// List of aliases (if any) to the tool, in the `[aliases]` config section, that also
+        /// resolve to this tool.
+        aliases: Vec<String>,
     },
+    /// `--prefetch-all` finished prefetching one configured tool.
     PrefetchAllCompleted {
-        invocation: String,
+        /// The name of the crate in the `[tools]` config section.
+        tool: String,
+        /// List of aliases (if any) to the tool, in the `[aliases]` config section, that also
+        /// resolve to this tool.
+        aliases: Vec<String>,
+        /// Path to the prepared binary.
         binary_path: PathBuf,
     },
+    /// `--prefetch-all` failed to prefetch one configured tool; the run continues with the
+    /// remaining tools and reports an overall failure at the end.
     PrefetchAllFailed {
-        invocation: String,
+        /// The name of the crate in the `[tools]` config section.
+        tool: String,
+        /// List of aliases (if any) to the tool, in the `[aliases]` config section, that also
+        /// resolve to this tool.
+        aliases: Vec<String>,
+        /// The rendered error that caused the failure.
         error: String,
     },
 }
@@ -65,35 +101,38 @@ impl RunnerMessage {
         }
     }
 
-    pub fn prefetch_started(invocation: &str) -> Self {
+    pub fn prefetch_started(crate_spec: &str) -> Self {
         Self::PrefetchStarted {
-            invocation: invocation.to_string(),
+            crate_spec: crate_spec.to_string(),
         }
     }
 
-    pub fn prefetch_completed(invocation: &str, binary_path: &std::path::Path) -> Self {
+    pub fn prefetch_completed(crate_spec: &str, binary_path: &std::path::Path) -> Self {
         Self::PrefetchCompleted {
-            invocation: invocation.to_string(),
+            crate_spec: crate_spec.to_string(),
             binary_path: binary_path.to_path_buf(),
         }
     }
 
-    pub fn prefetch_all_started(invocation: &str) -> Self {
+    pub fn prefetch_all_started(tool: &str, aliases: &[String]) -> Self {
         Self::PrefetchAllStarted {
-            invocation: invocation.to_string(),
+            tool: tool.to_string(),
+            aliases: aliases.to_vec(),
         }
     }
 
-    pub fn prefetch_all_completed(invocation: &str, binary_path: &std::path::Path) -> Self {
+    pub fn prefetch_all_completed(tool: &str, aliases: &[String], binary_path: &std::path::Path) -> Self {
         Self::PrefetchAllCompleted {
-            invocation: invocation.to_string(),
+            tool: tool.to_string(),
+            aliases: aliases.to_vec(),
             binary_path: binary_path.to_path_buf(),
         }
     }
 
-    pub fn prefetch_all_failed(invocation: &str, error: &dyn std::fmt::Display) -> Self {
+    pub fn prefetch_all_failed(tool: &str, aliases: &[String], error: &dyn std::fmt::Display) -> Self {
         Self::PrefetchAllFailed {
-            invocation: invocation.to_string(),
+            tool: tool.to_string(),
+            aliases: aliases.to_vec(),
             error: error.to_string(),
         }
     }

--- a/cgx-core/src/messages/runner.rs
+++ b/cgx-core/src/messages/runner.rs
@@ -3,6 +3,7 @@ use std::{ffi::OsString, path::PathBuf};
 use serde::{Deserialize, Serialize};
 
 use super::Message;
+use crate::config::ToolConfig;
 
 /// Messages related to binary execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,6 +13,32 @@ pub enum RunnerMessage {
         binary_path: PathBuf,
         args: Vec<String>,
         no_exec: bool,
+    },
+    ListTool {
+        name: String,
+        config: ToolConfig,
+    },
+    ListAlias {
+        name: String,
+        target: String,
+    },
+    PrefetchStarted {
+        invocation: String,
+    },
+    PrefetchCompleted {
+        invocation: String,
+        binary_path: PathBuf,
+    },
+    PrefetchAllStarted {
+        invocation: String,
+    },
+    PrefetchAllCompleted {
+        invocation: String,
+        binary_path: PathBuf,
+    },
+    PrefetchAllFailed {
+        invocation: String,
+        error: String,
     },
 }
 
@@ -23,10 +50,98 @@ impl RunnerMessage {
             no_exec,
         }
     }
+
+    pub fn list_tool(name: &str, config: &ToolConfig) -> Self {
+        Self::ListTool {
+            name: name.to_string(),
+            config: config.clone(),
+        }
+    }
+
+    pub fn list_alias(name: &str, target: &str) -> Self {
+        Self::ListAlias {
+            name: name.to_string(),
+            target: target.to_string(),
+        }
+    }
+
+    pub fn prefetch_started(invocation: &str) -> Self {
+        Self::PrefetchStarted {
+            invocation: invocation.to_string(),
+        }
+    }
+
+    pub fn prefetch_completed(invocation: &str, binary_path: &std::path::Path) -> Self {
+        Self::PrefetchCompleted {
+            invocation: invocation.to_string(),
+            binary_path: binary_path.to_path_buf(),
+        }
+    }
+
+    pub fn prefetch_all_started(invocation: &str) -> Self {
+        Self::PrefetchAllStarted {
+            invocation: invocation.to_string(),
+        }
+    }
+
+    pub fn prefetch_all_completed(invocation: &str, binary_path: &std::path::Path) -> Self {
+        Self::PrefetchAllCompleted {
+            invocation: invocation.to_string(),
+            binary_path: binary_path.to_path_buf(),
+        }
+    }
+
+    pub fn prefetch_all_failed(invocation: &str, error: &dyn std::fmt::Display) -> Self {
+        Self::PrefetchAllFailed {
+            invocation: invocation.to_string(),
+            error: error.to_string(),
+        }
+    }
 }
 
 impl From<RunnerMessage> for Message {
     fn from(msg: RunnerMessage) -> Self {
         Message::Runner(msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+    use crate::config::ToolConfig;
+
+    #[test]
+    fn list_tool_message_round_trips_as_json() {
+        let message: Message =
+            RunnerMessage::list_tool("timestamp", &ToolConfig::Version("0.1".to_string())).into();
+
+        let json = serde_json::to_string(&message).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+
+        assert_matches!(
+            parsed,
+            Message::Runner(RunnerMessage::ListTool {
+                ref name,
+                config: ToolConfig::Version(ref version),
+            }) if name == "timestamp" && version == "0.1"
+        );
+    }
+
+    #[test]
+    fn list_alias_message_round_trips_as_json() {
+        let message: Message = RunnerMessage::list_alias("ts", "timestamp").into();
+
+        let json = serde_json::to_string(&message).unwrap();
+        let parsed: Message = serde_json::from_str(&json).unwrap();
+
+        assert_matches!(
+            parsed,
+            Message::Runner(RunnerMessage::ListAlias {
+                ref name,
+                ref target,
+            }) if name == "ts" && target == "timestamp"
+        );
     }
 }

--- a/cgx-core/src/sbom.rs
+++ b/cgx-core/src/sbom.rs
@@ -464,12 +464,16 @@ pub(crate) mod tests {
         testdata::CrateTestCase,
     };
 
-    /// Get a CargoRunner for testing.
+    /// Get a [`CargoRunner`] for testing.
     ///
     /// Note that for the SBOM tests the actual cargo is needed, so this isn't a mock or dummy it's
     /// the real runner.
     fn test_cargo_runner() -> impl CargoRunner {
-        crate::cargo::find_cargo(crate::messages::MessageReporter::null()).unwrap()
+        crate::cargo::create_cargo_runner(
+            crate::config::Config::default(),
+            crate::messages::MessageReporter::null(),
+        )
+        .unwrap()
     }
 
     /// Generate an SBOM for a test case with the given build options.

--- a/cgx-example.toml
+++ b/cgx-example.toml
@@ -82,12 +82,14 @@ binary_providers = [
 
 # `cgx` can invoke any binary crate on crates.io, it doesn't need to be listed
 # here, but listing a tool here can pin it to a specific version or customize
-# its source, registry, path, or features.
+# its source, registry, path, features, or default-features.
 #
 # Each entry has the same format as a dependency in Cargo.toml.
 [tools]
 ripgrep   = "*"
 taplo-cli = { version = "1.11.0", features = ["schema"] }
+# `default-features = false` builds the tool with `--no-default-features`.
+sccache = { version = "0.8", default-features = false }
 
 # Not all crates have intuitive names. You can specify aliases here.
 [aliases]

--- a/cgx/src/lib.rs
+++ b/cgx/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod logging;
 mod reporter;
 
-use std::ffi::OsString;
+use std::{collections::BTreeSet, ffi::OsString};
 
 /// **INTERNAL - DO NOT USE IN PRODUCTION CODE**
 ///
@@ -13,7 +13,7 @@ pub use cgx_core::messages;
 use cgx_core::{
     Target,
     builder::BuildOptions,
-    cli::{CliArgs, MessageFormat},
+    cli::{Cli, CrateInvocation, MessageFormat, PrefetchAll},
     config::Config,
     cratespec::CrateSpec,
     error,
@@ -32,48 +32,34 @@ pub use snafu::Report as SnafuReport;
 /// Meant to be called from `main.rs` or other frontends.
 #[snafu::report]
 pub fn cgx_main() -> Result<()> {
-    let args = CliArgs::parse_from_cli_args();
+    let cli = Cli::parse_from_cli_args(cgx_version_string());
 
     // Initialize tracing early, before any other operations
-    logging::init(&args);
+    logging::init(cli.verbose());
 
-    if let Some(version_arg) = &args.version {
-        if version_arg.is_empty() {
-            let version = env!("CARGO_PKG_VERSION");
-
-            match (
-                option_env!("VERGEN_GIT_SHA"),
-                option_env!("VERGEN_GIT_COMMIT_DATE"),
-            ) {
-                (Some(sha), Some(date))
-                    if sha != "VERGEN_IDEMPOTENT_OUTPUT" && date != "VERGEN_IDEMPOTENT_OUTPUT" =>
-                {
-                    eprintln!("cgx {} ({} {})", version, sha, date);
-                }
-                _ => {
-                    eprintln!("cgx {}", version);
-                }
-            }
-            return Ok(());
-        }
-    }
-
-    let config = Config::load(&args)?;
+    let config = Config::load(&cli.config_inputs())?;
 
     // Apply log level from config file if appropriate
-    logging::apply_config(&config, &args);
+    logging::apply_config(&config, cli.verbose());
 
-    let crate_spec = CrateSpec::load(&config, &args)?;
-    let build_options = BuildOptions::load(&config, &args.build_options, args.verbose)?;
-
-    // Spawn a separate thread that will handle messages from the cgx core and report them to the user
-    // in the appropriate way.
-    let json_mode = matches!(args.message_format, Some(MessageFormat::Json));
+    // Spawn a separate thread that will handle messages from the cgx core and report them to the
+    // user in the appropriate way.
+    let json_mode = matches!(cli.message_format(), Some(MessageFormat::Json));
     let reporter_thread = reporter::ReporterThread::spawn(json_mode);
 
-    // Decode and prepare the command that the user wants to execute based on the args and env.
-    // This is where the heavy lifting happens.
-    let result = prepare_command(&reporter_thread, config, crate_spec, build_options, args);
+    // Decode and prepare the command that the user wants to execute. This is where the heavy
+    // lifting happens.
+    let result = match &cli {
+        Cli::ListTargets(invocation) => prepare_list_targets(&reporter_thread, &config, invocation),
+        Cli::ListTools(_) => prepare_list_tools(&reporter_thread, &config),
+        Cli::Prefetch(invocation) => prepare_prefetch(&reporter_thread, &config, invocation),
+        Cli::PrefetchAll(prefetch_all) => prepare_prefetch_all(&reporter_thread, &config, prefetch_all),
+        Cli::NoExec(invocation) => prepare_no_exec(&reporter_thread, &config, invocation),
+        Cli::Run {
+            invocation,
+            tool_args,
+        } => prepare_run(&reporter_thread, &config, invocation, tool_args.clone()),
+    };
 
     // Success or failure, there will be no more messages produced after this point, so join the
     // reporter thread to make sure we've processed any that were emitted before we proceed
@@ -83,7 +69,7 @@ pub fn cgx_main() -> Result<()> {
         Command::NoExec { bin_path } => {
             // Print path to stdout for scripting (e.g., binary=$(cgx --no-exec tool))
             println!("{}", bin_path.display());
-            return Ok(());
+            Ok(())
         }
         Command::Execute {
             bin_path,
@@ -121,12 +107,36 @@ pub fn cgx_main() -> Result<()> {
                 println!("example: {}", example.name);
             }
 
-            return Ok(());
+            Ok(())
         }
+        Command::ListTools { toml } => {
+            print!("{}", toml);
+            Ok(())
+        }
+        Command::Prefetched => Ok(()),
     }
 }
 
-/// Possible successful results of [`prepare_command`]
+/// Build the version string shown by `-V`/`--version`.
+///
+/// clap prepends the command name (`cgx`), so this returns just the version, including the git sha
+/// and commit date when they were available at build time (via `vergen`).
+fn cgx_version_string() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    match (
+        option_env!("VERGEN_GIT_SHA"),
+        option_env!("VERGEN_GIT_COMMIT_DATE"),
+    ) {
+        (Some(sha), Some(date))
+            if sha != "VERGEN_IDEMPOTENT_OUTPUT" && date != "VERGEN_IDEMPOTENT_OUTPUT" =>
+        {
+            format!("{version} ({sha} {date})")
+        }
+        _ => version.to_string(),
+    }
+}
+
+/// Possible successful results of preparing a command for execution.
 enum Command {
     /// Binary is ready to go but user requested `--no-exec` so just print the path we'd execute
     NoExec { bin_path: std::path::PathBuf },
@@ -142,46 +152,191 @@ enum Command {
         bins: Vec<Target>,
         examples: Vec<Target>,
     },
+    /// User asked to list configured tools and aliases
+    ListTools { toml: String },
+    /// Binary preparation completed without execution
+    Prefetched,
 }
 
-/// Internal implementation that does the actual work of decoding the args, determinine that
-/// command the user wants performed, and preparing the environment as needed.
-fn prepare_command(
-    reporter_thread: &reporter::ReporterThread,
-    config: Config,
-    crate_spec: CrateSpec,
-    build_options: BuildOptions,
-    args: CliArgs,
-) -> Result<Command> {
-    let cgx = cgx_core::Cgx::new(config, reporter_thread.message_reporter().clone())?;
+fn prepare_list_tools(reporter_thread: &reporter::ReporterThread, config: &Config) -> Result<Command> {
+    let reporter = reporter_thread.message_reporter();
 
-    if args.list_targets {
-        let (crate_name, default, bins, examples) = cgx.list_targets(&crate_spec, &build_options)?;
-
-        return Ok(Command::ListTargets {
-            crate_name,
-            default,
-            bins,
-            examples,
-        });
+    let mut tools: Vec<_> = config.tools.iter().collect();
+    tools.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (name, tool_config) in tools {
+        reporter.report(|| messages::RunnerMessage::list_tool(name, tool_config));
     }
+
+    let mut aliases: Vec<_> = config.aliases.iter().collect();
+    aliases.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (name, target) in aliases {
+        reporter.report(|| messages::RunnerMessage::list_alias(name, target));
+    }
+
+    Ok(Command::ListTools {
+        toml: config.tools_toml()?,
+    })
+}
+
+fn prepare_prefetch_all(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    prefetch_all: &PrefetchAll,
+) -> Result<Command> {
+    let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
+    let invocations = configured_invocations(config);
+    let reporter = reporter_thread.message_reporter();
+    let mut failures = Vec::new();
+
+    for invocation in invocations {
+        reporter.report(|| messages::RunnerMessage::prefetch_all_started(&invocation));
+
+        let result = prefetch_invocation(&cgx, config, prefetch_all, &invocation);
+        match result {
+            Ok(bin_path) => {
+                reporter.report(|| messages::RunnerMessage::prefetch_all_completed(&invocation, &bin_path));
+            }
+            Err(err) => {
+                reporter.report(|| messages::RunnerMessage::prefetch_all_failed(&invocation, &err));
+                failures.push(format!("{}: {}", invocation, err));
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(Command::Prefetched)
+    } else {
+        error::PrefetchAllFailedSnafu { failures }.fail()
+    }
+}
+
+fn configured_invocations(config: &Config) -> Vec<String> {
+    config
+        .tools
+        .keys()
+        .chain(config.aliases.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn prefetch_invocation(
+    cgx: &cgx_core::Cgx,
+    config: &Config,
+    prefetch_all: &PrefetchAll,
+    invocation: &str,
+) -> Result<std::path::PathBuf> {
+    let invocation = prefetch_all.invocation_for(invocation);
+
+    let crate_spec = CrateSpec::load(config, &invocation)?;
+    let build_options = BuildOptions::load_for_tool_name(
+        config,
+        &invocation.build_options,
+        invocation.reporting.verbose,
+        crate_spec.configured_tool_name(),
+    )?;
+
+    cgx.crate_to_bin(&crate_spec, &build_options)
+}
+
+/// Resolve a single crate invocation into a [`cgx_core::Cgx`] engine plus its crate spec and build
+/// options, shared by the run/no-exec/prefetch/list-targets commands.
+fn prepare_engine(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    invocation: &CrateInvocation,
+) -> Result<(cgx_core::Cgx, CrateSpec, BuildOptions)> {
+    let crate_spec = CrateSpec::load(config, invocation)?;
+    let build_options = BuildOptions::load_for_tool_name(
+        config,
+        &invocation.build_options,
+        invocation.reporting.verbose,
+        crate_spec.configured_tool_name(),
+    )?;
+    let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
+
+    Ok((cgx, crate_spec, build_options))
+}
+
+/// Prepare and execute a crate, forwarding `tool_args` to the executed binary.
+fn prepare_run(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    invocation: &CrateInvocation,
+    tool_args: Vec<OsString>,
+) -> Result<Command> {
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
+
+    reporter_thread
+        .message_reporter()
+        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &tool_args, false));
+
+    Ok(Command::Execute {
+        bin_path,
+        binary_args: tool_args,
+    })
+}
+
+/// Prepare a crate without executing it, printing the resolved binary path to stdout.
+fn prepare_no_exec(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    invocation: &CrateInvocation,
+) -> Result<Command> {
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
+
+    let no_args: Vec<OsString> = Vec::new();
+    reporter_thread
+        .message_reporter()
+        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &no_args, true));
+
+    Ok(Command::NoExec { bin_path })
+}
+
+/// Prepare a crate without executing it or printing its path.
+fn prepare_prefetch(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    invocation: &CrateInvocation,
+) -> Result<Command> {
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+
+    let label = invocation
+        .crate_spec
+        .as_deref()
+        .or_else(|| crate_spec.configured_tool_name())
+        .unwrap_or("<source>")
+        .to_string();
+
+    reporter_thread
+        .message_reporter()
+        .report(|| messages::RunnerMessage::prefetch_started(&label));
 
     let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
 
-    // Extract arguments to pass to the binary
-    let binary_args = CrateSpec::get_binary_args(&args);
-
-    // Report the execution plan
     reporter_thread
         .message_reporter()
-        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &binary_args, args.no_exec));
+        .report(|| messages::RunnerMessage::prefetch_completed(&label, &bin_path));
 
-    if args.no_exec {
-        Ok(Command::NoExec { bin_path })
-    } else {
-        Ok(Command::Execute {
-            bin_path,
-            binary_args,
-        })
-    }
+    Ok(Command::Prefetched)
+}
+
+/// Resolve a crate and list its runnable targets without building or executing.
+fn prepare_list_targets(
+    reporter_thread: &reporter::ReporterThread,
+    config: &Config,
+    invocation: &CrateInvocation,
+) -> Result<Command> {
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let (crate_name, default, bins, examples) = cgx.list_targets(&crate_spec, &build_options)?;
+
+    Ok(Command::ListTargets {
+        crate_name,
+        default,
+        bins,
+        examples,
+    })
 }

--- a/cgx/src/lib.rs
+++ b/cgx/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod logging;
 mod reporter;
 
-use std::{collections::BTreeSet, ffi::OsString};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
+};
 
 /// **INTERNAL - DO NOT USE IN PRODUCTION CODE**
 ///
@@ -181,21 +184,24 @@ fn prepare_prefetch_all(
     prefetch_all: &PrefetchAll,
 ) -> Result<Command> {
     let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
-    let invocations = configured_invocations(config);
+    let tools = configured_tools(config);
     let reporter = reporter_thread.message_reporter();
     let mut failures = Vec::new();
 
-    for invocation in invocations {
-        reporter.report(|| messages::RunnerMessage::prefetch_all_started(&invocation));
+    for tool in tools {
+        reporter.report(|| messages::RunnerMessage::prefetch_all_started(&tool.name, &tool.aliases));
 
-        let result = prefetch_invocation(&cgx, config, prefetch_all, &invocation);
+        let result = prefetch_tool(&cgx, config, prefetch_all, &tool);
         match result {
             Ok(bin_path) => {
-                reporter.report(|| messages::RunnerMessage::prefetch_all_completed(&invocation, &bin_path));
+                reporter.report(|| {
+                    messages::RunnerMessage::prefetch_all_completed(&tool.name, &tool.aliases, &bin_path)
+                });
             }
             Err(err) => {
-                reporter.report(|| messages::RunnerMessage::prefetch_all_failed(&invocation, &err));
-                failures.push(format!("{}: {}", invocation, err));
+                reporter
+                    .report(|| messages::RunnerMessage::prefetch_all_failed(&tool.name, &tool.aliases, &err));
+                failures.push(format!("{}: {}", tool.name, err));
             }
         }
     }
@@ -207,24 +213,53 @@ fn prepare_prefetch_all(
     }
 }
 
-fn configured_invocations(config: &Config) -> Vec<String> {
-    config
-        .tools
-        .keys()
-        .chain(config.aliases.keys())
-        .cloned()
-        .collect::<BTreeSet<_>>()
+/// One distinct tool referenced by the configuration: the alias-resolved tool name plus the
+/// configured names that map to it. `--prefetch-all` prefetches each of these exactly once.
+#[derive(Debug, PartialEq, Eq)]
+struct ConfiguredTool {
+    /// The alias-resolved tool name, reported as `tool` in the prefetch-all messages.
+    name: String,
+    /// The other configured names that resolve to this tool, sorted, excluding the name itself.
+    aliases: Vec<String>,
+    /// The configured name to load the crate spec with. Any grouped name loads the same crate,
+    /// and using a configured name (rather than the resolved one) keeps [`CrateSpec::load`]'s
+    /// single-step alias resolution identical to a direct `cgx <name>` invocation.
+    request: String,
+}
+
+/// Group every configured tool and alias by the tool it resolves to, applying the same
+/// single-step alias resolution as [`CrateSpec::load`].
+fn configured_tools(config: &Config) -> Vec<ConfiguredTool> {
+    let mut groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for name in config.tools.keys().chain(config.aliases.keys()) {
+        let resolved = config.aliases.get(name).unwrap_or(name);
+        groups.entry(resolved.clone()).or_default().insert(name.clone());
+    }
+
+    groups
         .into_iter()
+        .map(|(name, members)| {
+            let request = members.first().cloned().unwrap();
+            let aliases = members.into_iter().filter(|member| *member != name).collect();
+            ConfiguredTool {
+                name,
+                aliases,
+                request,
+            }
+        })
         .collect()
 }
 
-fn prefetch_invocation(
+fn prefetch_tool(
     cgx: &cgx_core::Cgx,
     config: &Config,
     prefetch_all: &PrefetchAll,
-    tool_name: &str,
+    configured_tool: &ConfiguredTool,
 ) -> Result<std::path::PathBuf> {
-    let crate_spec = CrateSpec::load(config, &CrateRequest::for_configured_tool(tool_name))?;
+    let crate_spec = CrateSpec::load(
+        config,
+        &CrateRequest::for_configured_tool(&configured_tool.request),
+    )?;
     let build_options =
         BuildOptions::load_for_crate(config, &prefetch_all.to_build_overrides(), &crate_spec)?;
 
@@ -326,4 +361,93 @@ fn prepare_list_targets(
         bins,
         examples,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use cgx_core::config::ToolConfig;
+
+    use super::*;
+
+    fn config_with(tools: &[&str], aliases: &[(&str, &str)]) -> Config {
+        let mut config = Config::default();
+        for &tool in tools {
+            config
+                .tools
+                .insert(tool.to_string(), ToolConfig::Version("*".to_string()));
+        }
+        for &(name, target) in aliases {
+            config.aliases.insert(name.to_string(), target.to_string());
+        }
+        config
+    }
+
+    #[test]
+    fn tool_with_alias_yields_single_entry() {
+        let config = config_with(&["eza"], &[("e", "eza")]);
+        assert_eq!(
+            configured_tools(&config),
+            [ConfiguredTool {
+                name: "eza".to_string(),
+                aliases: vec!["e".to_string()],
+                request: "e".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn alias_to_unconfigured_crate_yields_its_target_tool() {
+        let config = config_with(&[], &[("x", "ripgrep")]);
+        assert_eq!(
+            configured_tools(&config),
+            [ConfiguredTool {
+                name: "ripgrep".to_string(),
+                aliases: vec!["x".to_string()],
+                request: "x".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn multiple_aliases_group_under_one_tool() {
+        let config = config_with(&["eza"], &[("e", "eza"), ("ez", "eza")]);
+        assert_eq!(
+            configured_tools(&config),
+            [ConfiguredTool {
+                name: "eza".to_string(),
+                aliases: vec!["e".to_string(), "ez".to_string()],
+                request: "e".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn tools_are_deterministically_ordered() {
+        let config = config_with(&["zoxide", "eza"], &[("a", "zoxide")]);
+        let names: Vec<_> = configured_tools(&config)
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert_eq!(names, ["eza", "zoxide"]);
+    }
+
+    #[test]
+    fn independent_tools_remain_separate() {
+        let config = config_with(&["eza", "ripgrep"], &[]);
+        assert_eq!(
+            configured_tools(&config),
+            [
+                ConfiguredTool {
+                    name: "eza".to_string(),
+                    aliases: Vec::new(),
+                    request: "eza".to_string(),
+                },
+                ConfiguredTool {
+                    name: "ripgrep".to_string(),
+                    aliases: Vec::new(),
+                    request: "ripgrep".to_string(),
+                },
+            ]
+        );
+    }
 }

--- a/cgx/src/lib.rs
+++ b/cgx/src/lib.rs
@@ -13,9 +13,9 @@ pub use cgx_core::messages;
 use cgx_core::{
     Target,
     builder::BuildOptions,
-    cli::{Cli, CrateInvocation, MessageFormat, PrefetchAll},
+    cli::{Cli, CrateArgs, MessageFormat, PrefetchAll},
     config::Config,
-    cratespec::CrateSpec,
+    cratespec::{CrateRequest, CrateSpec},
     error,
 };
 // Re-export key types from cgx-core for convenience
@@ -35,12 +35,12 @@ pub fn cgx_main() -> Result<()> {
     let cli = Cli::parse_from_cli_args(cgx_version_string());
 
     // Initialize tracing early, before any other operations
-    logging::init(cli.verbose());
+    logging::init(cli.verbosity());
 
-    let config = Config::load(&cli.config_inputs())?;
+    let config = Config::load(&cli.to_config_overrides())?;
 
     // Apply log level from config file if appropriate
-    logging::apply_config(&config, cli.verbose());
+    logging::apply_config(&config);
 
     // Spawn a separate thread that will handle messages from the cgx core and report them to the
     // user in the appropriate way.
@@ -50,15 +50,12 @@ pub fn cgx_main() -> Result<()> {
     // Decode and prepare the command that the user wants to execute. This is where the heavy
     // lifting happens.
     let result = match &cli {
-        Cli::ListTargets(invocation) => prepare_list_targets(&reporter_thread, &config, invocation),
+        Cli::ListTargets(args) => prepare_list_targets(&reporter_thread, &config, args),
         Cli::ListTools(_) => prepare_list_tools(&reporter_thread, &config),
-        Cli::Prefetch(invocation) => prepare_prefetch(&reporter_thread, &config, invocation),
+        Cli::Prefetch(args) => prepare_prefetch(&reporter_thread, &config, args),
         Cli::PrefetchAll(prefetch_all) => prepare_prefetch_all(&reporter_thread, &config, prefetch_all),
-        Cli::NoExec(invocation) => prepare_no_exec(&reporter_thread, &config, invocation),
-        Cli::Run {
-            invocation,
-            tool_args,
-        } => prepare_run(&reporter_thread, &config, invocation, tool_args.clone()),
+        Cli::NoExec(args) => prepare_no_exec(&reporter_thread, &config, args),
+        Cli::Run { args, tool_args } => prepare_run(&reporter_thread, &config, args, tool_args.clone()),
     };
 
     // Success or failure, there will be no more messages produced after this point, so join the
@@ -225,35 +222,25 @@ fn prefetch_invocation(
     cgx: &cgx_core::Cgx,
     config: &Config,
     prefetch_all: &PrefetchAll,
-    invocation: &str,
+    tool_name: &str,
 ) -> Result<std::path::PathBuf> {
-    let invocation = prefetch_all.invocation_for(invocation);
-
-    let crate_spec = CrateSpec::load(config, &invocation)?;
-    let build_options = BuildOptions::load_for_tool_name(
-        config,
-        &invocation.build_options,
-        invocation.reporting.verbose,
-        crate_spec.configured_tool_name(),
-    )?;
+    let crate_spec = CrateSpec::load(config, &CrateRequest::for_configured_tool(tool_name))?;
+    let build_options =
+        BuildOptions::load_for_crate(config, &prefetch_all.to_build_overrides(), &crate_spec)?;
 
     cgx.crate_to_bin(&crate_spec, &build_options)
 }
 
-/// Resolve a single crate invocation into a [`cgx_core::Cgx`] engine plus its crate spec and build
-/// options, shared by the run/no-exec/prefetch/list-targets commands.
+/// Resolve a single set of crate arguments into a [`cgx_core::Cgx`] engine plus its crate spec and
+/// build options, for use by multiple commands that need a `Cgx` instance to operate on a specific
+/// crate.
 fn prepare_engine(
     reporter_thread: &reporter::ReporterThread,
     config: &Config,
-    invocation: &CrateInvocation,
+    args: &CrateArgs,
 ) -> Result<(cgx_core::Cgx, CrateSpec, BuildOptions)> {
-    let crate_spec = CrateSpec::load(config, invocation)?;
-    let build_options = BuildOptions::load_for_tool_name(
-        config,
-        &invocation.build_options,
-        invocation.reporting.verbose,
-        crate_spec.configured_tool_name(),
-    )?;
+    let crate_spec = CrateSpec::load(config, &args.crate_request()?)?;
+    let build_options = BuildOptions::load_for_crate(config, &args.to_build_overrides(), &crate_spec)?;
     let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
 
     Ok((cgx, crate_spec, build_options))
@@ -263,10 +250,10 @@ fn prepare_engine(
 fn prepare_run(
     reporter_thread: &reporter::ReporterThread,
     config: &Config,
-    invocation: &CrateInvocation,
+    args: &CrateArgs,
     tool_args: Vec<OsString>,
 ) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
     let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
 
     reporter_thread
@@ -283,9 +270,9 @@ fn prepare_run(
 fn prepare_no_exec(
     reporter_thread: &reporter::ReporterThread,
     config: &Config,
-    invocation: &CrateInvocation,
+    args: &CrateArgs,
 ) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
     let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
 
     let no_args: Vec<OsString> = Vec::new();
@@ -300,11 +287,11 @@ fn prepare_no_exec(
 fn prepare_prefetch(
     reporter_thread: &reporter::ReporterThread,
     config: &Config,
-    invocation: &CrateInvocation,
+    args: &CrateArgs,
 ) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
 
-    let label = invocation
+    let label = args
         .crate_spec
         .as_deref()
         .or_else(|| crate_spec.configured_tool_name())
@@ -328,9 +315,9 @@ fn prepare_prefetch(
 fn prepare_list_targets(
     reporter_thread: &reporter::ReporterThread,
     config: &Config,
-    invocation: &CrateInvocation,
+    args: &CrateArgs,
 ) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, invocation)?;
+    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
     let (crate_name, default, bins, examples) = cgx.list_targets(&crate_spec, &build_options)?;
 
     Ok(Command::ListTargets {

--- a/cgx/src/lib.rs
+++ b/cgx/src/lib.rs
@@ -1,10 +1,7 @@
 pub mod logging;
 mod reporter;
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    ffi::OsString,
-};
+use std::ffi::OsString;
 
 /// **INTERNAL - DO NOT USE IN PRODUCTION CODE**
 ///
@@ -14,11 +11,9 @@ use std::{
 #[doc(hidden)]
 pub use cgx_core::messages;
 use cgx_core::{
-    Target,
-    builder::BuildOptions,
+    Cgx, Target,
     cli::{Cli, CrateArgs, MessageFormat, PrefetchAll},
     config::Config,
-    cratespec::{CrateRequest, CrateSpec},
     error,
 };
 // Re-export key types from cgx-core for convenience
@@ -50,71 +45,16 @@ pub fn cgx_main() -> Result<()> {
     let json_mode = matches!(cli.message_format(), Some(MessageFormat::Json));
     let reporter_thread = reporter::ReporterThread::spawn(json_mode);
 
-    // Decode and prepare the command that the user wants to execute. This is where the heavy
-    // lifting happens.
-    let result = match &cli {
-        Cli::ListTargets(args) => prepare_list_targets(&reporter_thread, &config, args),
-        Cli::ListTools(_) => prepare_list_tools(&reporter_thread, &config),
-        Cli::Prefetch(args) => prepare_prefetch(&reporter_thread, &config, args),
-        Cli::PrefetchAll(prefetch_all) => prepare_prefetch_all(&reporter_thread, &config, prefetch_all),
-        Cli::NoExec(args) => prepare_no_exec(&reporter_thread, &config, args),
-        Cli::Run { args, tool_args } => prepare_run(&reporter_thread, &config, args, tool_args.clone()),
-    };
+    // Decode and prepare the command the user wants to run. This is where the heavy lifting
+    // happens; the result is a `Command` describing what to print or execute.
+    let result = Command::try_from_cli(&cli, &reporter_thread, &config);
 
     // Success or failure, there will be no more messages produced after this point, so join the
-    // reporter thread to make sure we've processed any that were emitted before we proceed
+    // reporter thread to make sure we've processed any that were emitted before we proceed.
     reporter_thread.join();
 
-    match result? {
-        Command::NoExec { bin_path } => {
-            // Print path to stdout for scripting (e.g., binary=$(cgx --no-exec tool))
-            println!("{}", bin_path.display());
-            Ok(())
-        }
-        Command::Execute {
-            bin_path,
-            binary_args,
-        } => {
-            // Run the binary - this function never returns on success
-            // It either replaces the process (Unix) or exits with the child's code (Windows)
-            cgx_core::runner::run(&bin_path, &binary_args)
-        }
-        Command::ListTargets {
-            crate_name,
-            default,
-            bins,
-            examples,
-        } => {
-            // Ensure there are executable targets
-            if bins.is_empty() && examples.is_empty() {
-                return error::NoPackageBinariesSnafu { krate: crate_name }.fail();
-            }
-
-            println!(
-                "default_run: {}",
-                default
-                    .map(|target| target.name)
-                    .as_deref()
-                    .unwrap_or("<not set>")
-            );
-            // Print bins with default indication
-            for bin in bins {
-                println!("bin: {}", bin.name);
-            }
-
-            // Print examples
-            for example in examples {
-                println!("example: {}", example.name);
-            }
-
-            Ok(())
-        }
-        Command::ListTools { toml } => {
-            print!("{}", toml);
-            Ok(())
-        }
-        Command::Prefetched => Ok(()),
-    }
+    let command = result?;
+    command.execute()
 }
 
 /// Build the version string shown by `-V`/`--version`.
@@ -158,296 +98,146 @@ enum Command {
     Prefetched,
 }
 
-fn prepare_list_tools(reporter_thread: &reporter::ReporterThread, config: &Config) -> Result<Command> {
-    let reporter = reporter_thread.message_reporter();
-
-    let mut tools: Vec<_> = config.tools.iter().collect();
-    tools.sort_by(|(left, _), (right, _)| left.cmp(right));
-    for (name, tool_config) in tools {
-        reporter.report(|| messages::RunnerMessage::list_tool(name, tool_config));
-    }
-
-    let mut aliases: Vec<_> = config.aliases.iter().collect();
-    aliases.sort_by(|(left, _), (right, _)| left.cmp(right));
-    for (name, target) in aliases {
-        reporter.report(|| messages::RunnerMessage::list_alias(name, target));
-    }
-
-    Ok(Command::ListTools {
-        toml: config.tools_toml()?,
-    })
-}
-
-fn prepare_prefetch_all(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    prefetch_all: &PrefetchAll,
-) -> Result<Command> {
-    let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
-    let tools = configured_tools(config);
-    let reporter = reporter_thread.message_reporter();
-    let mut failures = Vec::new();
-
-    for tool in tools {
-        reporter.report(|| messages::RunnerMessage::prefetch_all_started(&tool.name, &tool.aliases));
-
-        let result = prefetch_tool(&cgx, config, prefetch_all, &tool);
-        match result {
-            Ok(bin_path) => {
-                reporter.report(|| {
-                    messages::RunnerMessage::prefetch_all_completed(&tool.name, &tool.aliases, &bin_path)
-                });
+impl Command {
+    /// Execute the prepared command: run the binary, or print the resolved path, the crate's
+    /// targets, or the configured-tools TOML.
+    fn execute(self) -> Result<()> {
+        match self {
+            Command::NoExec { bin_path } => {
+                // Print path to stdout for scripting (e.g., binary=$(cgx --no-exec tool))
+                println!("{}", bin_path.display());
+                Ok(())
             }
-            Err(err) => {
-                reporter
-                    .report(|| messages::RunnerMessage::prefetch_all_failed(&tool.name, &tool.aliases, &err));
-                failures.push(format!("{}: {}", tool.name, err));
+            Command::Execute {
+                bin_path,
+                binary_args,
+            } => {
+                // Run the binary - never returns on success. It either replaces the process
+                // (Unix) or exits with the child's code (Windows).
+                cgx_core::runner::run(&bin_path, &binary_args)
             }
+            Command::ListTargets {
+                crate_name,
+                default,
+                bins,
+                examples,
+            } => {
+                // Ensure there are executable targets
+                if bins.is_empty() && examples.is_empty() {
+                    return error::NoPackageBinariesSnafu { krate: crate_name }.fail();
+                }
+
+                println!(
+                    "default_run: {}",
+                    default
+                        .map(|target| target.name)
+                        .as_deref()
+                        .unwrap_or("<not set>")
+                );
+                for bin in bins {
+                    println!("bin: {}", bin.name);
+                }
+                for example in examples {
+                    println!("example: {}", example.name);
+                }
+
+                Ok(())
+            }
+            Command::ListTools { toml } => {
+                print!("{}", toml);
+                Ok(())
+            }
+            Command::Prefetched => Ok(()),
         }
     }
 
-    if failures.is_empty() {
+    /// Decode the parsed CLI into the command to run, performing all resolution/build work and
+    /// emitting progress messages, but without executing or printing anything yet.
+    fn try_from_cli(
+        cli: &Cli,
+        reporter_thread: &reporter::ReporterThread,
+        config: &Config,
+    ) -> Result<Command> {
+        let cgx = Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
+
+        match cli {
+            Cli::ListTargets(args) => Self::list_targets(cgx, args),
+            Cli::ListTools(_) => Self::list_tools(cgx),
+            Cli::Prefetch(args) => Self::prefetch(cgx, args),
+            Cli::PrefetchAll(prefetch_all) => Self::prefetch_all(cgx, prefetch_all),
+            Cli::NoExec(args) => Self::no_exec(cgx, reporter_thread, args),
+            Cli::Run { args, tool_args } => Self::run(cgx, reporter_thread, args, tool_args.clone()),
+        }
+    }
+
+    fn list_tools(cgx: Cgx) -> Result<Command> {
+        let toml = cgx.list_configured_tools()?;
+        Ok(Command::ListTools { toml })
+    }
+
+    fn prefetch_all(cgx: Cgx, prefetch_all: &PrefetchAll) -> Result<Command> {
+        cgx.prefetch_all(&prefetch_all.to_build_overrides())?;
         Ok(Command::Prefetched)
-    } else {
-        error::PrefetchAllFailedSnafu { failures }.fail()
-    }
-}
-
-/// One distinct tool referenced by the configuration: the alias-resolved tool name plus the
-/// configured names that map to it. `--prefetch-all` prefetches each of these exactly once.
-#[derive(Debug, PartialEq, Eq)]
-struct ConfiguredTool {
-    /// The alias-resolved tool name, reported as `tool` in the prefetch-all messages.
-    name: String,
-    /// The other configured names that resolve to this tool, sorted, excluding the name itself.
-    aliases: Vec<String>,
-    /// The configured name to load the crate spec with. Any grouped name loads the same crate,
-    /// and using a configured name (rather than the resolved one) keeps [`CrateSpec::load`]'s
-    /// single-step alias resolution identical to a direct `cgx <name>` invocation.
-    request: String,
-}
-
-/// Group every configured tool and alias by the tool it resolves to, applying the same
-/// single-step alias resolution as [`CrateSpec::load`].
-fn configured_tools(config: &Config) -> Vec<ConfiguredTool> {
-    let mut groups: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
-    for name in config.tools.keys().chain(config.aliases.keys()) {
-        let resolved = config.aliases.get(name).unwrap_or(name);
-        groups.entry(resolved.clone()).or_default().insert(name.clone());
     }
 
-    groups
-        .into_iter()
-        .map(|(name, members)| {
-            let request = members.first().cloned().unwrap();
-            let aliases = members.into_iter().filter(|member| *member != name).collect();
-            ConfiguredTool {
-                name,
-                aliases,
-                request,
-            }
+    /// Prepare and execute a crate, forwarding `tool_args` to the executed binary.
+    fn run(
+        cgx: Cgx,
+        reporter_thread: &reporter::ReporterThread,
+        args: &CrateArgs,
+        tool_args: Vec<OsString>,
+    ) -> Result<Command> {
+        let bin_path = cgx.prepare_bin_crate(&args.crate_request()?, &args.to_build_overrides())?;
+
+        reporter_thread
+            .message_reporter()
+            .report(|| messages::RunnerMessage::execution_plan(&bin_path, &tool_args, false));
+
+        Ok(Command::Execute {
+            bin_path,
+            binary_args: tool_args,
         })
-        .collect()
-}
-
-fn prefetch_tool(
-    cgx: &cgx_core::Cgx,
-    config: &Config,
-    prefetch_all: &PrefetchAll,
-    configured_tool: &ConfiguredTool,
-) -> Result<std::path::PathBuf> {
-    let crate_spec = CrateSpec::load(
-        config,
-        &CrateRequest::for_configured_tool(&configured_tool.request),
-    )?;
-    let build_options =
-        BuildOptions::load_for_crate(config, &prefetch_all.to_build_overrides(), &crate_spec)?;
-
-    cgx.crate_to_bin(&crate_spec, &build_options)
-}
-
-/// Resolve a single set of crate arguments into a [`cgx_core::Cgx`] engine plus its crate spec and
-/// build options, for use by multiple commands that need a `Cgx` instance to operate on a specific
-/// crate.
-fn prepare_engine(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    args: &CrateArgs,
-) -> Result<(cgx_core::Cgx, CrateSpec, BuildOptions)> {
-    let crate_spec = CrateSpec::load(config, &args.crate_request()?)?;
-    let build_options = BuildOptions::load_for_crate(config, &args.to_build_overrides(), &crate_spec)?;
-    let cgx = cgx_core::Cgx::new(config.clone(), reporter_thread.message_reporter().clone())?;
-
-    Ok((cgx, crate_spec, build_options))
-}
-
-/// Prepare and execute a crate, forwarding `tool_args` to the executed binary.
-fn prepare_run(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    args: &CrateArgs,
-    tool_args: Vec<OsString>,
-) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
-    let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
-
-    reporter_thread
-        .message_reporter()
-        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &tool_args, false));
-
-    Ok(Command::Execute {
-        bin_path,
-        binary_args: tool_args,
-    })
-}
-
-/// Prepare a crate without executing it, printing the resolved binary path to stdout.
-fn prepare_no_exec(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    args: &CrateArgs,
-) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
-    let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
-
-    let no_args: Vec<OsString> = Vec::new();
-    reporter_thread
-        .message_reporter()
-        .report(|| messages::RunnerMessage::execution_plan(&bin_path, &no_args, true));
-
-    Ok(Command::NoExec { bin_path })
-}
-
-/// Prepare a crate without executing it or printing its path.
-fn prepare_prefetch(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    args: &CrateArgs,
-) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
-
-    let label = args
-        .crate_spec
-        .as_deref()
-        .or_else(|| crate_spec.configured_tool_name())
-        .unwrap_or("<source>")
-        .to_string();
-
-    reporter_thread
-        .message_reporter()
-        .report(|| messages::RunnerMessage::prefetch_started(&label));
-
-    let bin_path = cgx.crate_to_bin(&crate_spec, &build_options)?;
-
-    reporter_thread
-        .message_reporter()
-        .report(|| messages::RunnerMessage::prefetch_completed(&label, &bin_path));
-
-    Ok(Command::Prefetched)
-}
-
-/// Resolve a crate and list its runnable targets without building or executing.
-fn prepare_list_targets(
-    reporter_thread: &reporter::ReporterThread,
-    config: &Config,
-    args: &CrateArgs,
-) -> Result<Command> {
-    let (cgx, crate_spec, build_options) = prepare_engine(reporter_thread, config, args)?;
-    let (crate_name, default, bins, examples) = cgx.list_targets(&crate_spec, &build_options)?;
-
-    Ok(Command::ListTargets {
-        crate_name,
-        default,
-        bins,
-        examples,
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use cgx_core::config::ToolConfig;
-
-    use super::*;
-
-    fn config_with(tools: &[&str], aliases: &[(&str, &str)]) -> Config {
-        let mut config = Config::default();
-        for &tool in tools {
-            config
-                .tools
-                .insert(tool.to_string(), ToolConfig::Version("*".to_string()));
-        }
-        for &(name, target) in aliases {
-            config.aliases.insert(name.to_string(), target.to_string());
-        }
-        config
     }
 
-    #[test]
-    fn tool_with_alias_yields_single_entry() {
-        let config = config_with(&["eza"], &[("e", "eza")]);
-        assert_eq!(
-            configured_tools(&config),
-            [ConfiguredTool {
-                name: "eza".to_string(),
-                aliases: vec!["e".to_string()],
-                request: "e".to_string(),
-            }]
-        );
+    /// Prepare a crate without executing it, printing the resolved binary path to stdout.
+    fn no_exec(cgx: Cgx, reporter_thread: &reporter::ReporterThread, args: &CrateArgs) -> Result<Command> {
+        let bin_path = cgx.prepare_bin_crate(&args.crate_request()?, &args.to_build_overrides())?;
+
+        let no_args: Vec<OsString> = Vec::new();
+        reporter_thread
+            .message_reporter()
+            .report(|| messages::RunnerMessage::execution_plan(&bin_path, &no_args, true));
+
+        Ok(Command::NoExec { bin_path })
     }
 
-    #[test]
-    fn alias_to_unconfigured_crate_yields_its_target_tool() {
-        let config = config_with(&[], &[("x", "ripgrep")]);
-        assert_eq!(
-            configured_tools(&config),
-            [ConfiguredTool {
-                name: "ripgrep".to_string(),
-                aliases: vec!["x".to_string()],
-                request: "x".to_string(),
-            }]
-        );
+    /// Prepare a crate without executing it or printing its path.
+    fn prefetch(cgx: Cgx, args: &CrateArgs) -> Result<Command> {
+        let request = args.crate_request()?;
+
+        // Prefer the raw CLI spec (e.g. `ripgrep@1.0`) for the label; otherwise the resolved request
+        // name; otherwise a source-only invocation with no name to show.
+        let label = args
+            .crate_spec
+            .clone()
+            .or_else(|| request.name.clone())
+            .unwrap_or_else(|| "<source>".to_string());
+
+        cgx.prefetch(&label, &request, &args.to_build_overrides())?;
+
+        Ok(Command::Prefetched)
     }
 
-    #[test]
-    fn multiple_aliases_group_under_one_tool() {
-        let config = config_with(&["eza"], &[("e", "eza"), ("ez", "eza")]);
-        assert_eq!(
-            configured_tools(&config),
-            [ConfiguredTool {
-                name: "eza".to_string(),
-                aliases: vec!["e".to_string(), "ez".to_string()],
-                request: "e".to_string(),
-            }]
-        );
-    }
+    /// Resolve a crate and list its runnable targets without building or executing.
+    fn list_targets(cgx: Cgx, args: &CrateArgs) -> Result<Command> {
+        let (crate_name, default, bins, examples) =
+            cgx.list_targets(&args.crate_request()?, &args.to_build_overrides())?;
 
-    #[test]
-    fn tools_are_deterministically_ordered() {
-        let config = config_with(&["zoxide", "eza"], &[("a", "zoxide")]);
-        let names: Vec<_> = configured_tools(&config)
-            .into_iter()
-            .map(|tool| tool.name)
-            .collect();
-        assert_eq!(names, ["eza", "zoxide"]);
-    }
-
-    #[test]
-    fn independent_tools_remain_separate() {
-        let config = config_with(&["eza", "ripgrep"], &[]);
-        assert_eq!(
-            configured_tools(&config),
-            [
-                ConfiguredTool {
-                    name: "eza".to_string(),
-                    aliases: Vec::new(),
-                    request: "eza".to_string(),
-                },
-                ConfiguredTool {
-                    name: "ripgrep".to_string(),
-                    aliases: Vec::new(),
-                    request: "ripgrep".to_string(),
-                },
-            ]
-        );
+        Ok(Command::ListTargets {
+            crate_name,
+            default,
+            bins,
+            examples,
+        })
     }
 }

--- a/cgx/src/logging.rs
+++ b/cgx/src/logging.rs
@@ -1,5 +1,6 @@
 use std::{io::IsTerminal, sync::OnceLock};
 
+use cgx_core::config::Verbosity;
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*, reload};
 
@@ -45,12 +46,12 @@ static RELOAD_HANDLE: OnceLock<ReloadHandle> = OnceLock::new();
 ///
 /// This function will panic if called more than once in the same process, as the
 /// global tracing subscriber can only be initialized once.
-pub(crate) fn init(verbose: u8) {
-    let (level, use_simple_format) = match verbose {
-        0 => (Level::WARN, true),
-        1 => (Level::INFO, false),
-        2 => (Level::DEBUG, false),
-        _ => (Level::TRACE, false),
+pub(crate) fn init(verbosity: Verbosity) {
+    let (level, use_simple_format) = match verbosity {
+        Verbosity::Normal => (Level::WARN, true),
+        Verbosity::Verbose => (Level::INFO, false),
+        Verbosity::VeryVerbose => (Level::DEBUG, false),
+        Verbosity::ExtremelyVerbose => (Level::TRACE, false),
     };
 
     // Build the filter by checking environment variables in priority order
@@ -59,7 +60,7 @@ pub(crate) fn init(verbose: u8) {
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| {
             // Neither env var set, use hard-coded default based on verbosity
-            if verbose == 0 {
+            if verbosity == Verbosity::Normal {
                 // For silent mode, only show WARN and ERROR
                 EnvFilter::new("warn")
             } else {
@@ -111,14 +112,14 @@ pub(crate) fn init(verbose: u8) {
 /// the config file. It respects the following priority order:
 /// 1. `CGX_LOG` environment variable (highest priority, checked at init time)
 /// 2. `RUST_LOG` environment variable (checked at init time)
-/// 3. CLI `-v` flags (if user specified verbosity, don't override)
+/// 3. CLI `-v` flags (if [`Config::verbosity`] is non-default, don't override)
 /// 4. `Config.log_level` field (applied by this function)
 /// 5. Hard-coded defaults (lowest priority, set at init time)
 ///
 /// # Arguments
 ///
-/// * `config` - The loaded configuration containing the optional `log_level` field
-/// * `args` - The CLI arguments to check if user explicitly set verbosity
+/// * `config` - The loaded configuration, carrying both the [`Config::verbosity`] level (to check
+///   whether the user requested verbosity via `-v`) and the optional `log_level` filter string
 ///
 /// # Log Level Format
 ///
@@ -130,9 +131,9 @@ pub(crate) fn init(verbose: u8) {
 /// - `"error"` - Errors only
 ///
 /// More complex filter syntax is also supported (e.g., `"cgx=debug,info"`).
-pub(crate) fn apply_config(config: &Config, verbose: u8) {
+pub(crate) fn apply_config(config: &Config) {
     // Don't override if user explicitly set verbosity via CLI
-    if verbose > 0 {
+    if config.verbosity != Verbosity::Normal {
         tracing::debug!("Not applying config log_level: CLI verbosity flag takes precedence");
         return;
     }

--- a/cgx/src/logging.rs
+++ b/cgx/src/logging.rs
@@ -3,7 +3,7 @@ use std::{io::IsTerminal, sync::OnceLock};
 use tracing::Level;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*, reload};
 
-use crate::{CliArgs, Config};
+use crate::Config;
 
 /// Default tracing filter expression for INFO level logging.
 ///
@@ -45,8 +45,8 @@ static RELOAD_HANDLE: OnceLock<ReloadHandle> = OnceLock::new();
 ///
 /// This function will panic if called more than once in the same process, as the
 /// global tracing subscriber can only be initialized once.
-pub(crate) fn init(args: &CliArgs) {
-    let (level, use_simple_format) = match args.verbose {
+pub(crate) fn init(verbose: u8) {
+    let (level, use_simple_format) = match verbose {
         0 => (Level::WARN, true),
         1 => (Level::INFO, false),
         2 => (Level::DEBUG, false),
@@ -59,7 +59,7 @@ pub(crate) fn init(args: &CliArgs) {
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| {
             // Neither env var set, use hard-coded default based on verbosity
-            if args.verbose == 0 {
+            if verbose == 0 {
                 // For silent mode, only show WARN and ERROR
                 EnvFilter::new("warn")
             } else {
@@ -130,9 +130,9 @@ pub(crate) fn init(args: &CliArgs) {
 /// - `"error"` - Errors only
 ///
 /// More complex filter syntax is also supported (e.g., `"cgx=debug,info"`).
-pub(crate) fn apply_config(config: &Config, args: &CliArgs) {
+pub(crate) fn apply_config(config: &Config, verbose: u8) {
     // Don't override if user explicitly set verbosity via CLI
-    if args.verbose > 0 {
+    if verbose > 0 {
         tracing::debug!("Not applying config log_level: CLI verbosity flag takes precedence");
         return;
     }

--- a/cgx/tests/integration/basic.rs
+++ b/cgx/tests/integration/basic.rs
@@ -34,6 +34,6 @@ fn test_version_output() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicates::str::is_empty())
-        .stderr(predicates::str::is_match(r"cgx \d+\.\d+\.\d+ \([0-9a-f]{7} \d{4}-\d{2}-\d{2}\)\n").unwrap());
+        .stdout(predicates::str::is_match(r"cgx \d+\.\d+\.\d+ \([0-9a-f]{7} \d{4}-\d{2}-\d{2}\)\n").unwrap())
+        .stderr(predicates::str::is_empty());
 }

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -387,7 +387,7 @@ fn prefetch_single_tool_prepares_without_stdout() {
 }
 
 #[test]
-fn prefetch_all_covers_tools_and_alias_invocations() {
+fn prefetch_all_prefetches_each_configured_tool_once() {
     let mut cgx = Cgx::with_test_fs();
 
     cgx.test_fs()
@@ -409,25 +409,35 @@ e = "eza"
 
     assert.success().stdout(predicates::str::is_empty());
 
-    assert!(
-        messages.iter().any(|message| {
-            matches!(
-                message,
-                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "eza"
-            )
-        }),
-        "expected prefetch-all completion for configured tool"
+    // The tool and its alias resolve to the same crate, so there is exactly one prefetch, reported
+    // under the tool name with the alias listed alongside it.
+    let completions: Vec<_> = messages
+        .iter()
+        .filter_map(|message| match message {
+            Message::Runner(RunnerMessage::PrefetchAllCompleted { tool, aliases, .. }) => {
+                Some((tool.clone(), aliases.clone()))
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        completions,
+        [("eza".to_string(), vec!["e".to_string()])],
+        "expected exactly one prefetch-all completion, reporting the tool with its alias"
     );
+
     assert!(
-        messages.iter().any(|message| {
+        !messages.iter().any(|message| {
             matches!(
                 message,
-                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "e"
+                Message::Runner(
+                    RunnerMessage::PrefetchAllStarted { tool, .. }
+                        | RunnerMessage::PrefetchAllCompleted { tool, .. }
+                        | RunnerMessage::PrefetchAllFailed { tool, .. }
+                ) if tool == "e"
             )
         }),
-        "expected prefetch-all completion for alias invocation"
+        "expected no prefetch-all messages under the alias name"
     );
 }
 
@@ -460,8 +470,8 @@ eza = "=0.23.1"
         messages.iter().any(|message| {
             matches!(
                 message,
-                Message::Runner(RunnerMessage::PrefetchAllFailed { invocation, .. })
-                    if invocation == "aaa_bad"
+                Message::Runner(RunnerMessage::PrefetchAllFailed { tool, .. })
+                    if tool == "aaa_bad"
             )
         }),
         "expected prefetch-all failure for bad tool"
@@ -470,8 +480,8 @@ eza = "=0.23.1"
         messages.iter().any(|message| {
             matches!(
                 message,
-                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "eza"
+                Message::Runner(RunnerMessage::PrefetchAllCompleted { tool, .. })
+                    if tool == "eza"
             )
         }),
         "expected prefetch-all to continue after a failure"

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -289,6 +289,78 @@ eza = { version = "=0.23.1", features = ["a-config-only-feature"] }
 }
 
 #[test]
+fn config_default_features_are_honored() {
+    let mut cgx = Cgx::with_test_fs();
+
+    // `default-features = false` configured for a tool in `[tools]` must reach the resolved build
+    // plan as `no_default_features`. We assert on the `CratePlan` message via `--list-targets`
+    // (resolve + metadata, no compile) rather than running the tool.
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(
+            r#"
+[tools]
+eza = { version = "=0.23.1", default-features = false }
+"#,
+        )
+        .unwrap();
+
+    cgx.cmd.arg("--list-targets").with_json_messages().arg("eza");
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    assert.success();
+
+    let no_default_features = messages
+        .iter()
+        .find_map(|message| match message {
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.no_default_features),
+            _ => None,
+        })
+        .expect("expected a CratePlan message");
+
+    assert!(no_default_features);
+}
+
+#[test]
+fn config_default_features_and_cli_features_coexist() {
+    let mut cgx = Cgx::with_test_fs();
+
+    // Config `default-features` is independent of the feature list: passing `--features` on the CLI
+    // replaces the (here unset) configured features but leaves the configured `default-features =
+    // false` in effect, so the build plan carries both.
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(
+            r#"
+[tools]
+eza = { version = "=0.23.1", default-features = false }
+"#,
+        )
+        .unwrap();
+
+    cgx.cmd
+        .arg("--list-targets")
+        .arg("--features")
+        .arg("vendored-openssl")
+        .with_json_messages()
+        .arg("eza");
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    assert.success();
+
+    let options = messages
+        .iter()
+        .find_map(|message| match message {
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.clone()),
+            _ => None,
+        })
+        .expect("expected a CratePlan message");
+
+    assert!(options.no_default_features);
+    assert_eq!(options.features, vec!["vendored-openssl"]);
+}
+
+#[test]
 fn prefetch_single_tool_prepares_without_stdout() {
     let mut cgx = Cgx::with_test_fs();
 

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -537,20 +537,46 @@ e = "eza"
         "expected list-tools JSON message for configured alias"
     );
 
+    // Now the ultimate test of the TOML output by `--list-tools: The round-trip test.
+    //
+    // Feed the rendered TOML back into a fully isolated `cgx` (the same `with_test_fs`
+    // isolation as the rest of the suite, so a host `/etc/cgx.toml` cannot contaminate the result)
+    // and confirm the tool and alias survive re-rendering. Verify via the structured messages, not
+    // substring matches.
     let rendered_toml = String::from_utf8(output).unwrap();
-    let verify_cwd = assert_fs::TempDir::with_prefix("cgx-list-tools-verify-").unwrap();
-    let verify_home = assert_fs::TempDir::with_prefix("cgx-list-tools-home-").unwrap();
-    verify_cwd.child("cgx.toml").write_str(&rendered_toml).unwrap();
 
-    let mut verify = Cgx::find();
+    let mut verify = Cgx::with_test_fs();
     verify
-        .cmd
-        .current_dir(verify_cwd.path())
-        .env("HOME", verify_home.path())
-        .env("XDG_CONFIG_HOME", verify_home.path().join("config"))
-        .arg("--list-tools")
-        .assert()
+        .test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&rendered_toml)
+        .unwrap();
+
+    verify.cmd.arg("--list-tools").with_json_messages();
+    let (assert, messages) = verify.cmd.assert_with_messages();
+    assert
         .success()
-        .stdout(predicates::str::contains("eza"))
-        .stdout(predicates::str::contains("e"));
+        .stdout(predicates::str::contains("[tools]"))
+        .stdout(predicates::str::contains("[aliases]"));
+
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::ListTool { name, .. }) if name == "eza"
+            )
+        }),
+        "expected the re-rendered config to still list the configured tool"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::ListAlias { name, target })
+                    if name == "e" && target == "eza"
+            )
+        }),
+        "expected the re-rendered config to still list the configured alias"
+    );
 }

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -3,51 +3,11 @@
 //! These tests verify that cgx correctly loads and honors configuration from cgx.toml files,
 //! including the config hierarchy (user < cwd < CLI).
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
-
 use assert_fs::prelude::*;
-use cgx::messages::{Message, RunnerMessage};
+use cgx::messages::{CgxMessage, Message, Provenance, RunnerMessage};
 use predicates::prelude::*;
 
 use crate::utils::{Cgx, CommandExt};
-
-const TIMESTAMP_FIXTURE: &str = concat!(
-    env!("CARGO_MANIFEST_DIR"),
-    "/../cgx-core/testdata/crates/timestamp"
-);
-
-fn timestamp_fixture(cgx: &Cgx) -> PathBuf {
-    copy_timestamp_fixture(cgx.test_fs().cwd.path())
-}
-
-fn copy_timestamp_fixture(root: &Path) -> PathBuf {
-    let destination = root.join("timestamp-fixture");
-    copy_dir(Path::new(TIMESTAMP_FIXTURE), &destination);
-    destination
-}
-
-fn copy_dir(source: &Path, destination: &Path) {
-    fs::create_dir_all(destination).unwrap();
-
-    for entry in fs::read_dir(source).unwrap() {
-        let entry = entry.unwrap();
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-
-        if source_path.is_dir() {
-            copy_dir(&source_path, &destination_path);
-        } else {
-            fs::copy(&source_path, &destination_path).unwrap();
-        }
-    }
-}
-
-fn toml_path(path: &Path) -> String {
-    path.display().to_string().replace('\\', "\\\\")
-}
 
 /// Test that a cgx.toml in the cwd pins a tool version.
 ///
@@ -258,91 +218,118 @@ cargo-binstall = { git = "https://github.com/cargo-bins/cargo-binstall.git", tag
 }
 
 #[test]
-fn config_features_are_honored_for_execution() {
+fn config_features_are_honored() {
     let mut cgx = Cgx::with_test_fs();
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
+    // A feature configured for a tool in `[tools]` must reach the resolved build plan. We assert on
+    // the `CratePlan` message via `--list-targets` (resolve + metadata, no compile) rather than
+    // running the tool. `vendored-openssl` is a real `eza` feature, so resolution succeeds.
     cgx.test_fs()
         .cwd
         .child("cgx.toml")
-        .write_str(&format!(
+        .write_str(
             r#"
 [tools]
-timestamp = {{ path = "{}", features = ["frobnulator"] }}
+eza = { version = "=0.23.1", features = ["vendored-openssl"] }
 "#,
-            toml_path(&timestamp_fixture)
-        ))
+        )
         .unwrap();
 
-    cgx.cmd
-        .arg("timestamp")
-        .assert()
-        .success()
-        .stdout(predicates::str::contains(
-            "Features enabled: frobnulator, gonkolator",
-        ));
+    cgx.cmd.arg("--list-targets").with_json_messages().arg("eza");
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    assert.success();
+
+    let features = messages
+        .iter()
+        .find_map(|message| match message {
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features.clone()),
+            _ => None,
+        })
+        .expect("expected a CratePlan message");
+
+    assert_eq!(features, vec!["vendored-openssl"]);
 }
 
 #[test]
-fn cli_features_replace_config_features_for_execution() {
+fn cli_features_replace_config_features() {
     let mut cgx = Cgx::with_test_fs();
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
+    // `--features` on the CLI replaces (does not merge with) the configured tool features, so only
+    // the CLI feature reaches the build plan. The configured feature is never applied, so it need
+    // not be a real `eza` feature.
     cgx.test_fs()
         .cwd
         .child("cgx.toml")
-        .write_str(&format!(
+        .write_str(
             r#"
 [tools]
-timestamp = {{ path = "{}", features = ["frobnulator"] }}
+eza = { version = "=0.23.1", features = ["a-config-only-feature"] }
 "#,
-            toml_path(&timestamp_fixture)
-        ))
+        )
         .unwrap();
 
     cgx.cmd
+        .arg("--list-targets")
         .arg("--features")
-        .arg("gonkolator")
-        .arg("timestamp")
-        .assert()
-        .success()
-        .stdout(predicates::str::contains("Features enabled: gonkolator"))
-        .stdout(predicates::str::contains("frobnulator").not());
+        .arg("vendored-openssl")
+        .with_json_messages()
+        .arg("eza");
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    assert.success();
+
+    let features = messages
+        .iter()
+        .find_map(|message| match message {
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features.clone()),
+            _ => None,
+        })
+        .expect("expected a CratePlan message");
+    assert_eq!(features, vec!["vendored-openssl"]);
+    assert!(!features.contains(&"a-config-only-feature".to_string()));
 }
 
 #[test]
 fn prefetch_single_tool_prepares_without_stdout() {
     let mut cgx = Cgx::with_test_fs();
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
-    cgx.cmd
-        .arg("--prefetch")
-        .arg("--path")
-        .arg(&timestamp_fixture)
-        .arg("timestamp")
-        .assert()
-        .success()
-        .stdout(predicates::str::is_empty());
+    // Default options leave a pre-built binary eligible, so this prepares `eza` without compiling.
+    cgx.cmd.arg("--prefetch").with_json_messages().arg("eza@=0.23.1");
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    assert.success().stdout(predicates::str::is_empty());
+
+    // Preparing the crate emits a provenance message recording how (and where) the binary was obtained.
+    let binary_path = messages
+        .iter()
+        .find_map(|message| match message {
+            Message::Cgx(CgxMessage::CrateProvenance {
+                provenance: Provenance::Prebuilt { binary_path, .. },
+                ..
+            }) => Some(binary_path.clone()),
+            _ => None,
+        })
+        .expect("expected a CrateProvenance message reporting a pre-built binary");
+    assert!(
+        !binary_path.as_os_str().is_empty(),
+        "prebuilt provenance should report the binary path"
+    );
 }
 
 #[test]
 fn prefetch_all_covers_tools_and_alias_invocations() {
     let mut cgx = Cgx::with_test_fs();
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
     cgx.test_fs()
         .cwd
         .child("cgx.toml")
-        .write_str(&format!(
+        .write_str(
             r#"
 [tools]
-timestamp = {{ path = "{}" }}
+eza = "=0.23.1"
 
 [aliases]
-ts = "timestamp"
+e = "eza"
 "#,
-            toml_path(&timestamp_fixture)
-        ))
+        )
         .unwrap();
 
     cgx.cmd.arg("--prefetch-all").with_json_messages();
@@ -355,7 +342,7 @@ ts = "timestamp"
             matches!(
                 message,
                 Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "timestamp"
+                    if invocation == "eza"
             )
         }),
         "expected prefetch-all completion for configured tool"
@@ -365,7 +352,7 @@ ts = "timestamp"
             matches!(
                 message,
                 Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "ts"
+                    if invocation == "e"
             )
         }),
         "expected prefetch-all completion for alias invocation"
@@ -376,8 +363,9 @@ ts = "timestamp"
 fn prefetch_all_continues_after_failures_and_exits_nonzero() {
     let mut cgx = Cgx::with_test_fs();
     let missing_path = cgx.test_fs().cwd.child("missing");
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
+    // `aaa_bad` points at a missing path so it fails deterministically (no network); `eza` still
+    // resolves, and the overall command exits non-zero.
     cgx.test_fs()
         .cwd
         .child("cgx.toml")
@@ -385,10 +373,9 @@ fn prefetch_all_continues_after_failures_and_exits_nonzero() {
             r#"
 [tools]
 aaa_bad = {{ path = "{}" }}
-timestamp = {{ path = "{}" }}
+eza = "=0.23.1"
 "#,
-            toml_path(missing_path.path()),
-            toml_path(&timestamp_fixture)
+            missing_path.display().to_string().replace('\\', "\\\\"),
         ))
         .unwrap();
 
@@ -412,7 +399,7 @@ timestamp = {{ path = "{}" }}
             matches!(
                 message,
                 Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
-                    if invocation == "timestamp"
+                    if invocation == "eza"
             )
         }),
         "expected prefetch-all to continue after a failure"
@@ -422,21 +409,20 @@ timestamp = {{ path = "{}" }}
 #[test]
 fn list_tools_outputs_valid_toml_and_json_messages() {
     let mut cgx = Cgx::with_test_fs();
-    let timestamp_fixture = timestamp_fixture(&cgx);
 
+    // `--list-tools` only renders the merged config, so no crate is resolved or built.
     cgx.test_fs()
         .cwd
         .child("cgx.toml")
-        .write_str(&format!(
+        .write_str(
             r#"
 [tools]
-timestamp = {{ path = "{}", features = ["frobnulator"] }}
+eza = { version = "=0.23.1", features = ["vendored-openssl"] }
 
 [aliases]
-ts = "timestamp"
+e = "eza"
 "#,
-            toml_path(&timestamp_fixture)
-        ))
+        )
         .unwrap();
 
     cgx.cmd.arg("--list-tools").with_json_messages();
@@ -453,7 +439,7 @@ ts = "timestamp"
         messages.iter().any(|message| {
             matches!(
                 message,
-                Message::Runner(RunnerMessage::ListTool { name, .. }) if name == "timestamp"
+                Message::Runner(RunnerMessage::ListTool { name, .. }) if name == "eza"
             )
         }),
         "expected list-tools JSON message for configured tool"
@@ -463,7 +449,7 @@ ts = "timestamp"
             matches!(
                 message,
                 Message::Runner(RunnerMessage::ListAlias { name, target })
-                    if name == "ts" && target == "timestamp"
+                    if name == "e" && target == "eza"
             )
         }),
         "expected list-tools JSON message for configured alias"
@@ -483,6 +469,6 @@ ts = "timestamp"
         .arg("--list-tools")
         .assert()
         .success()
-        .stdout(predicates::str::contains("timestamp"))
-        .stdout(predicates::str::contains("ts"));
+        .stdout(predicates::str::contains("eza"))
+        .stdout(predicates::str::contains("e"));
 }

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -3,10 +3,51 @@
 //! These tests verify that cgx correctly loads and honors configuration from cgx.toml files,
 //! including the config hierarchy (user < cwd < CLI).
 
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
 use assert_fs::prelude::*;
+use cgx::messages::{Message, RunnerMessage};
 use predicates::prelude::*;
 
-use crate::utils::Cgx;
+use crate::utils::{Cgx, CommandExt};
+
+const TIMESTAMP_FIXTURE: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../cgx-core/testdata/crates/timestamp"
+);
+
+fn timestamp_fixture(cgx: &Cgx) -> PathBuf {
+    copy_timestamp_fixture(cgx.test_fs().cwd.path())
+}
+
+fn copy_timestamp_fixture(root: &Path) -> PathBuf {
+    let destination = root.join("timestamp-fixture");
+    copy_dir(Path::new(TIMESTAMP_FIXTURE), &destination);
+    destination
+}
+
+fn copy_dir(source: &Path, destination: &Path) {
+    fs::create_dir_all(destination).unwrap();
+
+    for entry in fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+
+        if source_path.is_dir() {
+            copy_dir(&source_path, &destination_path);
+        } else {
+            fs::copy(&source_path, &destination_path).unwrap();
+        }
+    }
+}
+
+fn toml_path(path: &Path) -> String {
+    path.display().to_string().replace('\\', "\\\\")
+}
 
 /// Test that a cgx.toml in the cwd pins a tool version.
 ///
@@ -214,4 +255,234 @@ cargo-binstall = { git = "https://github.com/cargo-bins/cargo-binstall.git", tag
         .assert()
         .success()
         .stdout(predicates::str::contains("cargo-binstall-1.14.0"));
+}
+
+#[test]
+fn config_features_are_honored_for_execution() {
+    let mut cgx = Cgx::with_test_fs();
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&format!(
+            r#"
+[tools]
+timestamp = {{ path = "{}", features = ["frobnulator"] }}
+"#,
+            toml_path(&timestamp_fixture)
+        ))
+        .unwrap();
+
+    cgx.cmd
+        .arg("timestamp")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "Features enabled: frobnulator, gonkolator",
+        ));
+}
+
+#[test]
+fn cli_features_replace_config_features_for_execution() {
+    let mut cgx = Cgx::with_test_fs();
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&format!(
+            r#"
+[tools]
+timestamp = {{ path = "{}", features = ["frobnulator"] }}
+"#,
+            toml_path(&timestamp_fixture)
+        ))
+        .unwrap();
+
+    cgx.cmd
+        .arg("--features")
+        .arg("gonkolator")
+        .arg("timestamp")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Features enabled: gonkolator"))
+        .stdout(predicates::str::contains("frobnulator").not());
+}
+
+#[test]
+fn prefetch_single_tool_prepares_without_stdout() {
+    let mut cgx = Cgx::with_test_fs();
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.cmd
+        .arg("--prefetch")
+        .arg("--path")
+        .arg(&timestamp_fixture)
+        .arg("timestamp")
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+#[test]
+fn prefetch_all_covers_tools_and_alias_invocations() {
+    let mut cgx = Cgx::with_test_fs();
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&format!(
+            r#"
+[tools]
+timestamp = {{ path = "{}" }}
+
+[aliases]
+ts = "timestamp"
+"#,
+            toml_path(&timestamp_fixture)
+        ))
+        .unwrap();
+
+    cgx.cmd.arg("--prefetch-all").with_json_messages();
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+
+    assert.success().stdout(predicates::str::is_empty());
+
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
+                    if invocation == "timestamp"
+            )
+        }),
+        "expected prefetch-all completion for configured tool"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
+                    if invocation == "ts"
+            )
+        }),
+        "expected prefetch-all completion for alias invocation"
+    );
+}
+
+#[test]
+fn prefetch_all_continues_after_failures_and_exits_nonzero() {
+    let mut cgx = Cgx::with_test_fs();
+    let missing_path = cgx.test_fs().cwd.child("missing");
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&format!(
+            r#"
+[tools]
+aaa_bad = {{ path = "{}" }}
+timestamp = {{ path = "{}" }}
+"#,
+            toml_path(missing_path.path()),
+            toml_path(&timestamp_fixture)
+        ))
+        .unwrap();
+
+    cgx.cmd.arg("--prefetch-all").with_json_messages();
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+
+    assert.failure();
+
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::PrefetchAllFailed { invocation, .. })
+                    if invocation == "aaa_bad"
+            )
+        }),
+        "expected prefetch-all failure for bad tool"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::PrefetchAllCompleted { invocation, .. })
+                    if invocation == "timestamp"
+            )
+        }),
+        "expected prefetch-all to continue after a failure"
+    );
+}
+
+#[test]
+fn list_tools_outputs_valid_toml_and_json_messages() {
+    let mut cgx = Cgx::with_test_fs();
+    let timestamp_fixture = timestamp_fixture(&cgx);
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(&format!(
+            r#"
+[tools]
+timestamp = {{ path = "{}", features = ["frobnulator"] }}
+
+[aliases]
+ts = "timestamp"
+"#,
+            toml_path(&timestamp_fixture)
+        ))
+        .unwrap();
+
+    cgx.cmd.arg("--list-tools").with_json_messages();
+    let (assert, messages) = cgx.cmd.assert_with_messages();
+    let output = assert
+        .success()
+        .stdout(predicates::str::contains("[tools]"))
+        .stdout(predicates::str::contains("[aliases]"))
+        .get_output()
+        .stdout
+        .clone();
+
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::ListTool { name, .. }) if name == "timestamp"
+            )
+        }),
+        "expected list-tools JSON message for configured tool"
+    );
+    assert!(
+        messages.iter().any(|message| {
+            matches!(
+                message,
+                Message::Runner(RunnerMessage::ListAlias { name, target })
+                    if name == "ts" && target == "timestamp"
+            )
+        }),
+        "expected list-tools JSON message for configured alias"
+    );
+
+    let rendered_toml = String::from_utf8(output).unwrap();
+    let verify_cwd = assert_fs::TempDir::with_prefix("cgx-list-tools-verify-").unwrap();
+    let verify_home = assert_fs::TempDir::with_prefix("cgx-list-tools-home-").unwrap();
+    verify_cwd.child("cgx.toml").write_str(&rendered_toml).unwrap();
+
+    let mut verify = Cgx::find();
+    verify
+        .cmd
+        .current_dir(verify_cwd.path())
+        .env("HOME", verify_home.path())
+        .env("XDG_CONFIG_HOME", verify_home.path().join("config"))
+        .arg("--list-tools")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("timestamp"))
+        .stdout(predicates::str::contains("ts"));
 }

--- a/cgx/tests/integration/defaults.rs
+++ b/cgx/tests/integration/defaults.rs
@@ -4,7 +4,7 @@ use cgx::messages::{
 };
 use predicates::prelude::*;
 
-use crate::utils::{Cgx, CommandExt, assert_built_from_source, assert_prebuilt};
+use crate::utils::{Cgx, CommandExt, assert_compiled_from_source, assert_prebuilt};
 
 /// Test running a crate that publishes pre-built binaries (eza).
 ///
@@ -181,7 +181,7 @@ fn messages_without_prebuilt_binary() {
             .any(|m| matches!(m, Message::BuildCache(BuildCacheMessage::CacheMiss { .. }))),
         "Expected BuildCache::CacheMiss on first run (building from source)"
     );
-    assert_built_from_source(&messages);
+    assert_compiled_from_source(&messages);
 
     // Second invocation should hit all caches
     let mut cgx = cgx.reset();

--- a/cgx/tests/integration/defaults.rs
+++ b/cgx/tests/integration/defaults.rs
@@ -1,11 +1,10 @@
 //! Tests that do not override any config settings and verify the default behavior of cgx
-
 use cgx::messages::{
     BuildCacheMessage, CrateResolutionMessage, Message, PrebuiltBinaryMessage, RunnerMessage, SourceMessage,
 };
 use predicates::prelude::*;
 
-use crate::utils::{Cgx, CommandExt};
+use crate::utils::{Cgx, CommandExt, assert_built_from_source, assert_prebuilt};
 
 /// Test running a crate that publishes pre-built binaries (eza).
 ///
@@ -19,8 +18,7 @@ use crate::utils::{Cgx, CommandExt};
 fn run_with_prebuilt_binary() {
     let mut cgx = Cgx::with_test_fs();
 
-    // First invocation should download eza pre-built binary
-    // Should NOT see "Compiling" since we're using a pre-built binary
+    // First invocation should download and run the eza pre-built binary
     cgx.cmd
         .arg("eza@=0.23.1")
         .arg("--version")
@@ -60,8 +58,7 @@ https://github.com/eza-community/eza
 fn run_without_prebuilt_binary() {
     let mut cgx = Cgx::with_test_fs();
 
-    // First invocation should build from source since cargo-expand doesn't publish binaries
-    // Should see "Compiling" in stderr
+    // First invocation should build from source since cargo-expand doesn't publish binaries.
     cgx.cmd
         .arg("cargo-expand@=1.0.88")
         .arg("--version")
@@ -109,6 +106,7 @@ fn messages_with_prebuilt_binary() {
         )),
         "Expected CrateResolution::CacheMiss on first run"
     );
+    assert_prebuilt(&messages);
 
     // Second invocation should hit all caches
     let mut cgx = cgx.reset();
@@ -183,6 +181,7 @@ fn messages_without_prebuilt_binary() {
             .any(|m| matches!(m, Message::BuildCache(BuildCacheMessage::CacheMiss { .. }))),
         "Expected BuildCache::CacheMiss on first run (building from source)"
     );
+    assert_built_from_source(&messages);
 
     // Second invocation should hit all caches
     let mut cgx = cgx.reset();

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -9,7 +9,10 @@ use cgx::messages::{
 };
 use cgx_core::config::BinaryProvider;
 
-use crate::utils::{Cgx, CommandExt, assert_built_from_source, assert_prebuilt};
+use crate::utils::{
+    Cgx, CommandExt, assert_built_from_source, assert_cached_source_build, assert_compiled_from_source,
+    assert_prebuilt,
+};
 
 /// Test that `--prebuilt-binary never` forces building from source even when binaries exist.
 #[test]
@@ -280,7 +283,7 @@ fn cache_flow_switching_modes() {
         )),
         "Expected PrebuiltBinaryMessage::PrebuiltBinariesDisabled on second run"
     );
-    assert_built_from_source(&messages);
+    assert_compiled_from_source(&messages);
 
     // Third run with defaults again - should use pre-built binary from cache (no network)
     let mut cgx = cgx.reset();
@@ -328,7 +331,7 @@ fn custom_features_uses_separate_cache() {
         )),
         "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization on first run"
     );
-    assert_built_from_source(&messages);
+    assert_compiled_from_source(&messages);
     assert!(
         messages
             .iter()
@@ -377,7 +380,7 @@ fn custom_features_uses_separate_cache() {
             .any(|m| matches!(m, Message::BuildCache(BuildCacheMessage::CacheHit { .. }))),
         "Expected BuildCacheMessage::CacheHit on third run (reusing build from first run)"
     );
-    assert_built_from_source(&messages);
+    assert_cached_source_build(&messages);
 }
 
 /// Test that negative binary resolution results are cached.

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -3,13 +3,13 @@
 //! These tests explicitly set --prebuilt-binary flags to test non-default behavior,
 //! disqualification scenarios, cache interactions, and config overrides.
 
+use assert_fs::prelude::*;
 use cgx::messages::{
     BuildCacheMessage, BuildMessage, CrateResolutionMessage, Message, PrebuiltBinaryMessage, SourceMessage,
 };
 use cgx_core::config::BinaryProvider;
-use predicates::prelude::*;
 
-use crate::utils::{Cgx, CommandExt};
+use crate::utils::{Cgx, CommandExt, assert_built_from_source, assert_prebuilt};
 
 /// Test that `--prebuilt-binary never` forces building from source even when binaries exist.
 #[test]
@@ -26,12 +26,9 @@ fn never_mode_forces_source_build() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stdout(predicates::str::contains("eza"))
-        .stderr(predicates::str::contains("Compiling"));
+    assert.success().stdout(predicates::str::contains("eza"));
 
-    // Verify prebuilt binaries were disabled
+    // Verify prebuilt binaries were disabled and the binary was built from source.
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -39,14 +36,7 @@ fn never_mode_forces_source_build() {
         )),
         "Expected PrebuiltBinaryMessage::PrebuiltBinariesDisabled"
     );
-
-    // Verify build was initiated
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started"
-    );
+    assert_built_from_source(&messages);
 }
 
 /// Test that `--prebuilt-binary always` succeeds when a binary is available.
@@ -64,26 +54,16 @@ fn always_mode_succeeds_with_available_binary() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stdout(predicates::str::contains("eza"))
-        .stderr(predicates::str::contains("Compiling").not());
+    assert.success().stdout(predicates::str::contains("eza"));
 
-    // Verify prebuilt binary was resolved
+    // Verify a prebuilt binary was resolved and that the binary came from it (no source build).
     assert!(
         messages
             .iter()
             .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { .. }))),
         "Expected PrebuiltBinaryMessage::Resolved"
     );
-
-    // Verify no build was initiated
-    assert!(
-        !messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Should not have BuildMessage::Started when using prebuilt binary"
-    );
+    assert_prebuilt(&messages);
 }
 
 /// Test that `--prebuilt-binary always` fails when no binary is available.
@@ -116,9 +96,9 @@ fn custom_features_disqualifies() {
         .assert_with_messages();
 
     // Should build from source due to custom features
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
-    // Verify disqualification message
+    // Verify disqualification and that the binary was built from source.
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -126,14 +106,7 @@ fn custom_features_disqualifies() {
         )),
         "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization"
     );
-
-    // Verify build was initiated
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started"
-    );
+    assert_built_from_source(&messages);
 }
 
 /// Test that `--all-features` disqualifies pre-built binary usage.
@@ -150,9 +123,9 @@ fn all_features_disqualifies() {
         .assert_with_messages();
 
     // Should build from source due to --all-features
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
-    // Verify disqualification message
+    // Verify disqualification and that the binary was built from source.
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -160,14 +133,7 @@ fn all_features_disqualifies() {
         )),
         "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization"
     );
-
-    // Verify build was initiated
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started"
-    );
+    assert_built_from_source(&messages);
 }
 
 /// Test that `--no-default-features` disqualifies pre-built binary usage.
@@ -184,9 +150,47 @@ fn no_default_features_disqualifies() {
         .assert_with_messages();
 
     // Should build from source due to --no-default-features
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
-    // Verify disqualification message
+    // Verify disqualification and that the binary was built from source.
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::DisqualifiedDueToCustomization { .. })
+        )),
+        "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization"
+    );
+    assert_built_from_source(&messages);
+}
+
+/// Test that `default-features = false` configured for a tool in `[tools]` disqualifies pre-built
+/// binary usage, the same as the `--no-default-features` CLI flag.
+#[test]
+fn config_default_features_false_disqualifies() {
+    let mut cgx = Cgx::with_test_fs();
+
+    cgx.test_fs()
+        .cwd
+        .child("cgx.toml")
+        .write_str(
+            r#"
+[tools]
+eza = { version = "=0.23.1", default-features = false }
+"#,
+        )
+        .unwrap();
+
+    // No CLI feature flags; just use the configred `[tools]` options
+    let (assert, messages) = cgx
+        .cmd
+        .with_json_messages()
+        .arg("eza")
+        .arg("--version")
+        .assert_with_messages();
+
+    assert.success();
+
+    // The configured `default-features = false` disqualifies the pre-built binary...
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -195,13 +199,8 @@ fn no_default_features_disqualifies() {
         "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization"
     );
 
-    // Verify build was initiated
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started"
-    );
+    // ...so the binary is built from source.
+    assert_built_from_source(&messages);
 }
 
 /// Test cache flow: default (binary) → never (source) → default (binary from cache).
@@ -217,23 +216,16 @@ fn cache_flow_switching_modes() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stderr(predicates::str::contains("Compiling").not());
+    assert.success();
 
-    // Verify prebuilt binary was resolved
+    // Verify a prebuilt binary was resolved and used (no source build) on the first run.
     assert!(
         messages
             .iter()
             .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { .. }))),
         "Expected PrebuiltBinaryMessage::Resolved on first run"
     );
-    assert!(
-        !messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Should not have BuildMessage::Started on first run (using prebuilt binary)"
-    );
+    assert_prebuilt(&messages);
 
     // Second run with --prebuilt-binary never - should build from source
     let mut cgx = cgx.reset();
@@ -246,9 +238,9 @@ fn cache_flow_switching_modes() {
         .arg("--version")
         .assert_with_messages();
 
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
-    // Verify prebuilt binaries were disabled and build was initiated
+    // Verify prebuilt binaries were disabled and the binary was built from source on the second run.
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -256,12 +248,7 @@ fn cache_flow_switching_modes() {
         )),
         "Expected PrebuiltBinaryMessage::PrebuiltBinariesDisabled on second run"
     );
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started on second run"
-    );
+    assert_built_from_source(&messages);
 
     // Third run with defaults again - should use pre-built binary from cache (no network)
     let mut cgx = cgx.reset();
@@ -274,19 +261,14 @@ fn cache_flow_switching_modes() {
 
     assert.success().stderr(predicates::str::is_empty());
 
-    // Verify we hit the binary resolution cache
+    // Verify we hit the binary resolution cache and reused the prebuilt binary on the third run.
     assert!(
         messages
             .iter()
             .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::CacheHit { .. }))),
         "Expected PrebuiltBinaryMessage::CacheHit on third run"
     );
-    assert!(
-        !messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Should not have BuildMessage::Started on third run (using cached prebuilt binary)"
-    );
+    assert_prebuilt(&messages);
 }
 
 /// Test that custom features and default settings use different cache entries.
@@ -304,9 +286,9 @@ fn custom_features_uses_separate_cache() {
         .arg("--version")
         .assert_with_messages();
 
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
-    // Verify disqualification and source build
+    // Verify disqualification, a source build, and a build-cache miss on the first run.
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -314,12 +296,7 @@ fn custom_features_uses_separate_cache() {
         )),
         "Expected PrebuiltBinaryMessage::DisqualifiedDueToCustomization on first run"
     );
-    assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Expected BuildMessage::Started on first run"
-    );
+    assert_built_from_source(&messages);
     assert!(
         messages
             .iter()
@@ -336,23 +313,17 @@ fn custom_features_uses_separate_cache() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stderr(predicates::str::contains("Compiling").not());
+    assert.success();
 
-    // Verify prebuilt binary was resolved (proves different cache entry from source build)
+    // Verify a prebuilt binary was resolved and used on the second run (proves a different cache
+    // entry from the first run's source build).
     assert!(
         messages
             .iter()
             .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { .. }))),
         "Expected PrebuiltBinaryMessage::Resolved on second run (different cache entry from first run)"
     );
-    assert!(
-        !messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Should not have BuildMessage::Started on second run (using prebuilt binary)"
-    );
+    assert_prebuilt(&messages);
 
     // Third run with custom features again - should use cached build from first run
     let mut cgx = cgx.reset();
@@ -367,19 +338,14 @@ fn custom_features_uses_separate_cache() {
 
     assert.success().stderr(predicates::str::is_empty());
 
-    // Verify we hit the compiled binary cache (from first run with custom features)
+    // Verify we hit the compiled binary cache from the first run (still a source-built binary).
     assert!(
         messages
             .iter()
             .any(|m| matches!(m, Message::BuildCache(BuildCacheMessage::CacheHit { .. }))),
         "Expected BuildCacheMessage::CacheHit on third run (reusing build from first run)"
     );
-    assert!(
-        !messages
-            .iter()
-            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "Should not have BuildMessage::Started on third run (using cached build)"
-    );
+    assert_built_from_source(&messages);
 }
 
 /// Test that negative binary resolution results are cached.
@@ -550,10 +516,7 @@ fn github_provider_resolves_binary() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stdout(predicates::str::contains("eza"))
-        .stderr(predicates::str::contains("Compiling").not());
+    assert.success().stdout(predicates::str::contains("eza"));
 
     let providers: Vec<_> = messages
         .iter()
@@ -703,10 +666,7 @@ fn quickinstall_provider_resolves_binary() {
         .arg("--version")
         .assert_with_messages();
 
-    assert
-        .success()
-        .stdout(predicates::str::contains("eza"))
-        .stderr(predicates::str::contains("Compiling").not());
+    assert.success().stdout(predicates::str::contains("eza"));
 
     let providers: Vec<_> = messages
         .iter()
@@ -774,7 +734,7 @@ fn gitlab_provider_reports_no_binary_for_github_crate() {
         .arg("--version")
         .assert_with_messages();
 
-    assert.success().stderr(predicates::str::contains("Compiling"));
+    assert.success();
 
     let providers: Vec<_> = messages
         .iter()

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -81,6 +81,38 @@ fn always_mode_fails_without_binary() {
         .failure();
 }
 
+/// Test that `--prebuilt-binary always` fails fast when build options disqualify prebuilt
+/// binaries, and does NOT fall back to building from source.
+#[test]
+fn always_mode_fails_when_build_options_disqualify() {
+    let mut cgx = Cgx::with_test_fs();
+
+    // A custom profile disqualifies prebuilt binaries, which is not compatible with `always` mode,
+    // so this should error without attempting to build from source.
+    let (assert, messages) = cgx
+        .cmd
+        .with_json_messages()
+        .arg("--prebuilt-binary")
+        .arg("always")
+        .arg("--profile")
+        .arg("dev")
+        .arg("eza@=0.23.1")
+        .arg("--version")
+        .assert_with_messages();
+
+    assert
+        .failure()
+        .stderr(predicates::str::contains("custom profile specified"));
+
+    // The invocation must fail before any source build starts.
+    assert!(
+        !messages
+            .iter()
+            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+        "expected the invocation to fail without starting a build"
+    );
+}
+
 /// Test that custom features disqualify pre-built binary usage.
 #[test]
 fn custom_features_disqualifies() {

--- a/cgx/tests/integration/utils.rs
+++ b/cgx/tests/integration/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions to help run our CLI as part of a test
 use assert_cmd::{Command, assert::OutputAssertExt, cargo::cargo_bin_cmd};
 use assert_fs::{TempDir, prelude::*};
-use cgx::messages::{CgxMessage, Message, Provenance};
+use cgx::messages::{BuildCacheMessage, BuildMessage, CgxMessage, Message, Provenance};
 use serde_json::Deserializer;
 
 pub(crate) struct TestFs {
@@ -151,8 +151,66 @@ impl CommandExt for Command {
 
 /// Assert that the emitted messages report the crate's binary was built from source.
 ///
-/// Reads the authoritative [`CgxMessage::CrateProvenance`].
+/// This is cache-agnostic: it reads only the [`CgxMessage::CrateProvenance`] message and does
+/// not distinguish a fresh compile from a build-cache hit. Use [`assert_compiled_from_source`] or
+/// [`assert_cached_source_build`] to assert one or the other of those cases specifically.
 pub(crate) fn assert_built_from_source(messages: &[Message]) {
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::Cgx(CgxMessage::CrateProvenance {
+                provenance: Provenance::BuiltFromSource { .. },
+                ..
+            })
+        )),
+        "expected a CrateProvenance message reporting the binary was built from source, got: {messages:#?}"
+    );
+}
+
+/// Assert that the emitted messages report the crate's binary was compiled from source *during this
+/// run*, meaning that it performed a fresh `cargo` build, rather than serving from cache.
+///
+/// Checks both that a [`BuildMessage::Started`] was emitted (cargo actually ran; it is emitted only on
+/// a build-cache miss) and that the [`CgxMessage::CrateProvenance`] message reports a source
+/// build.
+pub(crate) fn assert_compiled_from_source(messages: &[Message]) {
+    assert!(
+        messages
+            .iter()
+            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+        "expected a BuildMessage::Started message (a fresh cargo compile), got: {messages:#?}"
+    );
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::Cgx(CgxMessage::CrateProvenance {
+                provenance: Provenance::BuiltFromSource { .. },
+                ..
+            })
+        )),
+        "expected a CrateProvenance message reporting the binary was built from source, got: {messages:#?}"
+    );
+}
+
+/// Assert that the emitted messages report the crate's binary was a source build served from the
+/// build cache *without* recompiling.
+///
+/// Checks that a [`BuildCacheMessage::CacheHit`] was emitted, that no [`BuildMessage::Started`] was
+/// emitted (cargo did not run this time), and that the authoritative [`CgxMessage::CrateProvenance`]
+/// reports a source build. Use this when a test's point is "this run reused a cached source build".
+pub(crate) fn assert_cached_source_build(messages: &[Message]) {
+    assert!(
+        messages
+            .iter()
+            .any(|m| matches!(m, Message::BuildCache(BuildCacheMessage::CacheHit { .. }))),
+        "expected a BuildCacheMessage::CacheHit message, got: {messages:#?}"
+    );
+    assert!(
+        !messages
+            .iter()
+            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+        "expected NO BuildMessage::Started message (binary should be served from cache, not recompiled), got: {messages:#?}"
+    );
     assert!(
         messages.iter().any(|m| matches!(
             m,
@@ -168,7 +226,6 @@ pub(crate) fn assert_built_from_source(messages: &[Message]) {
 /// Assert that the emitted messages report the crate's binary was obtained as a pre-built binary.
 ///
 /// Reads the authoritative [`CgxMessage::CrateProvenance`].
-/// the absence of `Compiling` in stderr.
 pub(crate) fn assert_prebuilt(messages: &[Message]) {
     assert!(
         messages.iter().any(|m| matches!(

--- a/cgx/tests/integration/utils.rs
+++ b/cgx/tests/integration/utils.rs
@@ -1,7 +1,7 @@
 //! Utility functions to help run our CLI as part of a test
 use assert_cmd::{Command, assert::OutputAssertExt, cargo::cargo_bin_cmd};
 use assert_fs::{TempDir, prelude::*};
-use cgx::messages::Message;
+use cgx::messages::{CgxMessage, Message, Provenance};
 use serde_json::Deserializer;
 
 pub(crate) struct TestFs {
@@ -147,4 +147,37 @@ impl CommandExt for Command {
 
         (assert, messages)
     }
+}
+
+/// Assert that the emitted messages report the crate's binary was built from source.
+///
+/// Reads the authoritative [`CgxMessage::CrateProvenance`].
+pub(crate) fn assert_built_from_source(messages: &[Message]) {
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::Cgx(CgxMessage::CrateProvenance {
+                provenance: Provenance::BuiltFromSource { .. },
+                ..
+            })
+        )),
+        "expected a CrateProvenance message reporting the binary was built from source, got: {messages:#?}"
+    );
+}
+
+/// Assert that the emitted messages report the crate's binary was obtained as a pre-built binary.
+///
+/// Reads the authoritative [`CgxMessage::CrateProvenance`].
+/// the absence of `Compiling` in stderr.
+pub(crate) fn assert_prebuilt(messages: &[Message]) {
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::Cgx(CgxMessage::CrateProvenance {
+                provenance: Provenance::Prebuilt { .. },
+                ..
+            })
+        )),
+        "expected a CrateProvenance message reporting a pre-built binary, got: {messages:#?}"
+    );
 }

--- a/cgx/tests/integration/utils.rs
+++ b/cgx/tests/integration/utils.rs
@@ -170,8 +170,8 @@ pub(crate) fn assert_built_from_source(messages: &[Message]) {
 /// Assert that the emitted messages report the crate's binary was compiled from source *during this
 /// run*, meaning that it performed a fresh `cargo` build, rather than serving from cache.
 ///
-/// Checks both that a [`BuildMessage::Started`] was emitted (cargo actually ran; it is emitted only on
-/// a build-cache miss) and that the [`CgxMessage::CrateProvenance`] message reports a source
+/// Checks both that a [`BuildMessage::Started`] was emitted (cargo actually ran; it is emitted only
+/// on a build-cache miss) and that the [`CgxMessage::CrateProvenance`] message reports a source
 /// build.
 pub(crate) fn assert_compiled_from_source(messages: &[Message]) {
     assert!(
@@ -196,8 +196,9 @@ pub(crate) fn assert_compiled_from_source(messages: &[Message]) {
 /// build cache *without* recompiling.
 ///
 /// Checks that a [`BuildCacheMessage::CacheHit`] was emitted, that no [`BuildMessage::Started`] was
-/// emitted (cargo did not run this time), and that the authoritative [`CgxMessage::CrateProvenance`]
-/// reports a source build. Use this when a test's point is "this run reused a cached source build".
+/// emitted (cargo did not run this time), and that the authoritative
+/// [`CgxMessage::CrateProvenance`] reports a source build. Use this when a test's point is "this
+/// run reused a cached source build".
 pub(crate) fn assert_cached_source_build(messages: &[Message]) {
     assert!(
         messages
@@ -209,7 +210,8 @@ pub(crate) fn assert_cached_source_build(messages: &[Message]) {
         !messages
             .iter()
             .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
-        "expected NO BuildMessage::Started message (binary should be served from cache, not recompiled), got: {messages:#?}"
+        "expected NO BuildMessage::Started message (binary should be served from cache, not recompiled), \
+         got: {messages:#?}"
     );
     assert!(
         messages.iter().any(|m| matches!(


### PR DESCRIPTION
Added new CLI commands `--prefetch`, `--prefetch-all`, and `--list-tools`.

See the issue for details on what this does and why it might be useful.

As a consequent of this, a pretty substantial refactor of `cli.rs` was necessary to improve the structure of the CLI parsing now that there are multiple commands besides just running a crate.


Closes #195 
