### PR TITLE
fix: handle fresh Cargo home

### DIFF
--- a/cgx-core/src/registry.rs
+++ b/cgx-core/src/registry.rs
@@ -1,14 +1,25 @@
+use std::{fs, io::ErrorKind};
+
 use backon::{BlockingRetryable, ExponentialBuilder};
 use semver::Version;
 use snafu::ResultExt;
 use tame_index::{
-    Error as TameIndexError, HttpError as TameHttpError, IndexKrate, IndexLocation, IndexUrl, KrateName,
-    SparseIndex,
-    index::RemoteSparseIndex,
+    CRATES_IO_HTTP_INDEX, Error as TameIndexError, HttpError as TameHttpError, IndexKrate, IndexLocation,
+    IndexPath, IndexUrl, KrateName, SparseIndex,
+    index::{IndexConfig, RemoteSparseIndex},
     utils::flock::{FileLock, LockOptions},
 };
 
 use crate::{Result, config::HttpConfig, cratespec::RegistrySource, error, http::HttpClient};
+
+/// File name of the sparse registry configuration stored at the root of Cargo's index cache.
+const SPARSE_INDEX_CONFIG_FILENAME: &str = "config.json";
+
+/// Base crates.io API URL recorded in Cargo's crates.io sparse index config.
+const CRATES_IO_API_URL: &str = "https://crates.io";
+
+/// crates.io download API URL recorded in Cargo's crates.io sparse index config.
+const CRATES_IO_DOWNLOAD_API_URL: &str = "https://crates.io/api/v1/crates";
 
 /// Result of looking up a download URL for a specific crate version.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -34,6 +45,9 @@ pub(crate) struct RegistryClient {
     remote_index: RemoteSparseIndex,
     lock: FileLock,
     http_config: HttpConfig,
