### PR TITLE
fix: Fix various typos in comments and docs and add `typos` check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
         with:
           tool: ast-grep
 
+      - name: Install typos
+        uses: taiki-e/install-action@v2.81.3
+        with:
+          tool: typos@1.44.0
+
       - uses: Swatinem/rust-cache@v2
         with:
           cache-targets: false

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -39,6 +39,7 @@ Additional tools used by the fuller project recipes:
 
 - `taplo` for TOML formatting checks.
 - `ast-grep` for the structural lints in `just vibecheck`.
+- `typos` (the `typos-cli` crate) for the spell check in `just vibecheck`.
 - `cargo-deny` and `cargo-machete` for dependency checks.
 - The nightly Rust toolchain for the first pass of `just fmt`.
 - `gh` is optional for tests; `just test` uses `gh auth token` as `GITHUB_TOKEN` when available to avoid
@@ -79,8 +80,9 @@ Run the main compile/lint/doc check:
 just vibecheck
 ```
 
-`vibecheck` checks that cargo-dist generated workflows are up to date, runs the ast-grep structural lints, then runs
-workspace `cargo check`, all-feature `cargo check`, clippy with warnings as errors, and private-item docs.
+`vibecheck` checks that cargo-dist generated workflows are up to date, runs the ast-grep structural lints and the
+`typos` spell check, then runs workspace `cargo check`, all-feature `cargo check`, clippy with warnings as errors, and
+private-item docs.
 
 Format the project:
 

--- a/Justfile
+++ b/Justfile
@@ -133,11 +133,16 @@ ast-grep:
     ast-grep test --skip-snapshot-tests
     ast-grep scan
 
+# Spell-check source, comments, docs, and text files.
+# Config and allow-list overrides go in `typos.toml`.
+typos:
+    typos
+
 # Do a Rust "vibe check" (*cringe*) on the codebase
 # This is helpful for humans but it's mainly intended to provide a deterministic way for coding agents
 # to get feedback on their almost certainly shitty changes before wasting a human's time with their garbage code.
 # Run the generated workflow check plus Rust compile, clippy, and docs checks.
-vibecheck: check-dist-release-generated ast-grep
+vibecheck: check-dist-release-generated ast-grep typos
     cargo check --all-targets --workspace
     cargo check --all-targets --all-features --workspace
     cargo clippy --all-targets --all-features --workspace -- -D warnings

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ cgx --list-tools
 ```
 
 `--prefetch` is equivalent to `--no-exec` but prints nothing on success; once a crate is prefetched it is guaranteed to
-be runnable later without network access and without building froms ource (as long as you don't change build options,
+be runnable later without network access and without building from source (as long as you don't change build options,
 features, or toolchain). `--prefetch-all` is a convenience shortcut equivalent to running `--prefetch` for each
 configured tool and alias.
 

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -52,7 +52,7 @@ pub trait BinaryResolver {
     ) -> Result<Option<ResolvedBinary>>;
 }
 
