### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.0.14] - 2026-08-01
+
+## [0.1.0] - 2026-08-02
 
 ### 🚀 Features
 
-- *(bin_resolver)* Further expand prebuilt binary heuristics ([#242](https://github.com/anelson/cgx/pull/242))
+- Implement `anelson/cgx` custom GitHub Action to download and install `cgx` (and optionally `cargo-cgx`) in workflows, add it to `PATH` for later workflow steps, cache tool state, and prefetch configured tools ([#207](https://github.com/anelson/cgx/pull/207))
+- Fall back to ABI-compatible alternative targets when resolving prebuilt binaries ([#240](https://github.com/anelson/cgx/pull/240))
+- Further expand prebuilt binary heuristics ([#242](https://github.com/anelson/cgx/pull/242))
 
 ### 🐛 Bug Fixes
 
 - Fix various typos in comments and docs and add `typos` check ([#222](https://github.com/anelson/cgx/pull/222))
 - Relative tool paths in config files are now evaluated relative to the config file's location ([#224](https://github.com/anelson/cgx/pull/224))
-- *(bin_resolver)* Improve binary provider support so `cgx ripgrep` can resolve a prebuilt binary ([#235](https://github.com/anelson/cgx/pull/235))
+- Improve prebuilt binary discovery for alternate binary names and target layouts, and avoid reusing cached resolutions when the enabled providers change ([#232](https://github.com/anelson/cgx/pull/232))
+- Improve binary provider support so `cgx ripgrep` can resolve a prebuilt binary ([#235](https://github.com/anelson/cgx/pull/235))
 
 ### 📚 Documentation
 
@@ -26,20 +30,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Cargo.lock dependencies
 - Fix a typo that slipped in past the recent `typos` commit
+
+### 🛡️ Security
+
+- Enable Github release attestation on release builds and verify attestation by default in the `cgx` custom action ([#252](https://github.com/anelson/cgx/pull/252))
+- Pin the GitHub Actions used by the release workflows to commit SHA digests ([#252](https://github.com/anelson/cgx/pull/252))
+
 ## [0.0.13] - 2026-06-19
 
 ### 🚀 Features
 
-- Add GitHub Action for installing `cgx` ([#207](https://github.com/anelson/cgx/pull/207))
+- Add the `anelson/cgx` GitHub Action to download and install `cgx` (and optionally `cargo-cgx`), add it to `PATH` for later workflow steps, cache tool state, and prefetch configured tools ([#207](https://github.com/anelson/cgx/pull/207))
 
 ### ⚙️ Miscellaneous Tasks
 
 - Enable several more clippy lints and fix the code accordingly ([#212](https://github.com/anelson/cgx/pull/212))
+
 ## [0.0.12] - 2026-06-17
+
+### 🚀 Features
+
+- Add `--prefetch`, `--prefetch-all`, and `--list-tools` for warming caches and preparing configured tools for later offline execution ([#201](https://github.com/anelson/cgx/pull/201))
 
 ### 🐛 Bug Fixes
 
 - Handle fresh Cargo home ([#210](https://github.com/anelson/cgx/pull/210))
+
 ## [0.0.11] - 2026-06-03
 
 ### ⚙️ Miscellaneous Tasks
@@ -68,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🛡️ Security
 
 - _(deps)_ Bump gix from 0.80.0 to 0.83.0 ([#148](https://github.com/anelson/cgx/pull/148))
+- _(release)_ Embed auditable dependency SBOMs in published binaries via cargo-auditable ([#166](https://github.com/anelson/cgx/pull/166))
 
 ## [0.0.9] - 2026-03-14
 
@@ -129,6 +146,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🚀 Features
 
+- Resolve crates from crates.io, other registries, Git repositories, or local paths, build their selected binaries, and execute them with forwarded arguments
+- Add offline-aware caches for crate resolution, source downloads, persistent Git checkouts, and built binaries
+- Generate CycloneDX SBOMs for binaries built from source
+- Automatically detect GitHub and GitLab repository URLs passed to `--git`
+- Add `--no-exec` to print the prepared binary path and `--list-targets` to inspect runnable targets
+- Load and merge `cgx.toml` configuration from system, user, and directory scopes ([#18](https://github.com/anelson/cgx/pull/18))
 - Add `cargo-cgx` binary crate for cargo subcommand integration ([#51](https://github.com/anelson/cgx/pull/51))
 - Honor tool versions in config when resolving crates ([#46](https://github.com/anelson/cgx/pull/46))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.0.14] - 2026-08-01
+
+### 🚀 Features
+
+- *(bin_resolver)* Further expand prebuilt binary heuristics ([#242](https://github.com/anelson/cgx/pull/242))
+
+### 🐛 Bug Fixes
+
+- Fix various typos in comments and docs and add `typos` check ([#222](https://github.com/anelson/cgx/pull/222))
+- Relative tool paths in config files are now evaluated relative to the config file's location ([#224](https://github.com/anelson/cgx/pull/224))
+- *(bin_resolver)* Improve binary provider support so `cgx ripgrep` can resolve a prebuilt binary ([#235](https://github.com/anelson/cgx/pull/235))
+
+### 📚 Documentation
+
+- Document and apply AI policy ([#243](https://github.com/anelson/cgx/pull/243))
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.lock dependencies
+- Fix a typo that slipped in past the recent `typos` commit
 ## [0.0.13] - 2026-06-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-cgx"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "assert_cmd",
  "cgx",
@@ -467,7 +467,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgx"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "assert-json-diff",
  "assert_cmd",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cgx-core"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "assert-json-diff",
  "assert_matches",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-cgx"
-version = "0.0.14"
+version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "cgx",
@@ -467,7 +467,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgx"
-version = "0.0.14"
+version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "assert_cmd",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "cgx-core"
-version = "0.0.14"
+version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ build-context      = "0.1.4"
 bytes              = "1"
 bzip2              = "0.6.1"
 cargo_metadata     = "0.20.0"
-cgx                = { version = "0.0.13", path = "cgx" }
-cgx-core           = { version = "0.0.13", path = "cgx-core" }
+cgx                = { version = "0.0.14", path = "cgx" }
+cgx-core           = { version = "0.0.14", path = "cgx-core" }
 chrono             = { version = "0.4.44", features = ["serde"] }
 clap               = { version = "4.6.1", features = ["derive", "env", "string", "unicode"] }
 ctrlc              = "3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ build-context      = "0.1.4"
 bytes              = "1"
 bzip2              = "0.6.1"
 cargo_metadata     = "0.20.0"
-cgx                = { version = "0.0.14", path = "cgx" }
-cgx-core           = { version = "0.0.14", path = "cgx-core" }
+cgx                = { version = "0.1.0", path = "cgx" }
+cgx-core           = { version = "0.1.0", path = "cgx-core" }
 chrono             = { version = "0.4.44", features = ["serde"] }
 clap               = { version = "4.6.1", features = ["derive", "env", "string", "unicode"] }
 ctrlc              = "3.5"

--- a/cargo-cgx/Cargo.toml
+++ b/cargo-cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cargo-cgx"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.13"
+version                = "0.0.14"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cargo-cgx/Cargo.toml
+++ b/cargo-cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cargo-cgx"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.14"
+version                = "0.1.0"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cgx-core/Cargo.toml
+++ b/cgx-core/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx-core"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.13"
+version                = "0.0.14"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/cgx-core/Cargo.toml
+++ b/cgx-core/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx-core"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.14"
+version                = "0.1.0"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/cgx/Cargo.toml
+++ b/cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.13"
+version                = "0.0.14"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cgx/Cargo.toml
+++ b/cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.0.14"
+version                = "0.1.0"
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION



## 🤖 New release

* `cgx-core`: 0.0.13 -> 0.1.0 (✓ API compatible changes)
* `cgx`: 0.0.13 -> 0.1.0 (✓ API compatible changes)
* `cargo-cgx`: 0.0.13 -> 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>


## `cgx`

<blockquote>

## [0.0.14] - 2026-08-01

### 🚀 Features

- *(bin_resolver)* Further expand prebuilt binary heuristics ([#242](https://github.com/anelson/cgx/pull/242))

### 🐛 Bug Fixes

- Fix various typos in comments and docs and add `typos` check ([#222](https://github.com/anelson/cgx/pull/222))
- Relative tool paths in config files are now evaluated relative to the config file's location ([#224](https://github.com/anelson/cgx/pull/224))
- *(bin_resolver)* Improve binary provider support so `cgx ripgrep` can resolve a prebuilt binary ([#235](https://github.com/anelson/cgx/pull/235))

### 📚 Documentation

- Document and apply AI policy ([#243](https://github.com/anelson/cgx/pull/243))

### ⚙️ Miscellaneous Tasks

- Update Cargo.lock dependencies
- Fix a typo that slipped in past the recent `typos` commit
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).