+    http_client: HttpClient,
+    index_path: tame_index::PathBuf,
+    index_url: String,
 }
 
 impl RegistryClient {
@@ -48,9 +62,15 @@ impl RegistryClient {
 
         // Use the sparse index for this registry and connect to it remotely.
         // NOTE: We currently assume remote registries only.
-        let index_location = IndexLocation::new(index_url);
-        let sparse_index = SparseIndex::new(index_location).context(error::RegistrySnafu)?;
-        let remote_index = RemoteSparseIndex::new(sparse_index, http_client.inner().clone());
+        let (index_path, resolved_index_url) = IndexLocation::new(index_url)
+            .into_parts()
+            .context(error::RegistrySnafu)?;
+        let sparse_index = SparseIndex::new(IndexLocation {
+            url: IndexUrl::from(resolved_index_url.as_str()),
+            root: IndexPath::Exact(index_path.clone()),
+            cargo_version: None,
+        })
+        .context(error::RegistrySnafu)?;
 
         // Use the same cache lock as cargo itself to maximize cache hits and compatibility.
         // The tradeoff is potential contention if cargo is simultaneously reading/updating
@@ -61,10 +81,15 @@ impl RegistryClient {
             .lock(|_| None)
             .context(error::RegistrySnafu)?;
 
+        let remote_index = RemoteSparseIndex::new(sparse_index, http_client.inner().clone());
+
         Ok(Self {
             remote_index,
             lock,
             http_config: http.clone(),
+            http_client: http_client.clone(),
+            index_path,
+            index_url: resolved_index_url,
         })
     }
 
@@ -113,11 +138,7 @@ impl RegistryClient {
         };
 
         // Get the index config to construct the download URL.
-        let index_config = self
-            .remote_index
-            .index
-            .index_config()
-            .context(error::RegistrySnafu)?;
+        let index_config = self.load_or_bootstrap_index_config(offline)?;
 
         // Get download URL for this exact version.
         let Some(download_url) = index_version.download_url(&index_config) else {
@@ -144,6 +165,123 @@ impl RegistryClient {
         };
 
         run_with_retry(&self.http_config, name, operation).context(error::RegistrySnafu)
+    }
+
+    /// Load the sparse registry config needed for tarball download URL construction.
+    ///
+    /// Cargo stores `config.json` beside the sparse index cache, but
+    /// [`RemoteSparseIndex`] only fetches per-crate index entries. It's quite possible, especially
+    /// when using prebuilt binaries or as part of the Github Action `anelson/cgx` running on a
+    /// fresh runner, that `cargo` hasn't run yet and thus the sparse index cache is empty.
+    ///
+    /// This function will detect that case and attempt to bootstrap the index config.
+    fn load_or_bootstrap_index_config(&self, offline: bool) -> Result<IndexConfig> {
+        match self.remote_index.index.index_config() {
+            Ok(config) => Ok(config),
+            Err(source) if !offline && Self::is_missing_index_config(&source) => {
+                let (config, contents) = self.bootstrap_index_config()?;
+                self.persist_index_config(&contents);
+                Ok(config)
+            }
+            Err(source) => Err(source).context(error::RegistrySnafu),
+        }
+    }
+
+    /// Obtain (or generate) a sparse registry config for a cache that does not have `config.json`
+    /// yet.
+    ///
+    /// For crates.io, Cargo's documented config is stable and [`IndexConfig`] already has a
+    /// crates.io-specific download URL fast path keyed off this exact `dl` value. For other
+    /// registries, we have to fetch the config from the sparse index itself.
+    fn bootstrap_index_config(&self) -> Result<(IndexConfig, Vec<u8>)> {
+        if self.is_crates_io() {
+            let config = Self::crates_io_index_config();
+            let contents = serde_json::to_vec(&config).context(error::JsonSnafu)?;
+            return Ok((config, contents));
+        }
+
+        let config_url = self.sparse_config_url();
+        let response = self.http_client.get(&config_url)?;
+        if !response.status().is_success() {
+            return Err(error::HttpStatusSnafu {
+                url: config_url,
+                status: response.status().as_u16(),
+            }
+            .build());
+        }
+
+        let contents = response
+            .bytes()
+            .with_context(|_| error::HttpRequestSnafu { url: config_url })?;
+        let config = serde_json::from_slice(&contents).context(error::JsonSnafu)?;
+        Ok((config, contents.to_vec()))
+    }
+
+    /// Persist the registry config into Cargo's sparse index cache on a best-effort basis.
+    ///
+    /// The in-memory config is enough for the current `cgx` run, so write failures are logged and
+    /// ignored, matching Cargo's own tolerance for config cache writes. The write goes through a
+    /// temporary file and rename so a failed write cannot leave `config.json` truncated.
+    fn persist_index_config(&self, contents: &[u8]) {
+        let path = self.index_path.join(SPARSE_INDEX_CONFIG_FILENAME);
+        let temp_path = self.index_path.join(format!(
+            "{SPARSE_INDEX_CONFIG_FILENAME}.{}.tmp",
+            uuid::Uuid::new_v4()
+        ));
+
+        if let Some(parent) = path.parent() {
+            if let Err(err) = fs::create_dir_all(parent.as_std_path()) {
+                tracing::debug!(
+                    "Failed to create sparse index config directory '{}': {}",
+                    parent,
+                    err
+                );
+                return;
+            }
+        }
+
+        if let Err(err) = fs::write(temp_path.as_std_path(), contents) {
+            tracing::debug!("Failed to write sparse index config '{}': {}", temp_path, err);
+            return;
+        }
+
+        if let Err(err) = fs::rename(temp_path.as_std_path(), path.as_std_path()) {
+            let _ = fs::remove_file(temp_path.as_std_path());
+            tracing::debug!("Failed to move sparse index config into '{}': {}", path, err);
+        }
+    }
+
+    /// Build the standard crates.io sparse index config.
+    fn crates_io_index_config() -> IndexConfig {
+        IndexConfig {
+            dl: CRATES_IO_DOWNLOAD_API_URL.to_string(),
+            api: Some(CRATES_IO_API_URL.to_string()),
+            auth_required: false,
+        }
+    }
+
+    /// Return true when this client uses Cargo's canonical crates.io sparse index.
+    fn is_crates_io(&self) -> bool {
+        self.index_url == CRATES_IO_HTTP_INDEX
+    }
+
+    /// Build the sparse registry config endpoint URL for custom registries.
+    fn sparse_config_url(&self) -> String {
+        if self.index_url.ends_with('/') {
+            format!("{}{}", self.index_url, SPARSE_INDEX_CONFIG_FILENAME)
+        } else {
+            format!("{}/{}", self.index_url, SPARSE_INDEX_CONFIG_FILENAME)
+        }
+    }
+
+    /// Return true only for a missing local sparse `config.json` error.
+    fn is_missing_index_config(err: &TameIndexError) -> bool {
+        matches!(
+            err,
+            TameIndexError::IoPath(source, path)
+                if source.kind() == ErrorKind::NotFound
+                    && path.file_name() == Some(SPARSE_INDEX_CONFIG_FILENAME)
+        )
     }
 }
 

--- a/cgx/tests/integration/cargo.rs
+++ b/cgx/tests/integration/cargo.rs
@@ -1,0 +1,67 @@
+//! Tests for interoperability with Cargo-managed state.
+
+use assert_cmd::Command;
+use assert_fs::{TempDir, prelude::*};
+
+use crate::utils::Cgx;
+
+/// `cgx` should be able to use a fresh Cargo home that has never initialized the crates.io sparse
+/// index.
+#[test]
+fn fresh_cargo_home_can_resolve_and_download_crates_io_crate() {
+    let cargo_home = TempDir::with_prefix("cgx-cargo-home-").unwrap();
+    let mut cgx = Cgx::with_test_fs();
+
+    cgx.cmd
+        .env("CARGO_HOME", cargo_home.path())
+        .arg("--list-targets")
+        .arg("ripgrep@14")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("rg"));
+}
+
+/// The sparse index config that `cgx` writes for a fresh Cargo home must remain compatible with
+/// Cargo itself.
+#[test]
+fn bootstrapped_crates_io_sparse_index_still_works_for_cargo() {
+    let cargo_home = TempDir::with_prefix("cgx-cargo-home-").unwrap();
+    let mut cgx = Cgx::with_test_fs();
+
+    cgx.cmd
+        .env("CARGO_HOME", cargo_home.path())
+        .arg("--list-targets")
+        .arg("ripgrep@14")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("rg"));
+
+    let cargo_project = TempDir::with_prefix("cgx-cargo-project-").unwrap();
+    cargo_project
+        .child("Cargo.toml")
+        .write_str(
+            r#"
+[package]
+name = "cgx-cargo-bootstrap-check"
+version = "0.0.0"
+edition = "2024"
+
+[dependencies]
+itoa = "1"
+"#,
+        )
+        .unwrap();
+    cargo_project
+        .child("src/lib.rs")
+        .write_str(
+            "pub fn dependency_smoke_test() -> String { itoa::Buffer::new().format(42).to_string() }\n",
+        )
+        .unwrap();
+
+    Command::new("cargo")
+        .arg("fetch")
+        .current_dir(cargo_project.path())
+        .env("CARGO_HOME", cargo_home.path())
+        .assert()
+        .success();
+}

--- a/cgx/tests/integration/main.rs
+++ b/cgx/tests/integration/main.rs
@@ -1,4 +1,5 @@
 mod basic;
+mod cargo;
 mod config;
 mod defaults;
 mod git_sources;


### PR DESCRIPTION
Fixes `cgx` so that it works properly even when when `$CARGO_HOME` has not been initialized yet, without requiring a prior Cargo command.  Also adds tests to reproduce the issue and confirm the fix.

Closes #209.