-/// Create the default [`BinaryResolver`] implementation, repecting the given config and using the
+/// Create the default [`BinaryResolver`] implementation, respecting the given config and using the
 /// provided cache.
 pub(crate) fn create_resolver(
     config: Config,

--- a/cgx-core/src/cargo.rs
+++ b/cgx-core/src/cargo.rs
@@ -75,7 +75,7 @@ impl From<&BuildOptions> for CargoMetadataOptions {
 /// error-prone, and worst of all inelegant.  But it's also the only way to get certain things
 /// done.
 ///
-/// This type is mainly concerened with the surprisingly complex task of figuring out where `cargo`
+/// This type is mainly concerned with the surprisingly complex task of figuring out where `cargo`
 /// is and how to invoke it, and secondarily with constructing its command lines and parsing the
 /// resulting output.
 pub(crate) trait CargoRunner: std::fmt::Debug + Send + Sync + 'static {

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -843,7 +843,7 @@ impl RawCli {
     /// required or forbidden, and whether trailing tool arguments are allowed.
     ///
     /// It would be nice if more of the rules about which args are allowed with which modes could
-    /// be expressed usign `clap` proc macros, but we're already pushing the limits of clap as it
+    /// be expressed using `clap` proc macros, but we're already pushing the limits of clap as it
     /// is.  An earlier attempt at CLI parsing was even more horrifyingly manual and
     /// stringly-typed.
     fn render(self) -> Result<Cli, clap::Error> {

--- a/cgx-core/src/config.rs
+++ b/cgx-core/src/config.rs
@@ -93,7 +93,7 @@ pub struct PrebuiltBinariesConfig {
     /// This adds minimal overhead and is recommended for security, therefore is on by default.
     pub verify_checksums: bool,
 
-    /// If enabled, when dowloading a binary check for a signature file and if found verify that
+    /// If enabled, when downloading a binary check for a signature file and if found verify that
     /// the download matches the signature.
     ///
     /// This is not quite as simple as [`Self::verify_checksums`] since it requires having the
@@ -1403,13 +1403,13 @@ mod tests {
     fn tool_config_unknown_key_error_names_the_field() {
         let toml_content = r#"
             [tools]
-            ripgrep = { versio = "14" }
+            ripgrep = { versio = "14" } # spellchecker:disable-line
         "#;
         let error = toml::from_str::<ConfigFile>(toml_content)
             .unwrap_err()
             .to_string();
         assert!(
-            error.contains("versio"),
+            error.contains("versio"), // spellchecker:disable-line
             "error did not name the bad key:\n{error}"
         );
         assert!(
@@ -1589,7 +1589,7 @@ mod tests {
     /// Test the config loading logic that traverses up a directory hierarchy looking for config
     /// files.
     ///
-    /// `testdata/configs` contains test config files constructed specificially to facilitate these
+    /// `testdata/configs` contains test config files constructed specifically to facilitate these
     /// tests
     mod hierarchy_tests {
         use assert_matches::assert_matches;

--- a/cgx-core/src/crate_resolver.rs
+++ b/cgx-core/src/crate_resolver.rs
@@ -102,7 +102,7 @@ pub enum ResolvedSource {
     },
 }
 
-/// Create the default [`CrateResolver`] implementation, repecting the given config and using the
+/// Create the default [`CrateResolver`] implementation, respecting the given config and using the
 /// provided cache.
 pub(crate) fn create_resolver(
     config: Config,

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -109,12 +109,12 @@ impl CrateRequest {
 /// For crate specs that point to registries (which store multiple versions of a crate), the
 /// default is to choose the latest version.  If a version is specified, then the most recent
 /// version that matches the specification is chosen.  If no such version exists then an error
-/// ocurrs.
+/// occurs.
 ///
 /// For crate specs that point to local paths, forges, or git repos, there is no choice of
 /// version; the version of the crate is whatever it is at the specified location.  In those cases,
 /// if the `version` field is present, it is validated against the version found at the location,
-/// and if it's not compatible then an error ocurrs.
+/// and if it's not compatible then an error occurs.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CrateSpec {
     /// A crate on Crates.io, specified by its name and optional version.
@@ -139,7 +139,7 @@ pub enum CrateSpec {
     /// the name must be specified.
     ///
     /// If the `version` field is present, the crate found at the specified repo must have a
-    /// version that is compatible with the version specification or an error ocurrs.
+    /// version that is compatible with the version specification or an error occurs.
     Git {
         repo: String,
         selector: GitSelector,
@@ -398,7 +398,7 @@ impl CrateSpec {
     /// Get the crate name used for looking up the crate in the `[tools]` TOML section,
     /// if one is known.
     ///
-    /// Not all `CrateSpec` variants have a known crate name; for those variants, unfortunatelly,
+    /// Not all `CrateSpec` variants have a known crate name; for those variants, unfortunately,
     /// the contents of the `[tools]` section cannot be used to configure them, and this method
     /// returns `None`.
     pub fn configured_tool_name(&self) -> Option<&str> {

--- a/cgx-core/src/downloader.rs
+++ b/cgx-core/src/downloader.rs
@@ -21,7 +21,7 @@ use crate::{
 /// This nomenclature is perhaps a bit misleading, since it's possible for the user to specify a
 /// [`crate::cratespec::CrateSpec::LocalDir`] crate spec to the resolver, which will resolve
 /// directly to that local dir without any downloading or caching.  However,
-/// `DownlaodedOrPossiblyAlreadyLocalCrate` isn't very catchy, so you'll have to do that
+/// `DownloadedOrPossiblyAlreadyLocalCrate` isn't very catchy, so you'll have to do that
 /// substitution in your head.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DownloadedCrate {

--- a/cgx-core/src/sbom.rs
+++ b/cgx-core/src/sbom.rs
@@ -590,7 +590,7 @@ pub(crate) mod tests {
     /// corresponding snapshot files see (`src/snapshots`).  By design, SBOMs contain dependencies
     /// for the specific platform being targeted, so these tests are only run on Linux.  There's no
     /// reason we couldn't run them on Windows or Mac, but that would produce different
-    /// dependencies and thus different snpashots.  If you try to run these tests that use linux
+    /// dependencies and thus different snapshots.  If you try to run these tests that use linux
     /// SBOMs on non-Linux platforms, they will fail.
     #[cfg(target_os = "linux")]
     mod snapshots {

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -215,7 +215,7 @@ eza = { version = "=0.23.1", default-features = false }
         )
         .unwrap();
 
-    // No CLI feature flags; just use the configred `[tools]` options
+    // No CLI feature flags; just use the configured `[tools]` options
     let (assert, messages) = cgx
         .cmd
         .with_json_messages()

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,18 @@
+# Configuration for the `typos` spell checker (https://github.com/crate-ci/typos).
+# Run via `just typos`, which is also part of `just vibecheck`. `typos` honors `.gitignore`,
+# so build artifacts and other ignored paths are already skipped.
+
+[default]
+# `typos` has no built-in inline ignore directive, but its documented workaround is to configure a regex that
+# matches a trailing marker comment indicating that typos should ignore the matching line.
+# Thus, A line ending in `spellchecker:disable-line` (after a TOML
+# `#` or Rust `//` comment leader) is skipped.
+#
+# This surprisingly not-built-in mechanism lets us deliberately make typos in tests or wherever without having to
+# globally register those typos as allowed words in the config.
+extend-ignore-re = ['(?Rm)^.*(#|//)\s*spellchecker:disable-line[ \t]*$']
+
+[default.extend-words]
+# "compilability" is intentional in AGENTS.md ("a basic compilability check" = whether the code
+# compiles); it is not a misspelling of "compatibility".
+compilability = "compilability"


### PR DESCRIPTION
This adds `typos` to `just vibecheck` to proactively detect and catch new typos going forward, and fixes several typos that crept into the code and docs over time.