### PR TITLE
Improve pre-built binary heuristics and fix logical issues in pre-built binary caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,15 +301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +516,7 @@ dependencies = [
  "serde",
  "serde-cyclonedx",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "shellexpand",
  "snafu",
  "strum",
@@ -574,7 +565,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
@@ -690,12 +681,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -816,15 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
-dependencies = [
- "hybrid-array",
-]
-
-[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,7 +823,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -862,7 +838,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -972,20 +948,9 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "block-buffer",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
- "const-oid",
- "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1006,7 +971,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3185,7 +3150,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3296,15 +3261,6 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -3799,7 +3755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -3905,7 +3861,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4052,7 +4008,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
 ]
 
@@ -4296,7 +4252,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4520,7 +4476,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4854,7 +4810,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4863,7 +4819,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "sha1",
 ]
 
@@ -4875,18 +4831,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest",
 ]
 
 [[package]]
@@ -5189,7 +5134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ semver             = { version = "1.0.28", features = ["serde"] }
 serde              = { version = "1.0.228", features = ["derive"] }
 serde-cyclonedx    = "0.10.0"
 serde_json         = "1.0.150"
-sha2               = "0.11.0"
+sha2               = "0.10"
 shellexpand        = "3.1.2"
 snafu              = "0.9.1"
 strum              = "0.28.0"

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -5,20 +5,18 @@ use std::os::unix::fs::PermissionsExt;
 
 use providers::{BinstallProvider, GithubProvider, GitlabProvider, Provider, QuickinstallProvider};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use snafu::ResultExt;
+use snafu::{IntoError, ResultExt};
 
 use crate::{
     Result,
     builder::{BuildOptions, BuildTarget},
-    cache::Cache,
+    cache::{BinaryCacheEntry, Cache},
     config::{BinaryProvider, Config, UsePrebuiltBinaries},
-    crate_resolver::{ResolvedCrate, ResolvedSource},
-    cratespec::RegistrySource,
+    crate_resolver::ResolvedCrate,
     downloader::DownloadedCrate,
-    error,
+    error::{self, Error},
     http::HttpClient,
-    messages::PrebuiltBinaryMessage,
+    messages::{MessageReporter, PrebuiltBinaryMessage},
 };
 
 /// A resolved binary is a pre-built executable that cgx found and prepared, so the crate can run
@@ -42,8 +40,8 @@ pub trait BinaryResolver {
     ///
     /// Returns:
     /// - `Ok(Some(ResolvedBinary))` - Found a pre-built binary
-    /// - `Ok(None)` - No pre-built binary available, or pre-built binaries are
-    ///   disabled/disqualified
+    /// - `Ok(None)` - No pre-built binary available (or pre-built binaries are
+    ///   disabled/disqualified, or resolution was inconclusive in a non-`always` mode)
     /// - `Err(...)` - Resolution failed in a way that should stop execution
     fn resolve(
         &self,
@@ -52,68 +50,239 @@ pub trait BinaryResolver {
     ) -> Result<Option<ResolvedBinary>>;
 }
 
+/// The outcome of attempting to resolve a pre-built binary
+#[derive(Debug)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "this is a short-lived return value (a handful per resolution), never stored in bulk; boxing \
+              the common Found payload would only add a heap allocation to the success path"
+)]
+enum BinaryResolution {
+    /// A pre-built binary was found and downloaded.
+    Found(ResolvedBinary),
+    /// We determined conclusively that no pre-built binary is available.
+    Nonexistent,
+    /// We could not determine whether a pre-built binary exists, because a transient error (a rate
+    /// limit, a network failure, etc) prevented a definitive answer. Behaves as "none for now"
+    /// but must never be cached.
+    Inconclusive { source: Box<Error> },
+}
+
 /// Create the default [`BinaryResolver`] implementation, respecting the given config and using the
 /// provided cache.
 pub(crate) fn create_resolver(
     config: Config,
     cache: Cache,
-    reporter: crate::messages::MessageReporter,
+    reporter: MessageReporter,
     http_client: HttpClient,
 ) -> impl BinaryResolver {
-    let mode = config.prebuilt_binaries.use_prebuilt_binaries;
-    let inner = DefaultBinaryResolver::new(config, reporter.clone(), http_client);
-    CachingResolver::new(inner, cache, reporter, mode)
+    BinaryResolverImpl::new(config, cache, reporter, http_client)
 }
 
-struct DefaultBinaryResolver {
+/// The prod [`BinaryResolver`] implementation, which delegates to the configured providers and
+/// integrates with the cache to avoid repeated expensive provider calls.
+struct BinaryResolverImpl {
     config: Config,
-    reporter: crate::messages::MessageReporter,
-    http_client: HttpClient,
+    cache: Cache,
+    reporter: MessageReporter,
+    mode: UsePrebuiltBinaries,
+    providers: Vec<Box<dyn Provider + Send + Sync>>,
 }
 
-/// Check if the build options disqualify the use of pre-built binaries.
-///
-/// Pre-built binaries are skipped when the request changes what Cargo would build, such as
-/// selecting features, a target, a profile, a toolchain, a bin, or an example.
-fn is_disqualified(build_options: &BuildOptions) -> Option<&'static str> {
-    if build_options.build_target != BuildTarget::DefaultBin {
-        return Some("explicit --bin or --example specified");
+impl BinaryResolverImpl {
+    fn new(config: Config, cache: Cache, reporter: MessageReporter, http_client: HttpClient) -> Self {
+        let providers = {
+            let cache_dir = &config.cache_dir;
+            let verify = config.prebuilt_binaries.verify_checksums;
+
+            config
+                .prebuilt_binaries
+                .binary_providers
+                .iter()
+                .map(|provider_type| -> Box<dyn Provider + Send + Sync> {
+                    match provider_type {
+                        BinaryProvider::Binstall => Box::new(BinstallProvider::new(
+                            reporter.clone(),
+                            cache_dir.clone(),
+                            verify,
+                            http_client.clone(),
+                        )),
+                        BinaryProvider::GithubReleases => Box::new(GithubProvider::new(
+                            reporter.clone(),
+                            cache_dir.clone(),
+                            verify,
+                            http_client.clone(),
+                        )),
+                        BinaryProvider::GitlabReleases => Box::new(GitlabProvider::new(
+                            reporter.clone(),
+                            cache_dir.clone(),
+                            verify,
+                            http_client.clone(),
+                        )),
+                        BinaryProvider::Quickinstall => Box::new(QuickinstallProvider::new(
+                            reporter.clone(),
+                            cache_dir.clone(),
+                            http_client.clone(),
+                        )),
+                    }
+                })
+                .collect()
+        };
+
+        Self::with_providers(config, cache, reporter, providers)
     }
 
-    if !build_options.features.is_empty() {
-        return Some("custom features specified");
-    }
-
-    if build_options.all_features {
-        return Some("--all-features specified");
-    }
-
-    if build_options.no_default_features {
-        return Some("--no-default-features specified");
-    }
-
-    if build_options.profile.is_some() {
-        return Some("custom profile specified");
-    }
-
-    if build_options.target.is_some() {
-        return Some("custom target specified");
-    }
-
-    if build_options.toolchain.is_some() {
-        return Some("custom toolchain specified");
-    }
-
-    None
-}
-
-impl DefaultBinaryResolver {
-    fn new(config: Config, reporter: crate::messages::MessageReporter, http_client: HttpClient) -> Self {
+    fn with_providers(
+        config: Config,
+        cache: Cache,
+        reporter: MessageReporter,
+        providers: Vec<Box<dyn Provider + Send + Sync>>,
+    ) -> Self {
+        let mode = config.prebuilt_binaries.use_prebuilt_binaries;
         Self {
             config,
+            cache,
             reporter,
-            http_client,
+            mode,
+            providers,
         }
+    }
+
+    /// Check if the build options disqualify the use of pre-built binaries.
+    ///
+    /// Pre-built binaries are skipped when the request changes what Cargo would build, such as
+    /// selecting features, a target, a profile, a toolchain, a bin, or an example.
+    fn is_disqualified(build_options: &BuildOptions) -> Option<&'static str> {
+        if build_options.build_target != BuildTarget::DefaultBin {
+            return Some("explicit --bin or --example specified");
+        }
+
+        if !build_options.features.is_empty() {
+            return Some("custom features specified");
+        }
+
+        if build_options.all_features {
+            return Some("--all-features specified");
+        }
+
+        if build_options.no_default_features {
+            return Some("--no-default-features specified");
+        }
+
+        if build_options.profile.is_some() {
+            return Some("custom profile specified");
+        }
+
+        if build_options.target.is_some() {
+            return Some("custom target specified");
+        }
+
+        if build_options.toolchain.is_some() {
+            return Some("custom toolchain specified");
+        }
+
+        None
+    }
+
+    /// Combine the per-provider resolutions into a single outcome.
+    ///
+    /// Precedence is `Found` > `Inconclusive` > `Nonexistent`: a found binary wins outright;
+    /// failing that, if any provider was inconclusive the overall result is inconclusive (we
+    /// cannot rule out a binary), keeping the first inconclusive error; only if every provider
+    /// conclusively reported no binary is the result `Nonexistent`. An empty iterator yields
+    /// `Nonexistent`.
+    fn combine(resolutions: impl IntoIterator<Item = BinaryResolution>) -> BinaryResolution {
+        let mut inconclusive: Option<Box<Error>> = None;
+        for resolution in resolutions {
+            match resolution {
+                BinaryResolution::Found(binary) => return BinaryResolution::Found(binary),
+                BinaryResolution::Inconclusive { source } => {
+                    inconclusive.get_or_insert(source);
+                }
+                BinaryResolution::Nonexistent => {}
+            }
+        }
+        match inconclusive {
+            Some(source) => BinaryResolution::Inconclusive { source },
+            None => BinaryResolution::Nonexistent,
+        }
+    }
+
+    /// Map a binary resolution to the [`BinaryCacheEntry`] (if any) that should be written to the
+    /// binary cache.
+    ///
+    /// `Found`/`Nonexistent` are conclusive and cacheable; `Inconclusive` returns `None` and is
+    /// never cached. This is the core invariant that prevents a transient failure from being
+    /// persisted as a negative.
+    fn cacheable(resolution: &BinaryResolution) -> Option<BinaryCacheEntry> {
+        match resolution {
+            BinaryResolution::Found(binary) => Some(BinaryCacheEntry::Found(binary.clone())),
+            BinaryResolution::Nonexistent => Some(BinaryCacheEntry::Nonexistent),
+            BinaryResolution::Inconclusive { .. } => None,
+        }
+    }
+
+    /// Convert a binary resolution to the public `Option<ResolvedBinary>`, applying the
+    /// `--prebuilt-binary` mode policy.
+    ///
+    /// This will fail with appropriate errors depending on what mode is specified and what the
+    /// resolution actually was.
+    fn apply_mode(
+        resolution: BinaryResolution,
+        mode: UsePrebuiltBinaries,
+        krate: &ResolvedCrate,
+    ) -> Result<Option<ResolvedBinary>> {
+        // If mode was never, execution would not make it this far, so we don't have to handle that
+        debug_assert_ne!(mode, UsePrebuiltBinaries::Never);
+
+        match resolution {
+            BinaryResolution::Found(binary) => Ok(Some(binary)),
+            BinaryResolution::Nonexistent => {
+                if mode == UsePrebuiltBinaries::Always {
+                    error::PrebuiltBinaryRequiredSnafu {
+                        name: krate.name.clone(),
+                        version: krate.version.to_string(),
+                    }
+                    .fail()
+                } else {
+                    Ok(None)
+                }
+            }
+            BinaryResolution::Inconclusive { source } => {
+                if mode == UsePrebuiltBinaries::Always {
+                    Err(error::PrebuiltBinaryResolutionFailedSnafu {
+                        name: krate.name.clone(),
+                        version: krate.version.to_string(),
+                    }
+                    .into_error(source))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Consult each configured provider in order, short-circuiting on the first `Found`, and fold
+    /// the results with [`Self::combine`].
+    fn resolve_via_providers(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+        if self.providers.is_empty() {
+            return error::NoProvidersConfiguredSnafu.fail();
+        }
+
+        let resolved = &krate.resolved;
+        let mut results = Vec::with_capacity(self.providers.len());
+        for provider in &self.providers {
+            self.reporter
+                .report(|| PrebuiltBinaryMessage::checking_provider(resolved, provider.kind()));
+            let resolution = provider.try_resolve(krate, platform)?;
+            let found = matches!(resolution, BinaryResolution::Found(_));
+            results.push(resolution);
+            if found {
+                break;
+            }
+        }
+
+        Ok(Self::combine(results))
     }
 
     /// Relocate a resolved binary from the provider's cache to the `bin_dir` structure.
@@ -126,8 +295,7 @@ impl DefaultBinaryResolver {
         krate: &ResolvedCrate,
         platform: &str,
     ) -> Result<ResolvedBinary> {
-        // Compute source hash based on the resolved crate source
-        let source_hash = Self::compute_source_hash(&krate.source);
+        let source_hash = krate.source.source_hash();
 
         // Build target directory: bin_dir/<crate>-<version>/<source-hash>/prebuilt-<provider>-<platform>/
         let target_dir = self
@@ -141,7 +309,7 @@ impl DefaultBinaryResolver {
             path: target_dir.clone(),
         })?;
 
-        let binary_name = binary.path.file_name().ok_or_else(|| error::Error::Io {
+        let binary_name = binary.path.file_name().ok_or_else(|| Error::Io {
             path: binary.path.clone(),
             source: std::io::Error::new(std::io::ErrorKind::InvalidInput, "binary path has no filename"),
         })?;
@@ -170,185 +338,37 @@ impl DefaultBinaryResolver {
         binary.path = target_path;
         Ok(binary)
     }
-
-    /// Compute a hash of the source for use in the `bin_dir` structure.
-    fn compute_source_hash(source: &ResolvedSource) -> String {
-        let mut hasher = Sha256::new();
-
-        match source {
-            ResolvedSource::CratesIo => {
-                hasher.update(b"crates-io");
-            }
-            ResolvedSource::Registry { source } => {
-                hasher.update(b"registry:");
-                match source {
-                    RegistrySource::Named(name) => {
-                        hasher.update(b"named:");
-                        hasher.update(name.as_bytes());
-                    }
-                    RegistrySource::IndexUrl(url) => {
-                        hasher.update(b"index:");
-                        hasher.update(url.as_str().as_bytes());
-                    }
-                }
-            }
-            ResolvedSource::Git { repo, commit } => {
-                hasher.update(b"git:");
-                hasher.update(repo.as_bytes());
-                hasher.update(b":");
-                hasher.update(commit.as_bytes());
-            }
-            ResolvedSource::Forge { forge, commit } => {
-                hasher.update(b"forge:");
-                hasher.update(format!("{:?}", forge).as_bytes());
-                hasher.update(b":");
-                hasher.update(commit.as_bytes());
-            }
-            ResolvedSource::LocalDir { path } => {
-                hasher.update(b"local:");
-                hasher.update(path.to_string_lossy().as_bytes());
-            }
-        }
-
-        #[expect(
-            clippy::string_slice,
-            reason = "format_hex_lower returns a 64-char ASCII hex digest, so [..16] is in range and on a \
-                      char boundary"
-        )]
-        let id = crate::helpers::format_hex_lower(hasher.finalize())[..16].to_string();
-        id
-    }
 }
 
-impl BinaryResolver for DefaultBinaryResolver {
-    fn resolve(
-        &self,
-        krate: &DownloadedCrate,
-        _build_options: &BuildOptions,
-    ) -> Result<Option<ResolvedBinary>> {
-        let resolved = &krate.resolved;
-
-        tracing::debug!(
-            "BinaryResolver::resolve called for {}@{}",
-            resolved.name,
-            resolved.version
-        );
-
-        if self.config.prebuilt_binaries.binary_providers.is_empty() {
-            return error::NoProvidersConfiguredSnafu.fail();
-        }
-
-        // Always use the build target platform for pre-built binaries
-        // If the user overrides this by specifying a custom target, execution is not supposed to
-        // make it to this point.
-        let platform: &'static str = build_context::TARGET;
-
-        let reporter = &self.reporter;
-        let cache_dir = &self.config.cache_dir;
-        let verify = self.config.prebuilt_binaries.verify_checksums;
-
-        for provider_type in &self.config.prebuilt_binaries.binary_providers {
-            reporter.report(|| PrebuiltBinaryMessage::checking_provider(resolved, *provider_type));
-
-            let result = match provider_type {
-                BinaryProvider::Binstall => BinstallProvider::new(
-                    reporter.clone(),
-                    cache_dir.clone(),
-                    verify,
-                    self.http_client.clone(),
-                )
-                .try_resolve(krate, platform),
-                BinaryProvider::GithubReleases => GithubProvider::new(
-                    reporter.clone(),
-                    cache_dir.clone(),
-                    verify,
-                    self.http_client.clone(),
-                )
-                .try_resolve(krate, platform),
-                BinaryProvider::GitlabReleases => GitlabProvider::new(
-                    reporter.clone(),
-                    cache_dir.clone(),
-                    verify,
-                    self.http_client.clone(),
-                )
-                .try_resolve(krate, platform),
-                BinaryProvider::Quickinstall => {
-                    QuickinstallProvider::new(reporter.clone(), cache_dir.clone(), self.http_client.clone())
-                        .try_resolve(krate, platform)
-                }
-            };
-
-            match result {
-                Ok(Some(binary)) => {
-                    let relocated_binary = self.relocate_to_bin_dir(binary, resolved, platform)?;
-                    reporter.report(|| PrebuiltBinaryMessage::resolved(&relocated_binary));
-                    return Ok(Some(relocated_binary));
-                }
-                Ok(None) => continue,
-                Err(e) => {
-                    tracing::debug!("Provider {:?} error: {:?}", provider_type, e);
-                    continue;
-                }
-            }
-        }
-
-        self.reporter.report(|| {
-            PrebuiltBinaryMessage::no_binary_found(
-                resolved,
-                vec!["no binary found from any configured provider".to_string()],
-            )
-        });
-
-        Ok(None)
-    }
-}
-
-struct CachingResolver<R: BinaryResolver> {
-    inner: R,
-    cache: Cache,
-    reporter: crate::messages::MessageReporter,
-    mode: UsePrebuiltBinaries,
-}
-
-impl<R: BinaryResolver> CachingResolver<R> {
-    fn new(
-        inner: R,
-        cache: Cache,
-        reporter: crate::messages::MessageReporter,
-        mode: UsePrebuiltBinaries,
-    ) -> Self {
-        Self {
-            inner,
-            cache,
-            reporter,
-            mode,
-        }
-    }
-}
-
-impl<R: BinaryResolver> BinaryResolver for CachingResolver<R> {
+impl BinaryResolver for BinaryResolverImpl {
     fn resolve(
         &self,
         krate: &DownloadedCrate,
         build_options: &BuildOptions,
     ) -> Result<Option<ResolvedBinary>> {
-        // This layer owns the use-prebuilt-binaries mode policy. Every path that can decline to
-        // produce a binary is decided here, so `always` mode cannot be bypassed by a
-        // disqualification short-circuit or by a cached negative result.
+        let resolved_krate = &krate.resolved;
+
+        tracing::debug!(
+            "BinaryResolver::resolve called for {}@{}",
+            resolved_krate.name,
+            resolved_krate.version
+        );
+
         if self.mode == UsePrebuiltBinaries::Never {
             self.reporter
                 .report(PrebuiltBinaryMessage::prebuilt_binaries_disabled);
             return Ok(None);
         }
 
-        // Check build options disqualification BEFORE touching cache: the binary cache is keyed
+        // Check build-options disqualification BEFORE touching the cache: the binary cache is keyed
         // on the resolved crate alone, so a cached binary must not be served to a build whose
-        // options prohibit prebuilt binaries.
-        if let Some(reason) = is_disqualified(build_options) {
+        // options disqualify the user of prebuilt binaries (such as options that enable or disable
+        // features, or otherwise require a binary that is built from source).
+        if let Some(reason) = Self::is_disqualified(build_options) {
             if self.mode == UsePrebuiltBinaries::Always {
                 return error::PrebuiltBinaryDisqualifiedSnafu {
-                    name: krate.resolved.name.clone(),
-                    version: krate.resolved.version.to_string(),
+                    name: resolved_krate.name.clone(),
+                    version: resolved_krate.version.to_string(),
                     reason,
                 }
                 .fail();
@@ -358,38 +378,93 @@ impl<R: BinaryResolver> BinaryResolver for CachingResolver<R> {
             return Ok(None);
         }
 
-        let result = self
-            .cache
-            .get_or_resolve_binary(&krate.resolved, || self.inner.resolve(krate, build_options))?;
-
-        if result.is_none() && self.mode == UsePrebuiltBinaries::Always {
-            return error::PrebuiltBinaryRequiredSnafu {
-                name: krate.resolved.name.clone(),
-                version: krate.resolved.version.to_string(),
+        // Check the binary resolution cache first unless refresh mode is enabled. Only conclusive
+        // outcomes are ever stored, so a cache hit is always authoritative. The cache itself reports
+        // the lookup/hit/miss events; here we only translate a hit into a resolution outcome.
+        if !self.config.refresh {
+            if let Ok(Some(cached)) = self.cache.get_cached_binary(resolved_krate) {
+                let resolution = if let BinaryCacheEntry::Found(binary) = cached {
+                    BinaryResolution::Found(binary)
+                } else {
+                    // The cache already reported the negative hit.  There is no reason to try to
+                    // find a prebuilt binary again.
+                    self.reporter.report(|| {
+                        PrebuiltBinaryMessage::no_binary_found(
+                            resolved_krate,
+                            vec!["negative cache hit - no binary available".to_string()],
+                        )
+                    });
+                    BinaryResolution::Nonexistent
+                };
+                return Self::apply_mode(resolution, self.mode, resolved_krate);
             }
-            .fail();
         }
 
-        Ok(result)
+        // Always use the build target platform for pre-built binaries. If the user overrides this by
+        // specifying a custom target, execution is not supposed to reach this point.
+        let platform: &'static str = build_context::TARGET;
+
+        let resolution = self.resolve_via_providers(krate, platform)?;
+
+        // For a found binary, relocate it into `bin_dir` (so the cached/returned path is stable and
+        // separate from provider caches) and report it. Report the terminal non-found states too.
+        let resolution = match resolution {
+            BinaryResolution::Found(binary) => {
+                let relocated = self.relocate_to_bin_dir(binary, resolved_krate, platform)?;
+                self.reporter
+                    .report(|| PrebuiltBinaryMessage::resolved(&relocated));
+                BinaryResolution::Found(relocated)
+            }
+            BinaryResolution::Nonexistent => {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::no_binary_found(
+                        resolved_krate,
+                        vec!["no binary found from any configured provider".to_string()],
+                    )
+                });
+                BinaryResolution::Nonexistent
+            }
+            BinaryResolution::Inconclusive { source } => {
+                self.reporter
+                    .report(|| PrebuiltBinaryMessage::resolution_inconclusive(source.to_string()));
+                BinaryResolution::Inconclusive { source }
+            }
+        };
+
+        // Persist only conclusive outcomes; an inconclusive result is structurally uncacheable.
+        if let Some(entry) = Self::cacheable(&resolution) {
+            self.cache.put_cached_binary(resolved_krate, &entry)?;
+        }
+
+        Self::apply_mode(resolution, self.mode, resolved_krate)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::Cell, path::PathBuf, rc::Rc};
+    use std::{
+        path::PathBuf,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use assert_matches::assert_matches;
     use semver::Version;
     use tempfile::TempDir;
 
     use super::*;
-    use crate::builder::{BuildOptions, BuildTarget};
+    use crate::{
+        builder::{BuildOptions, BuildTarget},
+        crate_resolver::ResolvedSource,
+    };
 
     /// Test that default build options are not disqualified
     #[test]
     fn test_disqualification_default_options_ok() {
         let options = BuildOptions::default();
-        assert_eq!(is_disqualified(&options), None);
+        assert_eq!(BinaryResolverImpl::is_disqualified(&options), None);
     }
 
     /// Test that explicit --bin flag disqualifies pre-built binaries
@@ -400,7 +475,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            is_disqualified(&options),
+            BinaryResolverImpl::is_disqualified(&options),
             Some("explicit --bin or --example specified")
         );
     }
@@ -413,7 +488,7 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(
-            is_disqualified(&options),
+            BinaryResolverImpl::is_disqualified(&options),
             Some("explicit --bin or --example specified")
         );
     }
@@ -425,7 +500,10 @@ mod tests {
             features: vec!["serde".to_string(), "json".to_string()],
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("custom features specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("custom features specified")
+        );
     }
 
     /// Test that --all-features disqualifies pre-built binaries
@@ -435,7 +513,10 @@ mod tests {
             all_features: true,
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("--all-features specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("--all-features specified")
+        );
     }
 
     /// Test that --no-default-features disqualifies pre-built binaries
@@ -445,7 +526,10 @@ mod tests {
             no_default_features: true,
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("--no-default-features specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("--no-default-features specified")
+        );
     }
 
     /// Test that custom profile disqualifies pre-built binaries
@@ -455,7 +539,10 @@ mod tests {
             profile: Some("release-with-debug".to_string()),
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("custom profile specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("custom profile specified")
+        );
     }
 
     /// Test that custom target disqualifies pre-built binaries
@@ -465,7 +552,10 @@ mod tests {
             target: Some("x86_64-unknown-linux-musl".to_string()),
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("custom target specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("custom target specified")
+        );
     }
 
     /// Test that custom toolchain disqualifies pre-built binaries
@@ -475,49 +565,85 @@ mod tests {
             toolchain: Some("nightly".to_string()),
             ..Default::default()
         };
-        assert_eq!(is_disqualified(&options), Some("custom toolchain specified"));
+        assert_eq!(
+            BinaryResolverImpl::is_disqualified(&options),
+            Some("custom toolchain specified")
+        );
     }
 
-    /// A [`BinaryResolver`] standing in for the provider-backed inner resolver, returning a
-    /// canned result and counting how often it is consulted.
-    struct StubResolver {
-        result: Option<ResolvedBinary>,
-        calls: Rc<Cell<usize>>,
+    /// The canned outcome a [`StubProvider`] returns.
+    #[expect(
+        clippy::large_enum_variant,
+        reason = "test stub; at most one instance exists per test, so the size disparity is irrelevant"
+    )]
+    enum StubOutcome {
+        Found(ResolvedBinary),
+        Nonexistent,
+        Inconclusive,
     }
 
-    impl BinaryResolver for StubResolver {
-        fn resolve(
-            &self,
-            _krate: &DownloadedCrate,
-            _build_options: &BuildOptions,
-        ) -> Result<Option<ResolvedBinary>> {
-            self.calls.set(self.calls.get() + 1);
-            Ok(self.result.clone())
+    /// A [`Provider`] standing in for a real provider, returning a canned [`BinaryResolution`] and
+    /// counting how often it is consulted (so tests can assert short-circuiting and cache hits).
+    struct StubProvider {
+        outcome: StubOutcome,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Provider for StubProvider {
+        fn kind(&self) -> BinaryProvider {
+            BinaryProvider::GithubReleases
+        }
+
+        fn try_resolve(&self, _krate: &DownloadedCrate, _platform: &str) -> Result<BinaryResolution> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(match &self.outcome {
+                StubOutcome::Found(binary) => BinaryResolution::Found(binary.clone()),
+                StubOutcome::Nonexistent => BinaryResolution::Nonexistent,
+                StubOutcome::Inconclusive => BinaryResolution::Inconclusive {
+                    source: boxed_transient(),
+                },
+            })
         }
     }
 
-    fn test_cache() -> (Cache, TempDir) {
-        crate::logging::init_test_logging();
-
-        let (temp_dir, config) = crate::config::create_test_env();
-        (
-            Cache::new(config, crate::messages::MessageReporter::null()),
-            temp_dir,
+    /// A boxed transient (HTTP 429) error, standing in for a rate limit error / network glitch.
+    fn boxed_transient() -> Box<Error> {
+        Box::new(
+            error::HttpStatusSnafu {
+                url: "https://api.github.com/repos/x/y/releases/tags/v1.0.0".to_string(),
+                status: 429u16,
+            }
+            .build(),
         )
     }
 
-    fn stub_caching_resolver(
+    fn test_env() -> (Cache, Config, TempDir) {
+        crate::logging::init_test_logging();
+
+        let (temp_dir, config) = crate::config::create_test_env();
+        let cache = Cache::new(config.clone(), MessageReporter::null());
+        (cache, config, temp_dir)
+    }
+
+    /// Build a [`BinaryResolverImpl`] backed by a single [`StubProvider`] with the given mode and
+    /// canned outcome.
+    fn resolver_with(
         cache: Cache,
+        config: Config,
         mode: UsePrebuiltBinaries,
-        result: Option<ResolvedBinary>,
-    ) -> (CachingResolver<StubResolver>, Rc<Cell<usize>>) {
-        let calls = Rc::new(Cell::new(0));
-        let stub = StubResolver {
-            result,
+        outcome: StubOutcome,
+    ) -> (BinaryResolverImpl, Arc<AtomicUsize>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut config = config;
+        config.prebuilt_binaries.use_prebuilt_binaries = mode;
+        let providers: Vec<Box<dyn Provider + Send + Sync>> = vec![Box::new(StubProvider {
+            outcome,
             calls: calls.clone(),
-        };
-        let resolver = CachingResolver::new(stub, cache, crate::messages::MessageReporter::null(), mode);
-        (resolver, calls)
+        })];
+        (
+            BinaryResolverImpl::with_providers(config, cache, MessageReporter::null(), providers),
+            calls,
+        )
     }
 
     fn test_downloaded_crate() -> DownloadedCrate {
@@ -539,38 +665,159 @@ mod tests {
         }
     }
 
+    #[test]
+    fn combine_empty_is_nonexistent() {
+        assert_matches!(
+            BinaryResolverImpl::combine(Vec::<BinaryResolution>::new()),
+            BinaryResolution::Nonexistent
+        );
+    }
+
+    #[test]
+    fn combine_all_nonexistent_is_nonexistent() {
+        let combined =
+            BinaryResolverImpl::combine([BinaryResolution::Nonexistent, BinaryResolution::Nonexistent]);
+        assert_matches!(combined, BinaryResolution::Nonexistent);
+    }
+
+    #[test]
+    fn combine_any_found_wins() {
+        let combined = BinaryResolverImpl::combine([
+            BinaryResolution::Inconclusive {
+                source: boxed_transient(),
+            },
+            BinaryResolution::Found(test_resolved_binary()),
+            BinaryResolution::Nonexistent,
+        ]);
+        assert_matches!(combined, BinaryResolution::Found(_));
+    }
+
+    #[test]
+    fn combine_inconclusive_beats_nonexistent() {
+        let combined = BinaryResolverImpl::combine([
+            BinaryResolution::Nonexistent,
+            BinaryResolution::Inconclusive {
+                source: boxed_transient(),
+            },
+            BinaryResolution::Nonexistent,
+        ]);
+        assert_matches!(combined, BinaryResolution::Inconclusive { .. });
+    }
+
+    #[test]
+    fn cacheable_found_and_nonexistent_but_never_inconclusive() {
+        assert_matches!(
+            BinaryResolverImpl::cacheable(&BinaryResolution::Found(test_resolved_binary())),
+            Some(BinaryCacheEntry::Found(_))
+        );
+        assert_matches!(
+            BinaryResolverImpl::cacheable(&BinaryResolution::Nonexistent),
+            Some(BinaryCacheEntry::Nonexistent)
+        );
+        assert_matches!(
+            BinaryResolverImpl::cacheable(&BinaryResolution::Inconclusive {
+                source: boxed_transient()
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_mode_found_returns_binary_in_any_mode() {
+        let resolved = test_downloaded_crate().resolved;
+        for mode in [UsePrebuiltBinaries::Auto, UsePrebuiltBinaries::Always] {
+            let out = BinaryResolverImpl::apply_mode(
+                BinaryResolution::Found(test_resolved_binary()),
+                mode,
+                &resolved,
+            )
+            .unwrap();
+            assert_matches!(out, Some(_));
+        }
+    }
+
+    #[test]
+    fn apply_mode_nonexistent_is_none_in_auto_but_errors_in_always() {
+        let resolved = test_downloaded_crate().resolved;
+        assert_matches!(
+            BinaryResolverImpl::apply_mode(
+                BinaryResolution::Nonexistent,
+                UsePrebuiltBinaries::Auto,
+                &resolved
+            ),
+            Ok(None)
+        );
+        assert_matches!(
+            BinaryResolverImpl::apply_mode(
+                BinaryResolution::Nonexistent,
+                UsePrebuiltBinaries::Always,
+                &resolved
+            ),
+            Err(Error::PrebuiltBinaryRequired { .. })
+        );
+    }
+
+    #[test]
+    fn apply_mode_inconclusive_is_none_in_auto_but_errors_with_source_in_always() {
+        let resolved = test_downloaded_crate().resolved;
+        assert_matches!(
+            BinaryResolverImpl::apply_mode(
+                BinaryResolution::Inconclusive {
+                    source: boxed_transient()
+                },
+                UsePrebuiltBinaries::Auto,
+                &resolved
+            ),
+            Ok(None)
+        );
+        let err = BinaryResolverImpl::apply_mode(
+            BinaryResolution::Inconclusive {
+                source: boxed_transient(),
+            },
+            UsePrebuiltBinaries::Always,
+            &resolved,
+        )
+        .unwrap_err();
+        assert_matches!(
+            err,
+            Error::PrebuiltBinaryResolutionFailed { ref name, .. } if name == "serde"
+        );
+    }
+
     /// In `always` mode, build options that disqualify the use of prebuilt binaries fail the binary
     /// resolution because the user demanded a prebuilt binary, and yet the build options would
-    /// force a source build.
+    /// force a source build. Providers are not consulted.
     #[test]
     fn always_mode_rejects_disqualifying_build_options() {
-        let (cache, _temp) = test_cache();
-        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+        let (cache, config, _temp) = test_env();
+        let (resolver, calls) = resolver_with(
+            cache,
+            config,
+            UsePrebuiltBinaries::Always,
+            StubOutcome::Nonexistent,
+        );
         let options = BuildOptions {
-            // Set a a custom profile which will disqualify the use of prebuilt binaries
             profile: Some("dev".to_string()),
             ..Default::default()
         };
 
         let result = resolver.resolve(&test_downloaded_crate(), &options);
 
-        // Prebuilt binaries can't be used because a `profile` is set, but the
-        // `UsePrebuiltBinaries::Always` mode requires a prebuilt binary, so attempting to resolve
-        // this is an error.
         assert_matches!(
             result,
-            Err(error::Error::PrebuiltBinaryDisqualified { ref name, ref reason, .. })
+            Err(Error::PrebuiltBinaryDisqualified { ref name, ref reason, .. })
                 if name == "serde" && reason.contains("profile")
         );
-        assert_eq!(calls.get(), 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
-    /// In `auto` mode, disqualifying build options skip prebuilt binaries so the crate falls
-    /// back to a source build.
+    /// In `auto` mode, build options that disquality the use of prebuilt binaries cause so the
+    /// binary resolution to fall back to a source build.
     #[test]
     fn auto_mode_skips_prebuilt_for_disqualifying_build_options() {
-        let (cache, _temp) = test_cache();
-        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Auto, None);
+        let (cache, config, _temp) = test_env();
+        let (resolver, calls) =
+            resolver_with(cache, config, UsePrebuiltBinaries::Auto, StubOutcome::Nonexistent);
         let options = BuildOptions {
             profile: Some("dev".to_string()),
             ..Default::default()
@@ -579,73 +826,188 @@ mod tests {
         let result = resolver.resolve(&test_downloaded_crate(), &options).unwrap();
 
         assert_eq!(result, None);
-        assert_eq!(calls.get(), 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
-    /// In `always` mode a missing prebuilt binary is an error rather than a silent reversion to
-    /// building from source.
+    /// In `always` mode a conclusively-missing prebuilt binary is an error because we are not
+    /// permitted to fall back to building from source.
     #[test]
     fn always_mode_errors_when_no_provider_has_binary() {
-        let (cache, _temp) = test_cache();
-        let (resolver, calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+        let (cache, config, _temp) = test_env();
+        let (resolver, calls) = resolver_with(
+            cache,
+            config,
+            UsePrebuiltBinaries::Always,
+            StubOutcome::Nonexistent,
+        );
 
         let result = resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
 
         assert_matches!(
             result,
-            Err(error::Error::PrebuiltBinaryRequired { ref name, .. }) if name == "serde"
+            Err(Error::PrebuiltBinaryRequired { ref name, .. }) if name == "serde"
         );
-        assert_eq!(calls.get(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
-    /// `always` mode applies to cached negative results too: a previous run's "no binary
-    /// available" answer fails the invocation instead of silently building from source.
+    /// `always` mode applies to cached negative results too: a previous run's conclusive "no binary
+    /// available" answer fails the invocation instead of silently building from source, and is
+    /// served from cache without re-consulting providers.
     #[test]
     fn always_mode_errors_on_cached_negative_result() {
-        let (cache, _temp) = test_cache();
+        let (cache, config, _temp) = test_env();
 
-        let (auto_resolver, auto_calls) =
-            stub_caching_resolver(cache.clone(), UsePrebuiltBinaries::Auto, None);
+        let (auto_resolver, auto_calls) = resolver_with(
+            cache.clone(),
+            config.clone(),
+            UsePrebuiltBinaries::Auto,
+            StubOutcome::Nonexistent,
+        );
         assert_matches!(
             auto_resolver.resolve(&test_downloaded_crate(), &BuildOptions::default()),
             Ok(None)
         );
-        assert_eq!(auto_calls.get(), 1);
+        assert_eq!(auto_calls.load(Ordering::SeqCst), 1);
 
-        let (always_resolver, always_calls) = stub_caching_resolver(cache, UsePrebuiltBinaries::Always, None);
+        let (always_resolver, always_calls) = resolver_with(
+            cache,
+            config,
+            UsePrebuiltBinaries::Always,
+            StubOutcome::Nonexistent,
+        );
         let result = always_resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
 
-        assert_matches!(result, Err(error::Error::PrebuiltBinaryRequired { .. }));
-        assert_eq!(always_calls.get(), 0);
+        assert_matches!(result, Err(Error::PrebuiltBinaryRequired { .. }));
+        assert_eq!(always_calls.load(Ordering::SeqCst), 0);
     }
 
     /// In `never` mode the cache and providers are not consulted at all.
     #[test]
     fn never_mode_returns_none_without_consulting_providers() {
-        let (cache, _temp) = test_cache();
-        let (resolver, calls) =
-            stub_caching_resolver(cache, UsePrebuiltBinaries::Never, Some(test_resolved_binary()));
+        let (cache, config, temp) = test_env();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+        let binary = ResolvedBinary {
+            krate: test_downloaded_crate().resolved,
+            provider: BinaryProvider::GithubReleases,
+            path: src,
+        };
+        let (resolver, calls) = resolver_with(
+            cache,
+            config,
+            UsePrebuiltBinaries::Never,
+            StubOutcome::Found(binary),
+        );
 
         let result = resolver
             .resolve(&test_downloaded_crate(), &BuildOptions::default())
             .unwrap();
 
         assert_eq!(result, None);
-        assert_eq!(calls.get(), 0);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
-    /// A binary the providers resolve passes through unchanged in `always` mode.
+    /// A binary a provider resolves is relocated into `bin_dir` and returned in `always` mode.
     #[test]
-    fn resolved_binary_passes_through_in_always_mode() {
-        let (cache, _temp) = test_cache();
-        let binary = test_resolved_binary();
-        let (resolver, _calls) =
-            stub_caching_resolver(cache, UsePrebuiltBinaries::Always, Some(binary.clone()));
+    fn resolved_binary_relocated_and_returned_in_always_mode() {
+        let (cache, config, temp) = test_env();
+        let bin_dir = config.bin_dir.clone();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+        let binary = ResolvedBinary {
+            krate: test_downloaded_crate().resolved,
+            provider: BinaryProvider::GithubReleases,
+            path: src.clone(),
+        };
+        let (resolver, _calls) = resolver_with(
+            cache,
+            config,
+            UsePrebuiltBinaries::Always,
+            StubOutcome::Found(binary),
+        );
+
+        let result = resolver
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.provider, BinaryProvider::GithubReleases);
+        assert!(result.path.exists(), "relocated binary should exist");
+        assert!(
+            result.path.starts_with(&bin_dir),
+            "binary should be relocated under bin_dir"
+        );
+        assert_ne!(result.path, src);
+    }
+
+    /// A transient (inconclusive) resolution must NOT be cached as a negative, so a
+    /// later run re-consults providers again.
+    #[test]
+    fn inconclusive_result_is_not_cached() {
+        let (cache, config, _temp) = test_env();
+        let (resolver, calls) = resolver_with(
+            cache.clone(),
+            config,
+            UsePrebuiltBinaries::Auto,
+            StubOutcome::Inconclusive,
+        );
 
         let result = resolver
             .resolve(&test_downloaded_crate(), &BuildOptions::default())
             .unwrap();
 
-        assert_eq!(result, Some(binary));
+        assert_eq!(result, None);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_matches!(
+            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            Ok(None),
+            "an inconclusive resolution must not be persisted"
+        );
+    }
+
+    /// A conclusive absence IS cached (as a negative entry), so later runs skip the providers.
+    #[test]
+    fn nonexistent_result_is_cached() {
+        let (cache, config, _temp) = test_env();
+        let (resolver, _calls) = resolver_with(
+            cache.clone(),
+            config,
+            UsePrebuiltBinaries::Auto,
+            StubOutcome::Nonexistent,
+        );
+
+        resolver
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+
+        assert_matches!(
+            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            Ok(Some(BinaryCacheEntry::Nonexistent))
+        );
+    }
+
+    /// In `always` mode an inconclusive resolution is a hard error carrying the transient source,
+    /// and is never cached.
+    #[test]
+    fn always_mode_errors_on_inconclusive_resolution() {
+        let (cache, config, _temp) = test_env();
+        let (resolver, calls) = resolver_with(
+            cache.clone(),
+            config,
+            UsePrebuiltBinaries::Always,
+            StubOutcome::Inconclusive,
+        );
+
+        let result = resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
+
+        assert_matches!(
+            result,
+            Err(Error::PrebuiltBinaryResolutionFailed { ref name, .. }) if name == "serde"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_matches!(
+            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            Ok(None)
+        );
     }
 }

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -10,13 +10,13 @@ use snafu::{IntoError, ResultExt};
 use crate::{
     Result,
     builder::{BuildOptions, BuildTarget},
-    cache::{BinaryCacheEntry, Cache},
+    cache::Cache,
     config::{BinaryProvider, Config, UsePrebuiltBinaries},
     crate_resolver::ResolvedCrate,
     downloader::DownloadedCrate,
     error::{self, Error},
     http::HttpClient,
-    messages::{MessageReporter, PrebuiltBinaryMessage},
+    messages::{MessageReporter, PrebuiltBinaryMessage, ProviderChangeReason},
 };
 
 /// A resolved binary is a pre-built executable that cgx found and prepared, so the crate can run
@@ -50,7 +50,50 @@ pub trait BinaryResolver {
     ) -> Result<Option<ResolvedBinary>>;
 }
 
-/// The outcome of attempting to resolve a pre-built binary
+/// A conclusive binary-resolution outcome: the cacheable subset of [`BinaryResolution`].
+///
+/// The two variants distinguish a positive result (a pre-built binary was resolved) from a
+/// conclusive negative (we determined no pre-built binary is available).  Theoretically it's
+/// possible that we could have checked at exactly the moment when a crate was just published but
+/// artifacts not yet released, or that a maintainer could go back and publish artifacts for older
+/// versions long after release, but both of these are highly unlikely.  By caching this result, we
+/// can speed up subsequent runs and avoid the many network requests (and potential throttling)
+/// that would be required to check for a pre-built binary every time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "only a handful of these exist at a time (one per resolved crate); the size disparity between \
+              Found and Nonexistent does not matter and boxing would only add indirection"
+)]
+pub(crate) enum ConclusiveResolution {
+    /// A pre-built binary was resolved.
+    Found(ResolvedBinary),
+    /// We conclusively determined that no pre-built binary is available.
+    Nonexistent,
+}
+
+/// The persisted form of a binary-resolution outcome: a [`ConclusiveResolution`] paired with the
+/// set of binary providers that were enabled when it was produced.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct BinaryCacheEntry {
+    #[serde(flatten)]
+    pub(crate) outcome: ConclusiveResolution,
+    /// The binary providers that were enabled for the resolution that produced [`Self::outcome`].
+    pub(crate) enabled_providers: Vec<BinaryProvider>,
+}
+
+/// Create the default [`BinaryResolver`] implementation, respecting the given config and using the
+/// provided cache.
+pub(crate) fn create_resolver(
+    config: Config,
+    cache: Cache,
+    reporter: MessageReporter,
+    http_client: HttpClient,
+) -> impl BinaryResolver {
+    DefaultBinaryResolver::new(config, cache, reporter, http_client)
+}
+
 #[derive(Debug)]
 #[expect(
     clippy::large_enum_variant,
@@ -68,20 +111,25 @@ enum BinaryResolution {
     Inconclusive { source: Box<Error> },
 }
 
-/// Create the default [`BinaryResolver`] implementation, respecting the given config and using the
-/// provided cache.
-pub(crate) fn create_resolver(
-    config: Config,
-    cache: Cache,
-    reporter: MessageReporter,
-    http_client: HttpClient,
-) -> impl BinaryResolver {
-    BinaryResolverImpl::new(config, cache, reporter, http_client)
+impl BinaryResolution {
+    /// Map this binary resolution to the [`ConclusiveResolution`] (if any) that should be written
+    /// to the binary cache to record this resolution for future runs.
+    ///
+    /// `Found`/`Nonexistent` are conclusive and cacheable; `Inconclusive` returns `None` and is
+    /// never cached. This is the core invariant that prevents a transient failure from being
+    /// persisted as a negative.
+    fn to_cacheable(&self) -> Option<ConclusiveResolution> {
+        match self {
+            BinaryResolution::Found(binary) => Some(ConclusiveResolution::Found(binary.clone())),
+            BinaryResolution::Nonexistent => Some(ConclusiveResolution::Nonexistent),
+            BinaryResolution::Inconclusive { .. } => None,
+        }
+    }
 }
 
 /// The prod [`BinaryResolver`] implementation, which delegates to the configured providers and
 /// integrates with the cache to avoid repeated expensive provider calls.
-struct BinaryResolverImpl {
+struct DefaultBinaryResolver {
     config: Config,
     cache: Cache,
     reporter: MessageReporter,
@@ -89,7 +137,7 @@ struct BinaryResolverImpl {
     providers: Vec<Box<dyn Provider + Send + Sync>>,
 }
 
-impl BinaryResolverImpl {
+impl DefaultBinaryResolver {
     fn new(config: Config, cache: Cache, reporter: MessageReporter, http_client: HttpClient) -> Self {
         let providers = {
             let cache_dir = &config.cache_dir;
@@ -191,7 +239,7 @@ impl BinaryResolverImpl {
     /// cannot rule out a binary), keeping the first inconclusive error; only if every provider
     /// conclusively reported no binary is the result `Nonexistent`. An empty iterator yields
     /// `Nonexistent`.
-    fn combine(resolutions: impl IntoIterator<Item = BinaryResolution>) -> BinaryResolution {
+    fn combine_resolutions(resolutions: impl IntoIterator<Item = BinaryResolution>) -> BinaryResolution {
         let mut inconclusive: Option<Box<Error>> = None;
         for resolution in resolutions {
             match resolution {
@@ -205,20 +253,6 @@ impl BinaryResolverImpl {
         match inconclusive {
             Some(source) => BinaryResolution::Inconclusive { source },
             None => BinaryResolution::Nonexistent,
-        }
-    }
-
-    /// Map a binary resolution to the [`BinaryCacheEntry`] (if any) that should be written to the
-    /// binary cache.
-    ///
-    /// `Found`/`Nonexistent` are conclusive and cacheable; `Inconclusive` returns `None` and is
-    /// never cached. This is the core invariant that prevents a transient failure from being
-    /// persisted as a negative.
-    fn cacheable(resolution: &BinaryResolution) -> Option<BinaryCacheEntry> {
-        match resolution {
-            BinaryResolution::Found(binary) => Some(BinaryCacheEntry::Found(binary.clone())),
-            BinaryResolution::Nonexistent => Some(BinaryCacheEntry::Nonexistent),
-            BinaryResolution::Inconclusive { .. } => None,
         }
     }
 
@@ -262,8 +296,66 @@ impl BinaryResolverImpl {
         }
     }
 
+    /// Look up a cached binary-resolution outcome for `krate`, honoring it only if it is still
+    /// valid for the config.
+    ///
+    /// Each cached entry records the providers that were enabled when it was written. A cached
+    /// outcome is used only when:
+    ///
+    /// - every currently-enabled provider was among those recorded. A newly-enabled provider that
+    ///   wasn't accounted for could change the outcome (a negative might become a positive, or a
+    ///   higher-precedence provider might now win), so the entry is stale and we should resolve the
+    ///   binary anew with all currently enabled providers. An entry that recorded *more* providers
+    ///   than are currently enabled stays valid.
+    /// - (positive entries only) the provider that produced the cached binary is still enabled. A
+    ///   binary must never be served from a provider the user has disabled.
+    ///
+    /// Returns `None` (so resolution falls through to the providers) when there is no entry or it
+    /// is stale for the current configuration.
+    fn get_cached_resolution(&self, krate: &ResolvedCrate) -> Option<ConclusiveResolution> {
+        let entry = self.cache.get_cached_binary(krate).ok()??;
+        let enabled = &self.config.prebuilt_binaries.binary_providers;
+
+        // If a provider that is enabled now was not enabled when this cache entry was written, then we
+        // consider the cache entry stale and must not use it.
+        if let Some(missing) = enabled.iter().find(|p| !entry.enabled_providers.contains(p)) {
+            self.reporter.report(|| {
+                PrebuiltBinaryMessage::cache_invalidated_by_provider_change(
+                    krate,
+                    ProviderChangeReason::RequiredProviderNotEnabled(*missing),
+                )
+            });
+            return None;
+        }
+
+        // If the cached entry is a positive hit but it uses a provider that the user has currently
+        // disabled, then obviously we will not use that binary and the cache entry is considered stale.
+        if let ConclusiveResolution::Found(binary) = &entry.outcome {
+            if !enabled.contains(&binary.provider) {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::cache_invalidated_by_provider_change(
+                        krate,
+                        ProviderChangeReason::SourceProviderDisabled(binary.provider),
+                    )
+                });
+                return None;
+            }
+        }
+
+        match &entry.outcome {
+            ConclusiveResolution::Found(binary) => self
+                .reporter
+                .report(|| PrebuiltBinaryMessage::positive_cache_hit(krate, &binary.path, binary.provider)),
+            ConclusiveResolution::Nonexistent => self
+                .reporter
+                .report(|| PrebuiltBinaryMessage::negative_cache_hit(krate)),
+        }
+
+        Some(entry.outcome)
+    }
+
     /// Consult each configured provider in order, short-circuiting on the first `Found`, and fold
-    /// the results with [`Self::combine`].
+    /// the results with [`Self::combine_resolutions`].
     fn resolve_via_providers(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
         if self.providers.is_empty() {
             return error::NoProvidersConfiguredSnafu.fail();
@@ -282,13 +374,13 @@ impl BinaryResolverImpl {
             }
         }
 
-        Ok(Self::combine(results))
+        Ok(Self::combine_resolutions(results))
     }
 
-    /// Relocate a resolved binary from the provider's cache to the `bin_dir` structure.
+    /// Relocate a resolved binary from the provider's internal path to the `bin_dir` structure.
     ///
     /// Pre-built binaries are copied into `bin_dir` so the path cgx returns is stable and separate
-    /// from provider-specific cache directories.
+    /// from provider-specific download/cache directories.
     fn relocate_to_bin_dir(
         &self,
         mut binary: ResolvedBinary,
@@ -340,7 +432,7 @@ impl BinaryResolverImpl {
     }
 }
 
-impl BinaryResolver for BinaryResolverImpl {
+impl BinaryResolver for DefaultBinaryResolver {
     fn resolve(
         &self,
         krate: &DownloadedCrate,
@@ -382,19 +474,20 @@ impl BinaryResolver for BinaryResolverImpl {
         // outcomes are ever stored, so a cache hit is always authoritative. The cache itself reports
         // the lookup/hit/miss events; here we only translate a hit into a resolution outcome.
         if !self.config.refresh {
-            if let Ok(Some(cached)) = self.cache.get_cached_binary(resolved_krate) {
-                let resolution = if let BinaryCacheEntry::Found(binary) = cached {
-                    BinaryResolution::Found(binary)
-                } else {
-                    // The cache already reported the negative hit.  There is no reason to try to
-                    // find a prebuilt binary again.
-                    self.reporter.report(|| {
-                        PrebuiltBinaryMessage::no_binary_found(
-                            resolved_krate,
-                            vec!["negative cache hit - no binary available".to_string()],
-                        )
-                    });
-                    BinaryResolution::Nonexistent
+            if let Some(cached) = self.get_cached_resolution(resolved_krate) {
+                let resolution = match cached {
+                    ConclusiveResolution::Found(binary) => BinaryResolution::Found(binary),
+                    ConclusiveResolution::Nonexistent => {
+                        // `cached_resolution` already reported the negative hit.  There is no reason
+                        // to try to find a prebuilt binary again.
+                        self.reporter.report(|| {
+                            PrebuiltBinaryMessage::no_binary_found(
+                                resolved_krate,
+                                vec!["negative cache hit - no binary available".to_string()],
+                            )
+                        });
+                        BinaryResolution::Nonexistent
+                    }
                 };
                 return Self::apply_mode(resolution, self.mode, resolved_krate);
             }
@@ -431,9 +524,15 @@ impl BinaryResolver for BinaryResolverImpl {
             }
         };
 
-        // Persist only conclusive outcomes; an inconclusive result is structurally uncacheable.
-        if let Some(entry) = Self::cacheable(&resolution) {
-            self.cache.put_cached_binary(resolved_krate, &entry)?;
+        // Persist only conclusive outcomes; an inconclusive result is structurally uncacheable. The
+        // entry records the providers enabled for this resolution so a future run can tell whether the
+        // cached answer still applies (see [`Self::cached_resolution`]).
+        if let Some(outcome) = resolution.to_cacheable() {
+            let entry = BinaryCacheEntry {
+                outcome,
+                enabled_providers: self.config.prebuilt_binaries.binary_providers.clone(),
+            };
+            self.cache.put_cached_binary(resolved_krate, entry)?;
         }
 
         Self::apply_mode(resolution, self.mode, resolved_krate)
@@ -460,117 +559,6 @@ mod tests {
         crate_resolver::ResolvedSource,
     };
 
-    /// Test that default build options are not disqualified
-    #[test]
-    fn test_disqualification_default_options_ok() {
-        let options = BuildOptions::default();
-        assert_eq!(BinaryResolverImpl::is_disqualified(&options), None);
-    }
-
-    /// Test that explicit --bin flag disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_explicit_bin() {
-        let options = BuildOptions {
-            build_target: BuildTarget::Bin("specific-bin".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("explicit --bin or --example specified")
-        );
-    }
-
-    /// Test that explicit --example flag disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_explicit_example() {
-        let options = BuildOptions {
-            build_target: BuildTarget::Example("my-example".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("explicit --bin or --example specified")
-        );
-    }
-
-    /// Test that custom features disqualify pre-built binaries
-    #[test]
-    fn test_disqualification_custom_features() {
-        let options = BuildOptions {
-            features: vec!["serde".to_string(), "json".to_string()],
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("custom features specified")
-        );
-    }
-
-    /// Test that --all-features disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_all_features() {
-        let options = BuildOptions {
-            all_features: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("--all-features specified")
-        );
-    }
-
-    /// Test that --no-default-features disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_no_default_features() {
-        let options = BuildOptions {
-            no_default_features: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("--no-default-features specified")
-        );
-    }
-
-    /// Test that custom profile disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_custom_profile() {
-        let options = BuildOptions {
-            profile: Some("release-with-debug".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("custom profile specified")
-        );
-    }
-
-    /// Test that custom target disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_custom_target() {
-        let options = BuildOptions {
-            target: Some("x86_64-unknown-linux-musl".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("custom target specified")
-        );
-    }
-
-    /// Test that custom toolchain disqualifies pre-built binaries
-    #[test]
-    fn test_disqualification_custom_toolchain() {
-        let options = BuildOptions {
-            toolchain: Some("nightly".to_string()),
-            ..Default::default()
-        };
-        assert_eq!(
-            BinaryResolverImpl::is_disqualified(&options),
-            Some("custom toolchain specified")
-        );
-    }
-
     /// The canned outcome a [`StubProvider`] returns.
     #[expect(
         clippy::large_enum_variant,
@@ -587,6 +575,28 @@ mod tests {
     struct StubProvider {
         outcome: StubOutcome,
         calls: Arc<AtomicUsize>,
+    }
+
+    impl StubProvider {
+        /// A `Found` stub whose binary's `provider` (and therefore the cached finder) is
+        /// `provider`, with a real on-disk file at `path` so relocation succeeds.
+        fn found(provider: BinaryProvider, path: PathBuf) -> Self {
+            Self {
+                outcome: StubOutcome::Found(ResolvedBinary {
+                    krate: test_downloaded_crate().resolved,
+                    provider,
+                    path,
+                }),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn nonexistent() -> Self {
+            Self {
+                outcome: StubOutcome::Nonexistent,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
     }
 
     impl Provider for StubProvider {
@@ -632,7 +642,7 @@ mod tests {
         config: Config,
         mode: UsePrebuiltBinaries,
         outcome: StubOutcome,
-    ) -> (BinaryResolverImpl, Arc<AtomicUsize>) {
+    ) -> (DefaultBinaryResolver, Arc<AtomicUsize>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let mut config = config;
         config.prebuilt_binaries.use_prebuilt_binaries = mode;
@@ -641,9 +651,24 @@ mod tests {
             calls: calls.clone(),
         })];
         (
-            BinaryResolverImpl::with_providers(config, cache, MessageReporter::null(), providers),
+            DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), providers),
             calls,
         )
+    }
+
+    /// Build an `auto`-mode resolver whose enabled provider list (the set recorded in / checked
+    /// against the cache) is `enabled`, backed by the given stub `providers` (which only supply
+    /// outcomes; their `kind()` is irrelevant to the cache's provider-set checks).
+    fn resolver_with_enabled_providers(
+        cache: Cache,
+        config: Config,
+        enabled: Vec<BinaryProvider>,
+        providers: Vec<Box<dyn Provider + Send + Sync>>,
+    ) -> DefaultBinaryResolver {
+        let mut config = config;
+        config.prebuilt_binaries.use_prebuilt_binaries = UsePrebuiltBinaries::Auto;
+        config.prebuilt_binaries.binary_providers = enabled;
+        DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), providers)
     }
 
     fn test_downloaded_crate() -> DownloadedCrate {
@@ -665,24 +690,136 @@ mod tests {
         }
     }
 
+    /// Test that default build options are not disqualified
+    #[test]
+    fn test_disqualification_default_options_ok() {
+        let options = BuildOptions::default();
+        assert_eq!(DefaultBinaryResolver::is_disqualified(&options), None);
+    }
+
+    /// Test that explicit --bin flag disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_explicit_bin() {
+        let options = BuildOptions {
+            build_target: BuildTarget::Bin("specific-bin".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("explicit --bin or --example specified")
+        );
+    }
+
+    /// Test that explicit --example flag disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_explicit_example() {
+        let options = BuildOptions {
+            build_target: BuildTarget::Example("my-example".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("explicit --bin or --example specified")
+        );
+    }
+
+    /// Test that custom features disqualify pre-built binaries
+    #[test]
+    fn test_disqualification_custom_features() {
+        let options = BuildOptions {
+            features: vec!["serde".to_string(), "json".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("custom features specified")
+        );
+    }
+
+    /// Test that --all-features disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_all_features() {
+        let options = BuildOptions {
+            all_features: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("--all-features specified")
+        );
+    }
+
+    /// Test that --no-default-features disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_no_default_features() {
+        let options = BuildOptions {
+            no_default_features: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("--no-default-features specified")
+        );
+    }
+
+    /// Test that custom profile disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_custom_profile() {
+        let options = BuildOptions {
+            profile: Some("release-with-debug".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("custom profile specified")
+        );
+    }
+
+    /// Test that custom target disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_custom_target() {
+        let options = BuildOptions {
+            target: Some("x86_64-unknown-linux-musl".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("custom target specified")
+        );
+    }
+
+    /// Test that custom toolchain disqualifies pre-built binaries
+    #[test]
+    fn test_disqualification_custom_toolchain() {
+        let options = BuildOptions {
+            toolchain: Some("nightly".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            DefaultBinaryResolver::is_disqualified(&options),
+            Some("custom toolchain specified")
+        );
+    }
     #[test]
     fn combine_empty_is_nonexistent() {
         assert_matches!(
-            BinaryResolverImpl::combine(Vec::<BinaryResolution>::new()),
+            DefaultBinaryResolver::combine_resolutions(Vec::<BinaryResolution>::new()),
             BinaryResolution::Nonexistent
         );
     }
 
     #[test]
     fn combine_all_nonexistent_is_nonexistent() {
-        let combined =
-            BinaryResolverImpl::combine([BinaryResolution::Nonexistent, BinaryResolution::Nonexistent]);
+        let combined = DefaultBinaryResolver::combine_resolutions([
+            BinaryResolution::Nonexistent,
+            BinaryResolution::Nonexistent,
+        ]);
         assert_matches!(combined, BinaryResolution::Nonexistent);
     }
 
     #[test]
     fn combine_any_found_wins() {
-        let combined = BinaryResolverImpl::combine([
+        let combined = DefaultBinaryResolver::combine_resolutions([
             BinaryResolution::Inconclusive {
                 source: boxed_transient(),
             },
@@ -694,7 +831,7 @@ mod tests {
 
     #[test]
     fn combine_inconclusive_beats_nonexistent() {
-        let combined = BinaryResolverImpl::combine([
+        let combined = DefaultBinaryResolver::combine_resolutions([
             BinaryResolution::Nonexistent,
             BinaryResolution::Inconclusive {
                 source: boxed_transient(),
@@ -707,17 +844,18 @@ mod tests {
     #[test]
     fn cacheable_found_and_nonexistent_but_never_inconclusive() {
         assert_matches!(
-            BinaryResolverImpl::cacheable(&BinaryResolution::Found(test_resolved_binary())),
-            Some(BinaryCacheEntry::Found(_))
+            BinaryResolution::Found(test_resolved_binary()).to_cacheable(),
+            Some(ConclusiveResolution::Found(_))
         );
         assert_matches!(
-            BinaryResolverImpl::cacheable(&BinaryResolution::Nonexistent),
-            Some(BinaryCacheEntry::Nonexistent)
+            BinaryResolution::Nonexistent.to_cacheable(),
+            Some(ConclusiveResolution::Nonexistent)
         );
         assert_matches!(
-            BinaryResolverImpl::cacheable(&BinaryResolution::Inconclusive {
+            BinaryResolution::Inconclusive {
                 source: boxed_transient()
-            }),
+            }
+            .to_cacheable(),
             None
         );
     }
@@ -726,7 +864,7 @@ mod tests {
     fn apply_mode_found_returns_binary_in_any_mode() {
         let resolved = test_downloaded_crate().resolved;
         for mode in [UsePrebuiltBinaries::Auto, UsePrebuiltBinaries::Always] {
-            let out = BinaryResolverImpl::apply_mode(
+            let out = DefaultBinaryResolver::apply_mode(
                 BinaryResolution::Found(test_resolved_binary()),
                 mode,
                 &resolved,
@@ -740,7 +878,7 @@ mod tests {
     fn apply_mode_nonexistent_is_none_in_auto_but_errors_in_always() {
         let resolved = test_downloaded_crate().resolved;
         assert_matches!(
-            BinaryResolverImpl::apply_mode(
+            DefaultBinaryResolver::apply_mode(
                 BinaryResolution::Nonexistent,
                 UsePrebuiltBinaries::Auto,
                 &resolved
@@ -748,7 +886,7 @@ mod tests {
             Ok(None)
         );
         assert_matches!(
-            BinaryResolverImpl::apply_mode(
+            DefaultBinaryResolver::apply_mode(
                 BinaryResolution::Nonexistent,
                 UsePrebuiltBinaries::Always,
                 &resolved
@@ -761,7 +899,7 @@ mod tests {
     fn apply_mode_inconclusive_is_none_in_auto_but_errors_with_source_in_always() {
         let resolved = test_downloaded_crate().resolved;
         assert_matches!(
-            BinaryResolverImpl::apply_mode(
+            DefaultBinaryResolver::apply_mode(
                 BinaryResolution::Inconclusive {
                     source: boxed_transient()
                 },
@@ -770,7 +908,7 @@ mod tests {
             ),
             Ok(None)
         );
-        let err = BinaryResolverImpl::apply_mode(
+        let err = DefaultBinaryResolver::apply_mode(
             BinaryResolution::Inconclusive {
                 source: boxed_transient(),
             },
@@ -982,7 +1120,10 @@ mod tests {
 
         assert_matches!(
             cache.get_cached_binary(&test_downloaded_crate().resolved),
-            Ok(Some(BinaryCacheEntry::Nonexistent))
+            Ok(Some(BinaryCacheEntry {
+                outcome: ConclusiveResolution::Nonexistent,
+                ..
+            }))
         );
     }
 
@@ -1008,6 +1149,181 @@ mod tests {
         assert_matches!(
             cache.get_cached_binary(&test_downloaded_crate().resolved),
             Ok(None)
+        );
+    }
+
+    /// The reported bug: a negative result cached when only GitLab was enabled must be re-resolved
+    /// once GitHub is also enabled, and GitHub (which has the binary) must actually be consulted.
+    #[test]
+    fn negative_cache_invalidated_when_new_provider_enabled() {
+        let (cache, config, temp) = test_env();
+
+        // Phase 1: only GitLab enabled, no binary -> caches Nonexistent with providers = [GitLab].
+        let gitlab1 = StubProvider::nonexistent();
+        let gitlab1_calls = gitlab1.calls.clone();
+        let r1 = resolver_with_enabled_providers(
+            cache.clone(),
+            config.clone(),
+            vec![BinaryProvider::GitlabReleases],
+            vec![Box::new(gitlab1)],
+        );
+        assert_matches!(
+            r1.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(None)
+        );
+        assert_eq!(gitlab1_calls.load(Ordering::SeqCst), 1);
+
+        // Phase 2: GitLab + GitHub enabled, and GitHub has a binary.
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+        let gitlab2 = StubProvider::nonexistent();
+        let github = StubProvider::found(BinaryProvider::GithubReleases, src);
+        let github_calls = github.calls.clone();
+        let r2 = resolver_with_enabled_providers(
+            cache.clone(),
+            config,
+            vec![BinaryProvider::GitlabReleases, BinaryProvider::GithubReleases],
+            vec![Box::new(gitlab2), Box::new(github)],
+        );
+
+        let result = r2
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+
+        assert_matches!(result, Some(_));
+        assert!(
+            github_calls.load(Ordering::SeqCst) >= 1,
+            "GitHub must be consulted once the stale negative entry is invalidated"
+        );
+    }
+
+    /// An identical provider set across runs must NOT invalidate: the second run is a cache hit and
+    /// the providers are not consulted again.
+    #[test]
+    fn identical_provider_set_is_cache_hit() {
+        let (cache, config, _temp) = test_env();
+        let enabled = vec![BinaryProvider::GitlabReleases, BinaryProvider::GithubReleases];
+
+        let gl1 = StubProvider::nonexistent();
+        let gh1 = StubProvider::nonexistent();
+        let (gl1_calls, gh1_calls) = (gl1.calls.clone(), gh1.calls.clone());
+        let r1 = resolver_with_enabled_providers(
+            cache.clone(),
+            config.clone(),
+            enabled.clone(),
+            vec![Box::new(gl1), Box::new(gh1)],
+        );
+        assert_matches!(
+            r1.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(None)
+        );
+        assert_eq!(gl1_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(gh1_calls.load(Ordering::SeqCst), 1);
+
+        let gl2 = StubProvider::nonexistent();
+        let gh2 = StubProvider::nonexistent();
+        let (gl2_calls, gh2_calls) = (gl2.calls.clone(), gh2.calls.clone());
+        let r2 = resolver_with_enabled_providers(cache, config, enabled, vec![Box::new(gl2), Box::new(gh2)]);
+        assert_matches!(
+            r2.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(None)
+        );
+        assert_eq!(
+            gl2_calls.load(Ordering::SeqCst),
+            0,
+            "cache hit must not re-consult providers"
+        );
+        assert_eq!(
+            gh2_calls.load(Ordering::SeqCst),
+            0,
+            "cache hit must not re-consult providers"
+        );
+    }
+
+    /// Removing a provider that did NOT produce the cached binary keeps the positive entry valid
+    /// (coverage still holds and the finder is still enabled): cache hit, no re-consultation.
+    #[test]
+    fn removing_non_finder_provider_keeps_positive_entry() {
+        let (cache, config, temp) = test_env();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+
+        // Phase 1: GitHub (the finder) + Quickinstall enabled; GitHub is first and is found.
+        let github = StubProvider::found(BinaryProvider::GithubReleases, src);
+        let quick = StubProvider::nonexistent();
+        let r1 = resolver_with_enabled_providers(
+            cache.clone(),
+            config.clone(),
+            vec![BinaryProvider::GithubReleases, BinaryProvider::Quickinstall],
+            vec![Box::new(github), Box::new(quick)],
+        );
+        assert_matches!(
+            r1.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(Some(_))
+        );
+
+        // Phase 2: drop the non-finder Quickinstall; GitHub remains enabled -> still a cache hit.
+        let github2 = StubProvider::nonexistent();
+        let github2_calls = github2.calls.clone();
+        let r2 = resolver_with_enabled_providers(
+            cache,
+            config,
+            vec![BinaryProvider::GithubReleases],
+            vec![Box::new(github2)],
+        );
+        let result = r2
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+        assert_matches!(result, Some(_));
+        assert_eq!(
+            github2_calls.load(Ordering::SeqCst),
+            0,
+            "a still-valid positive entry must not re-consult providers"
+        );
+    }
+
+    /// Disabling the exact provider that produced the cached binary invalidates the positive entry:
+    /// the binary must not be served, and the crate is re-resolved.
+    #[test]
+    fn disabling_finder_invalidates_positive_entry() {
+        let (cache, config, temp) = test_env();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+
+        // Phase 1: GitLab + GitHub enabled; GitHub (second) is found, so the finder is GitHub.
+        let gitlab = StubProvider::nonexistent();
+        let github = StubProvider::found(BinaryProvider::GithubReleases, src);
+        let r1 = resolver_with_enabled_providers(
+            cache.clone(),
+            config.clone(),
+            vec![BinaryProvider::GitlabReleases, BinaryProvider::GithubReleases],
+            vec![Box::new(gitlab), Box::new(github)],
+        );
+        assert_matches!(
+            r1.resolve(&test_downloaded_crate(), &BuildOptions::default()),
+            Ok(Some(_))
+        );
+
+        // Phase 2: GitHub (the finder) disabled, only GitLab enabled (which has no binary).
+        let gitlab2 = StubProvider::nonexistent();
+        let gitlab2_calls = gitlab2.calls.clone();
+        let r2 = resolver_with_enabled_providers(
+            cache,
+            config,
+            vec![BinaryProvider::GitlabReleases],
+            vec![Box::new(gitlab2)],
+        );
+        let result = r2
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap();
+        assert_eq!(
+            result, None,
+            "a binary from a now-disabled provider must not be served"
+        );
+        assert_eq!(
+            gitlab2_calls.load(Ordering::SeqCst),
+            1,
+            "must re-resolve once the finder is disabled"
         );
     }
 }

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -50,7 +50,8 @@ pub trait BinaryResolver {
     ) -> Result<Option<ResolvedBinary>>;
 }
 
-/// A conclusive binary-resolution outcome: the cacheable subset of [`BinaryResolution`].
+/// A conclusive provider outcome: a binary was found, or this provider determined
+/// no binary is available.
 ///
 /// The two variants distinguish a positive result (a pre-built binary was resolved) from a
 /// conclusive negative (we determined no pre-built binary is available).  Theoretically it's
@@ -123,6 +124,15 @@ impl BinaryResolution {
             BinaryResolution::Found(binary) => Some(ConclusiveResolution::Found(binary.clone())),
             BinaryResolution::Nonexistent => Some(ConclusiveResolution::Nonexistent),
             BinaryResolution::Inconclusive { .. } => None,
+        }
+    }
+}
+
+impl From<ConclusiveResolution> for BinaryResolution {
+    fn from(value: ConclusiveResolution) -> Self {
+        match value {
+            ConclusiveResolution::Found(binary) => Self::Found(binary),
+            ConclusiveResolution::Nonexistent => Self::Nonexistent,
         }
     }
 }
@@ -366,7 +376,24 @@ impl DefaultBinaryResolver {
         for provider in &self.providers {
             self.reporter
                 .report(|| PrebuiltBinaryMessage::checking_provider(resolved, provider.kind()));
-            let resolution = provider.try_resolve(krate, platform)?;
+
+            // Invoke the provider, and based on the outcome construct the BinaryResolution result.
+            //
+            // If a single provide fails with any kind of error, we consider that an inconclusive
+            // result.  Under normal circumstances, providers should not be failing; if the
+            // provider determines the binary isn't found that should be an Ok response.  However,
+            // the providers do a lot of fallible things, including making API calls that can be
+            // throttled, parsing formats that could be invalid, etc.
+            //
+            // If a provider fails for a given crate input, that is likely a bug in the provider
+            // code somewhere, but such a bug should not cause the binary resolution process itself
+            // to return an error, nor should it result in a permanent negative cache entry.
+            let resolution = match provider.try_resolve(krate, platform) {
+                Ok(resolution) => BinaryResolution::from(resolution),
+                Err(source) => BinaryResolution::Inconclusive {
+                    source: Box::new(source),
+                },
+            };
             let found = matches!(resolution, BinaryResolution::Found(_));
             results.push(resolution);
             if found {
@@ -567,10 +594,10 @@ mod tests {
     enum StubOutcome {
         Found(ResolvedBinary),
         Nonexistent,
-        Inconclusive,
+        Error,
     }
 
-    /// A [`Provider`] standing in for a real provider, returning a canned [`BinaryResolution`] and
+    /// A [`Provider`] standing in for a real provider, returning a canned provider result and
     /// counting how often it is consulted (so tests can assert short-circuiting and cache hits).
     struct StubProvider {
         outcome: StubOutcome,
@@ -597,6 +624,13 @@ mod tests {
                 calls: Arc::new(AtomicUsize::new(0)),
             }
         }
+
+        fn error() -> Self {
+            Self {
+                outcome: StubOutcome::Error,
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
     }
 
     impl Provider for StubProvider {
@@ -604,27 +638,27 @@ mod tests {
             BinaryProvider::GithubReleases
         }
 
-        fn try_resolve(&self, _krate: &DownloadedCrate, _platform: &str) -> Result<BinaryResolution> {
+        fn try_resolve(&self, _krate: &DownloadedCrate, _platform: &str) -> Result<ConclusiveResolution> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(match &self.outcome {
-                StubOutcome::Found(binary) => BinaryResolution::Found(binary.clone()),
-                StubOutcome::Nonexistent => BinaryResolution::Nonexistent,
-                StubOutcome::Inconclusive => BinaryResolution::Inconclusive {
-                    source: boxed_transient(),
-                },
-            })
+            match &self.outcome {
+                StubOutcome::Found(binary) => Ok(ConclusiveResolution::Found(binary.clone())),
+                StubOutcome::Nonexistent => Ok(ConclusiveResolution::Nonexistent),
+                StubOutcome::Error => Err(transient_error()),
+            }
         }
     }
 
-    /// A boxed transient (HTTP 429) error, standing in for a rate limit error / network glitch.
+    /// A transient-looking HTTP 429 error, standing in for a rate limit error / network glitch.
+    fn transient_error() -> Error {
+        error::HttpStatusSnafu {
+            url: "https://api.github.com/repos/x/y/releases/tags/v1.0.0".to_string(),
+            status: 429u16,
+        }
+        .build()
+    }
+
     fn boxed_transient() -> Box<Error> {
-        Box::new(
-            error::HttpStatusSnafu {
-                url: "https://api.github.com/repos/x/y/releases/tags/v1.0.0".to_string(),
-                status: 429u16,
-            }
-            .build(),
-        )
+        Box::new(transient_error())
     }
 
     fn test_env() -> (Cache, Config, TempDir) {
@@ -1087,7 +1121,7 @@ mod tests {
             cache.clone(),
             config,
             UsePrebuiltBinaries::Auto,
-            StubOutcome::Inconclusive,
+            StubOutcome::Error,
         );
 
         let result = resolver
@@ -1101,6 +1135,33 @@ mod tests {
             Ok(None),
             "an inconclusive resolution must not be persisted"
         );
+    }
+
+    #[test]
+    fn auto_mode_continues_after_provider_error_and_returns_later_found() {
+        let (cache, config, temp) = test_env();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+
+        let first = StubProvider::error();
+        let first_calls = first.calls.clone();
+        let second = StubProvider::found(BinaryProvider::GithubReleases, src);
+        let second_calls = second.calls.clone();
+        let resolver = resolver_with_enabled_providers(
+            cache,
+            config,
+            vec![BinaryProvider::GitlabReleases, BinaryProvider::GithubReleases],
+            vec![Box::new(first), Box::new(second)],
+        );
+
+        let result = resolver
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.provider, BinaryProvider::GithubReleases);
+        assert_eq!(first_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(second_calls.load(Ordering::SeqCst), 1);
     }
 
     /// A conclusive absence IS cached (as a negative entry), so later runs skip the providers.
@@ -1136,14 +1197,15 @@ mod tests {
             cache.clone(),
             config,
             UsePrebuiltBinaries::Always,
-            StubOutcome::Inconclusive,
+            StubOutcome::Error,
         );
 
         let result = resolver.resolve(&test_downloaded_crate(), &BuildOptions::default());
 
         assert_matches!(
             result,
-            Err(Error::PrebuiltBinaryResolutionFailed { ref name, .. }) if name == "serde"
+            Err(Error::PrebuiltBinaryResolutionFailed { ref name, ref source, .. })
+                if name == "serde" && matches!(source.as_ref(), Error::HttpStatus { status: 429, .. })
         );
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_matches!(

--- a/cgx-core/src/bin_resolver/providers/archive.rs
+++ b/cgx-core/src/bin_resolver/providers/archive.rs
@@ -17,6 +17,16 @@ pub(in crate::bin_resolver) enum ArchiveFormat {
     TarZst,
     TarBz2,
     Zip,
+    /// A single executable compressed with gzip (no tar wrapper).
+    Gz,
+    /// A single executable compressed with xz (no tar wrapper).
+    Xz,
+    /// A single executable compressed with zstd (no tar wrapper).
+    Zst,
+    /// A single executable compressed with bzip2 (no tar wrapper).
+    Bz2,
+
+    /// The release artifact itself is just the naked binary, with no compression.
     NakedBinary,
 }
 
@@ -30,6 +40,10 @@ impl ArchiveFormat {
             Self::TarZst => "archive.tar.zst",
             Self::TarBz2 => "archive.tar.bz2",
             Self::Zip => "archive.zip",
+            Self::Gz => "archive.gz",
+            Self::Xz => "archive.xz",
+            Self::Zst => "archive.zst",
+            Self::Bz2 => "archive.bz2",
             Self::NakedBinary => {
                 if cfg!(windows) {
                     "archive.exe"
@@ -52,6 +66,10 @@ impl ArchiveFormat {
                 (Self::TarZst, ".tar.zst"),
                 (Self::TarBz2, ".tar.bz2"),
                 (Self::Zip, ".zip"),
+                (Self::Gz, ".gz"),
+                (Self::Xz, ".xz"),
+                (Self::Zst, ".zst"),
+                (Self::Bz2, ".bz2"),
                 (Self::NakedBinary, ".exe"),
             ]
         }
@@ -65,6 +83,10 @@ impl ArchiveFormat {
                 (Self::TarZst, ".tar.zst"),
                 (Self::TarBz2, ".tar.bz2"),
                 (Self::Zip, ".zip"),
+                (Self::Gz, ".gz"),
+                (Self::Xz, ".xz"),
+                (Self::Zst, ".zst"),
+                (Self::Bz2, ".bz2"),
                 (Self::NakedBinary, ""),
             ]
         }
@@ -87,8 +109,75 @@ pub(in crate::bin_resolver) fn extract_binary(
         ArchiveFormat::TarZst => extract_tar_zst(archive_path, expected_binary_name, dest_dir),
         ArchiveFormat::TarBz2 => extract_tar_bz2(archive_path, expected_binary_name, dest_dir),
         ArchiveFormat::Zip => extract_zip(archive_path, expected_binary_name, dest_dir),
+        ArchiveFormat::Gz | ArchiveFormat::Xz | ArchiveFormat::Zst | ArchiveFormat::Bz2 => {
+            extract_naked_compressed(archive_path, format, expected_binary_name, dest_dir)
+        }
         ArchiveFormat::NakedBinary => extract_naked_binary(archive_path, expected_binary_name, dest_dir),
     }
+}
+
+/// Extract a single executable compressed without a tar wrapper (e.g. a bare `.gz`).
+///
+/// Unlike the `tar.*` formats, the decompressed stream *is* the binary, so there is no archive tree
+/// to search with [`find_binary_in_dir`]: the bytes are written directly to
+/// `dest_dir/{binary_name}{EXE_SUFFIX}` and marked executable.
+fn extract_naked_compressed(
+    archive_path: &Path,
+    format: ArchiveFormat,
+    binary_name: &str,
+    dest_dir: &Path,
+) -> Result<PathBuf> {
+    let file = std::fs::File::open(archive_path).with_context(|_| error::IoSnafu {
+        path: archive_path.to_path_buf(),
+    })?;
+
+    let mut reader: Box<dyn std::io::Read> = match format {
+        ArchiveFormat::Gz => Box::new(GzDecoder::new(file)),
+        ArchiveFormat::Xz => Box::new(XzDecoder::new(file)),
+        ArchiveFormat::Bz2 => Box::new(BzDecoder::new(file)),
+        ArchiveFormat::Zst => Box::new(zstd::stream::read::Decoder::new(file).map_err(|e| {
+            error::Error::ArchiveExtractionFailed {
+                source: Box::new(e) as Box<dyn std::error::Error + Send + Sync>,
+            }
+        })?),
+        ArchiveFormat::Tar
+        | ArchiveFormat::TarGz
+        | ArchiveFormat::TarXz
+        | ArchiveFormat::TarZst
+        | ArchiveFormat::TarBz2
+        | ArchiveFormat::Zip
+        | ArchiveFormat::NakedBinary => {
+            unreachable!("BUG: extract_naked_compressed only handles the naked compressed formats")
+        }
+    };
+
+    std::fs::create_dir_all(dest_dir).with_context(|_| error::IoSnafu {
+        path: dest_dir.to_path_buf(),
+    })?;
+
+    let dest_path = dest_dir.join(format!("{}{}", binary_name, std::env::consts::EXE_SUFFIX));
+    let mut dest_file = std::fs::File::create(&dest_path).with_context(|_| error::IoSnafu {
+        path: dest_path.clone(),
+    })?;
+
+    std::io::copy(&mut reader, &mut dest_file).map_err(|e| error::Error::ArchiveExtractionFailed {
+        source: Box::new(e) as Box<dyn std::error::Error + Send + Sync>,
+    })?;
+
+    #[cfg(unix)]
+    {
+        let mut perms = std::fs::metadata(&dest_path)
+            .with_context(|_| error::IoSnafu {
+                path: dest_path.clone(),
+            })?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&dest_path, perms).with_context(|_| error::IoSnafu {
+            path: dest_path.clone(),
+        })?;
+    }
+
+    Ok(dest_path)
 }
 
 fn extract_tar(archive_path: &Path, binary_name: &str, dest_dir: &Path) -> Result<PathBuf> {
@@ -268,6 +357,10 @@ mod tests {
                 Self::TarZst => ".tar.zst",
                 Self::TarBz2 => ".tar.bz2",
                 Self::Zip => ".zip",
+                Self::Gz => ".gz",
+                Self::Xz => ".xz",
+                Self::Zst => ".zst",
+                Self::Bz2 => ".bz2",
                 Self::NakedBinary => {
                     if cfg!(windows) {
                         ".exe"
@@ -538,6 +631,44 @@ mod tests {
         let binary_path = result.unwrap();
         assert!(binary_path.exists());
         assert!(binary_path.to_string_lossy().contains("testbin"));
+
+        #[cfg(unix)]
+        {
+            let perms = fs::metadata(&binary_path).unwrap().permissions();
+            assert_eq!(perms.mode() & 0o777, 0o755, "Binary should have 755 permissions");
+        }
+    }
+
+    /// A bare `.gz` (a single binary gzipped without a tar wrapper, as published by e.g. taplo)
+    /// decompresses directly to the named binary, executable, with no archive tree to search.
+    #[test]
+    fn test_extract_naked_gz() {
+        let payload = b"#!/bin/sh\necho test";
+
+        let mut gz_data = Vec::new();
+        {
+            let mut encoder = GzEncoder::new(&mut gz_data, Compression::default());
+            encoder.write_all(payload).unwrap();
+            encoder.finish().unwrap();
+        }
+
+        let temp_archive = tempfile::NamedTempFile::new().unwrap();
+        fs::write(temp_archive.path(), &gz_data).unwrap();
+
+        let dest_dir = tempfile::tempdir().unwrap();
+        let binary_path =
+            extract_binary(temp_archive.path(), ArchiveFormat::Gz, "taplo", dest_dir.path()).unwrap();
+
+        assert!(binary_path.exists());
+        assert_eq!(
+            binary_path.file_name().unwrap().to_string_lossy(),
+            format!("taplo{}", std::env::consts::EXE_SUFFIX)
+        );
+        assert_eq!(
+            fs::read(&binary_path).unwrap(),
+            payload,
+            "decompressed bytes are the binary"
+        );
 
         #[cfg(unix)]
         {

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -9,7 +9,7 @@ use snafu::ResultExt;
 use super::{ArchiveFormat, Provider};
 use crate::{
     Result,
-    bin_resolver::{BinaryResolution, ResolvedBinary},
+    bin_resolver::{ConclusiveResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     downloader::DownloadedCrate,
@@ -231,7 +231,7 @@ impl Provider for BinstallProvider {
         BinaryProvider::Binstall
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
         let resolved = &krate.resolved;
 
         let Some(meta) = Self::read_binstall_metadata(krate, platform)? else {
@@ -241,7 +241,7 @@ impl Provider for BinstallProvider {
                     "no [package.metadata.binstall] in Cargo.toml",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let Some(ref pkg_url_template) = meta.pkg_url else {
@@ -251,7 +251,7 @@ impl Provider for BinstallProvider {
                     "binstall metadata has no pkg-url",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let pkg_fmt = meta.pkg_fmt.as_deref();
@@ -263,7 +263,6 @@ impl Provider for BinstallProvider {
 
         let mut last_url = String::new();
         let mut data = None;
-        let mut transient: Option<Box<error::Error>> = None;
 
         for suffix in suffixes {
             let ctx = TemplateContext {
@@ -290,25 +289,11 @@ impl Provider for BinstallProvider {
                 Ok(None) => {
                     last_url = url;
                 }
-                Err(e) if e.is_transient_http_error() => {
-                    transient = Some(Box::new(e));
-                    last_url = url;
-                    break;
-                }
                 Err(e) => return Err(e),
             }
         }
 
         let Some(data) = data else {
-            if let Some(source) = transient {
-                // If even one provider failed with a transient error, we consider the resolution
-                // inconclusive. This transient error is just what went wrong that prevented
-                // at least one provider from being able to provide a definitive answer.
-                //
-                // Report the error as part of the resolution for diagnostic purposes.
-                return Ok(BinaryResolution::Inconclusive { source });
-            }
-
             // If not binary found and no transient error then it just means this crate legit
             // doesn't have a prebuilt binary for this platform in any of the places we know to
             // look.
@@ -318,7 +303,7 @@ impl Provider for BinstallProvider {
                     format!("download failed: {}", last_url),
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
         let url = last_url;
 
@@ -369,7 +354,7 @@ impl Provider for BinstallProvider {
             })?;
         }
 
-        Ok(BinaryResolution::Found(ResolvedBinary {
+        Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: resolved.clone(),
             provider: BinaryProvider::Binstall,
             path: final_path,

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -9,7 +9,7 @@ use snafu::ResultExt;
 use super::{ArchiveFormat, Provider};
 use crate::{
     Result,
-    bin_resolver::ResolvedBinary,
+    bin_resolver::{BinaryResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     downloader::DownloadedCrate,
@@ -227,7 +227,11 @@ impl BinstallProvider {
 }
 
 impl Provider for BinstallProvider {
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<Option<ResolvedBinary>> {
+    fn kind(&self) -> BinaryProvider {
+        BinaryProvider::Binstall
+    }
+
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
         let resolved = &krate.resolved;
 
         let Some(meta) = Self::read_binstall_metadata(krate, platform)? else {
@@ -237,7 +241,7 @@ impl Provider for BinstallProvider {
                     "no [package.metadata.binstall] in Cargo.toml",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         let Some(ref pkg_url_template) = meta.pkg_url else {
@@ -247,7 +251,7 @@ impl Provider for BinstallProvider {
                     "binstall metadata has no pkg-url",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         let pkg_fmt = meta.pkg_fmt.as_deref();
@@ -259,6 +263,7 @@ impl Provider for BinstallProvider {
 
         let mut last_url = String::new();
         let mut data = None;
+        let mut transient: Option<Box<error::Error>> = None;
 
         for suffix in suffixes {
             let ctx = TemplateContext {
@@ -276,23 +281,44 @@ impl Provider for BinstallProvider {
             self.reporter
                 .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Binstall));
 
-            if let Some(bytes) = self.try_download(&url)? {
-                data = Some(bytes);
-                last_url = url;
-                break;
+            match self.try_download(&url) {
+                Ok(Some(bytes)) => {
+                    data = Some(bytes);
+                    last_url = url;
+                    break;
+                }
+                Ok(None) => {
+                    last_url = url;
+                }
+                Err(e) if e.is_transient_http_error() => {
+                    transient = Some(Box::new(e));
+                    last_url = url;
+                    break;
+                }
+                Err(e) => return Err(e),
             }
-
-            last_url = url;
         }
 
         let Some(data) = data else {
+            if let Some(source) = transient {
+                // If even one provider failed with a transient error, we consider the resolution inconclusive.
+                // This transient error is just what went wrong that prevented at least one provider
+                // from being able to provide a definitive answer.
+                //
+                // Report the error as part of the resolution for diagnostic purposes.
+                return Ok(BinaryResolution::Inconclusive { source });
+            }
+
+            // If not binary found and no transient error then it just means this crate legit
+            // doesn't have a prebuilt binary for this platform in any of the places we know to
+            // look.
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::Binstall,
                     format!("download failed: {}", last_url),
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
         let url = last_url;
 
@@ -343,7 +369,7 @@ impl Provider for BinstallProvider {
             })?;
         }
 
-        Ok(Some(ResolvedBinary {
+        Ok(BinaryResolution::Found(ResolvedBinary {
             krate: resolved.clone(),
             provider: BinaryProvider::Binstall,
             path: final_path,

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -301,9 +301,9 @@ impl Provider for BinstallProvider {
 
         let Some(data) = data else {
             if let Some(source) = transient {
-                // If even one provider failed with a transient error, we consider the resolution inconclusive.
-                // This transient error is just what went wrong that prevented at least one provider
-                // from being able to provide a definitive answer.
+                // If even one provider failed with a transient error, we consider the resolution
+                // inconclusive. This transient error is just what went wrong that prevented
+                // at least one provider from being able to provide a definitive answer.
                 //
                 // Report the error as part of the resolution for diagnostic purposes.
                 return Ok(BinaryResolution::Inconclusive { source });

--- a/cgx-core/src/bin_resolver/providers/github.rs
+++ b/cgx-core/src/bin_resolver/providers/github.rs
@@ -2,6 +2,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
+use reqwest::StatusCode;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use snafu::ResultExt;
@@ -9,7 +10,7 @@ use snafu::ResultExt;
 use super::Provider;
 use crate::{
     Result,
-    bin_resolver::{BinaryResolution, ResolvedBinary},
+    bin_resolver::{ConclusiveResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     cratespec::Forge,
@@ -121,21 +122,19 @@ impl GithubProvider {
             }
         }
 
-        let response = self.http_client.get_with_headers(&url, &headers)?;
+        let response =
+            self.http_client
+                .get_with_headers_retrying_status(&url, &headers, Self::should_retry_status)?;
 
         if !response.status().is_success() {
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
+            if response.status() == StatusCode::NOT_FOUND {
                 // The API call worked, and Github is telling us that there are not release assets
                 // for this resource.  From the caller's perspective that isn't an error at all, it
                 // is a conclusive, negative result.
                 return Ok(Vec::new());
             }
 
-            return error::HttpStatusSnafu {
-                url: url.clone(),
-                status: response.status().as_u16(),
-            }
-            .fail();
+            return Self::non_success_response_error(&url, response);
         }
 
         let text = response
@@ -156,7 +155,102 @@ impl GithubProvider {
     /// Returns `Ok(Some(bytes))` on success, `Ok(None)` if the server returned 404 (resource
     /// does not exist), or `Err` for any other failure (network errors, non-404 HTTP errors).
     fn try_download(&self, url: &str) -> Result<Option<Bytes>> {
-        self.http_client.try_download(url)
+        let response = self
+            .http_client
+            .get_retrying_status(url, Self::should_retry_status)?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if !response.status().is_success() {
+            return Self::non_success_response_error(url, response);
+        }
+
+        let bytes = response
+            .bytes()
+            .with_context(|_| error::HttpRequestSnafu { url: url.to_string() })?;
+
+        Ok(Some(bytes))
+    }
+
+    /// GitHub rate limiting can be reported as HTTP 403 or 429, and callers should not retry
+    /// errors that are indicative of rate limiting. Let those statuses return to this provider so
+    /// [`Self::non_success_response_error`] can decide whether they are throttle responses; keep
+    /// ordinary server errors retryable through [`HttpClient`].
+    fn should_retry_status(status: StatusCode) -> bool {
+        status.is_server_error()
+    }
+
+    /// Classify a non-success GitHub API or release-asset response.
+    ///
+    /// GitHub uses HTTP 404 for an absent release tag or asset, which callers handle before this
+    /// function. This helper checks the remaining GitHub-specific throttle signals on HTTP 403/429
+    /// and otherwise preserves the response as a normal HTTP status error.
+    fn non_success_response_error<T>(url: &str, response: reqwest::blocking::Response) -> Result<T> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = if status == StatusCode::FORBIDDEN && !Self::is_throttled_response(status, &headers, None)
+        {
+            Some(
+                response
+                    .text()
+                    .with_context(|_| error::HttpRequestSnafu { url: url.to_string() })?,
+            )
+        } else {
+            None
+        };
+
+        if Self::is_throttled_response(status, &headers, body.as_deref()) {
+            return Err(Self::provider_throttled_error(url, status));
+        }
+
+        error::HttpStatusSnafu {
+            url: url.to_string(),
+            status: status.as_u16(),
+        }
+        .fail()
+    }
+
+    /// Return whether a GitHub HTTP response represents API throttling rather than an ordinary
+    /// authorization or client error.
+    ///
+    /// GitHub can report rate limiting with HTTP 429 directly, or with HTTP 403 plus headers such
+    /// as `retry-after` / `x-ratelimit-remaining: 0`, or with a rate-limit message in the response
+    /// body.
+    fn is_throttled_response(status: StatusCode, headers: &HeaderMap, body: Option<&str>) -> bool {
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            return true;
+        }
+
+        status == StatusCode::FORBIDDEN
+            && (Self::header_value(headers, "retry-after").is_some()
+                || Self::header_value(headers, "x-ratelimit-remaining").as_deref() == Some("0")
+                || body.is_some_and(Self::is_rate_limit_body))
+    }
+
+    /// Detect GitHub's textual rate-limit responses when the HTTP 403 headers alone are not enough
+    /// to distinguish throttling from ordinary forbidden access.
+    fn is_rate_limit_body(body: &str) -> bool {
+        let body = body.to_ascii_lowercase();
+        body.contains("rate limit") || body.contains("rate-limit") || body.contains("too many requests")
+    }
+
+    /// Build the provider-throttle error after GitHub-specific response classification has already
+    /// decided that the status represents rate limiting.
+    fn provider_throttled_error(url: &str, status: StatusCode) -> error::Error {
+        error::ProviderThrottledSnafu {
+            url: url.to_string(),
+            status: status.as_u16(),
+        }
+        .build()
+    }
+
+    fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
     }
 
     fn verify_checksum(&self, data: &[u8], url: &str) -> Result<()> {
@@ -202,7 +296,7 @@ impl Provider for GithubProvider {
         BinaryProvider::GithubReleases
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -212,7 +306,7 @@ impl Provider for GithubProvider {
                     "no repository URL available",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let Some((owner, repo)) = Self::parse_owner_repo(&repo_url) else {
@@ -222,7 +316,7 @@ impl Provider for GithubProvider {
                     format!("could not parse owner/repo from URL: {}", repo_url),
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let Some(api_base) = Self::api_base(&repo_url) else {
@@ -232,47 +326,35 @@ impl Provider for GithubProvider {
                     format!("could not determine API base for URL: {}", repo_url),
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let version = krate.resolved.version.to_string();
 
-        // Try both v{version} and {version} tags; stop at the first that returns assets. A transient
-        // failure (rate limit, network) on a tag is remembered: if no tag yields assets and at least
-        // one lookup failed transiently, the result is inconclusive.  To produce a definitive
-        // negative result, all lookups must succeed and return no assets.
+        // Try both v{version} and {version} tags; stop at the first that returns assets.
         let tags = [format!("v{}", version), version.clone()];
         let mut assets = Vec::new();
-        let mut transient: Option<Box<error::Error>> = None;
         for tag in &tags {
+            // `list_release_assets` already handles 404 and just returns an empty vec, so we can
+            // just check if the result is empty or not.
             match self.list_release_assets(&api_base, owner, repo, tag) {
                 Ok(a) if !a.is_empty() => {
                     assets = a;
                     break;
                 }
                 Ok(_) => {}
-                Err(e) if e.is_transient_http_error() => {
-                    if transient.is_none() {
-                        transient = Some(Box::new(e));
-                    }
-                }
                 Err(e) => return Err(e),
             }
         }
 
         if assets.is_empty() {
-            if let Some(source) = transient {
-                tracing::debug!(error = %source,
-                    "GitHub release lookup failed transiently; result is inconclusive");
-                return Ok(BinaryResolution::Inconclusive { source });
-            }
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::GithubReleases,
                     "no release found for any tag variant",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         }
 
         let crate_name = krate.resolved.name.as_str();
@@ -303,7 +385,7 @@ impl Provider for GithubProvider {
                     "no matching asset found in release",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         self.reporter.report(|| {
@@ -319,10 +401,7 @@ impl Provider for GithubProvider {
                         format!("Release artifact not found: {}", download_url),
                     )
                 });
-                return Ok(BinaryResolution::Nonexistent);
-            }
-            Err(e) if e.is_transient_http_error() => {
-                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+                return Ok(ConclusiveResolution::Nonexistent);
             }
             Err(e) => return Err(e),
         };
@@ -374,7 +453,7 @@ impl Provider for GithubProvider {
             })?;
         }
 
-        Ok(BinaryResolution::Found(ResolvedBinary {
+        Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GithubReleases,
             path: final_path,
@@ -384,13 +463,41 @@ impl Provider for GithubProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, time::Duration};
 
+    use assert_matches::assert_matches;
+    use httpmock::prelude::*;
     use semver::Version;
     use url::Url;
 
     use super::*;
-    use crate::{crate_resolver::ResolvedSource, cratespec::Forge};
+    use crate::{
+        config::HttpConfig, crate_resolver::ResolvedSource, cratespec::Forge, error::Error,
+        messages::MessageReporter,
+    };
+
+    fn fast_retry_config() -> HttpConfig {
+        HttpConfig {
+            retries: 2,
+            backoff_base: Duration::from_millis(1),
+            backoff_max: Duration::from_millis(10),
+            ..Default::default()
+        }
+    }
+
+    fn test_provider() -> (GithubProvider, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let http_client = HttpClient::new(&fast_retry_config()).unwrap();
+        (
+            GithubProvider::new(
+                MessageReporter::null(),
+                temp_dir.path().to_path_buf(),
+                false,
+                http_client,
+            ),
+            temp_dir,
+        )
+    }
 
     #[test]
     fn test_parse_owner_repo_standard() {
@@ -596,5 +703,54 @@ repository = "https://github.com/owner/mytool"
 
         let url = GithubProvider::get_repo_url(&krate).unwrap();
         assert_eq!(url, Some("https://github.com/owner/mytool".to_string()));
+    }
+
+    #[test]
+    fn list_release_assets_429_is_not_retried_and_becomes_provider_throttled() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/releases/tags/v1.0.0");
+            then.status(429).header("retry-after", "60");
+        });
+        let (provider, _temp_dir) = test_provider();
+
+        let result = provider.list_release_assets(&server.base_url(), "owner", "repo", "v1.0.0");
+
+        assert_matches!(result, Err(Error::ProviderThrottled { status: 429, .. }));
+        mock.assert_calls(1);
+    }
+
+    #[test]
+    fn list_release_assets_403_with_zero_remaining_becomes_provider_throttled() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/releases/tags/v1.0.0");
+            then.status(403)
+                .header("x-ratelimit-remaining", "0")
+                .header("x-ratelimit-reset", "1710000000");
+        });
+        let (provider, _temp_dir) = test_provider();
+
+        let result = provider.list_release_assets(&server.base_url(), "owner", "repo", "v1.0.0");
+
+        assert_matches!(result, Err(Error::ProviderThrottled { status: 403, .. }));
+        mock.assert_calls(1);
+    }
+
+    #[test]
+    fn list_release_assets_404_returns_empty_assets() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/repos/owner/repo/releases/tags/v1.0.0");
+            then.status(404);
+        });
+        let (provider, _temp_dir) = test_provider();
+
+        let assets = provider
+            .list_release_assets(&server.base_url(), "owner", "repo", "v1.0.0")
+            .unwrap();
+
+        assert!(assets.is_empty());
+        mock.assert_calls(1);
     }
 }

--- a/cgx-core/src/bin_resolver/providers/github.rs
+++ b/cgx-core/src/bin_resolver/providers/github.rs
@@ -9,7 +9,7 @@ use snafu::ResultExt;
 use super::Provider;
 use crate::{
     Result,
-    bin_resolver::ResolvedBinary,
+    bin_resolver::{BinaryResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     cratespec::Forge,
@@ -102,16 +102,15 @@ impl GithubProvider {
 
     /// List release assets for a given tag from the GitHub Releases API.
     ///
-    /// Returns a vec of `(asset_name, download_url)` pairs.
-    /// If the request fails, returns a non-success status, or cannot be parsed, treats the release
-    /// as having no usable assets.
+    /// Returns a vec of `(asset_name, download_url)` pairs. A 404 (no release for the tag) is a
+    /// conclusive absence and maps to `Ok(empty)`. Any other failure  is returned as `Err`.
     fn list_release_assets(
         &self,
         api_base: &str,
         owner: &str,
         repo: &str,
         tag: &str,
-    ) -> Vec<(String, String)> {
+    ) -> Result<Vec<(String, String)>> {
         let url = format!("{}/repos/{}/{}/releases/tags/{}", api_base, owner, repo, tag);
 
         let mut headers = HeaderMap::new();
@@ -122,30 +121,34 @@ impl GithubProvider {
             }
         }
 
-        let response = match self.http_client.get_with_headers(&url, &headers) {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
-        };
+        let response = self.http_client.get_with_headers(&url, &headers)?;
 
         if !response.status().is_success() {
-            return Vec::new();
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                // The API call worked, and Github is telling us that there are not release assets
+                // for this resource.  From the caller's perspective that isn't an error at all, it
+                // is a conclusive, negative result.
+                return Ok(Vec::new());
+            }
+
+            return error::HttpStatusSnafu {
+                url: url.clone(),
+                status: response.status().as_u16(),
+            }
+            .fail();
         }
 
-        let text = match response.text() {
-            Ok(t) => t,
-            Err(_) => return Vec::new(),
-        };
+        let text = response
+            .text()
+            .with_context(|_| error::HttpRequestSnafu { url: url.clone() })?;
 
-        let release: ReleaseResponse = match serde_json::from_str(&text) {
-            Ok(r) => r,
-            Err(_) => return Vec::new(),
-        };
+        let release: ReleaseResponse = serde_json::from_str(&text).context(error::JsonSnafu)?;
 
-        release
+        Ok(release
             .assets
             .into_iter()
             .map(|a| (a.name, a.browser_download_url))
-            .collect()
+            .collect())
     }
 
     /// Download a file from the given URL.
@@ -195,7 +198,11 @@ impl GithubProvider {
 }
 
 impl Provider for GithubProvider {
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<Option<ResolvedBinary>> {
+    fn kind(&self) -> BinaryProvider {
+        BinaryProvider::GithubReleases
+    }
+
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -205,7 +212,7 @@ impl Provider for GithubProvider {
                     "no repository URL available",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         let Some((owner, repo)) = Self::parse_owner_repo(&repo_url) else {
@@ -215,7 +222,7 @@ impl Provider for GithubProvider {
                     format!("could not parse owner/repo from URL: {}", repo_url),
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         let Some(api_base) = Self::api_base(&repo_url) else {
@@ -225,32 +232,58 @@ impl Provider for GithubProvider {
                     format!("could not determine API base for URL: {}", repo_url),
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         let version = krate.resolved.version.to_string();
 
-        // Try both v{version} and {version} tags; stop at the first that returns assets.
+        // Try both v{version} and {version} tags; stop at the first that returns assets. A transient
+        // failure (rate limit, network) on a tag is remembered: if no tag yields assets and at least
+        // one lookup failed transiently, the result is inconclusive.  To produce a definitive
+        // negative result, all lookups must succeed and return no assets.
         let tags = [format!("v{}", version), version.clone()];
         let mut assets = Vec::new();
+        let mut transient: Option<Box<error::Error>> = None;
         for tag in &tags {
-            assets = self.list_release_assets(&api_base, owner, repo, tag);
-            if !assets.is_empty() {
-                break;
+            match self.list_release_assets(&api_base, owner, repo, tag) {
+                Ok(a) if !a.is_empty() => {
+                    assets = a;
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) if e.is_transient_http_error() => {
+                    if transient.is_none() {
+                        transient = Some(Box::new(e));
+                    }
+                }
+                Err(e) => return Err(e),
             }
         }
 
         if assets.is_empty() {
+            if let Some(source) = transient {
+                tracing::debug!(error = %source,
+                    "GitHub release lookup failed transiently; result is inconclusive");
+                return Ok(BinaryResolution::Inconclusive { source });
+            }
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::GithubReleases,
                     "no release found for any tag variant",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         }
 
-        let candidates = super::generate_candidate_filenames(&krate.resolved.name, &version, platform);
+        let crate_name = krate.resolved.name.as_str();
+        let binary_names = krate.binary_names()?;
+        let extra_binary_names: Vec<&str> = binary_names
+            .iter()
+            .map(String::as_str)
+            .filter(|n| *n != crate_name)
+            .collect();
+        let candidates =
+            super::generate_candidate_filenames(crate_name, &extra_binary_names, &version, platform);
 
         let asset_map: std::collections::HashMap<&str, &str> = assets
             .iter()
@@ -270,23 +303,28 @@ impl Provider for GithubProvider {
                     "no matching asset found in release",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         self.reporter.report(|| {
             PrebuiltBinaryMessage::downloading_binary(download_url, BinaryProvider::GithubReleases)
         });
 
-        let data = if let Some(data) = self.try_download(download_url)? {
-            data
-        } else {
-            self.reporter.report(|| {
-                PrebuiltBinaryMessage::provider_has_no_binary(
-                    BinaryProvider::GithubReleases,
-                    format!("failed to download asset: {}", download_url),
-                )
-            });
-            return Ok(None);
+        let data = match self.try_download(download_url) {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::provider_has_no_binary(
+                        BinaryProvider::GithubReleases,
+                        format!("Release artifact not found: {}", download_url),
+                    )
+                });
+                return Ok(BinaryResolution::Nonexistent);
+            }
+            Err(e) if e.is_transient_http_error() => {
+                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+            }
+            Err(e) => return Err(e),
         };
 
         if self.verify_checksums {
@@ -336,7 +374,7 @@ impl Provider for GithubProvider {
             })?;
         }
 
-        Ok(Some(ResolvedBinary {
+        Ok(BinaryResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GithubReleases,
             path: final_path,

--- a/cgx-core/src/bin_resolver/providers/gitlab.rs
+++ b/cgx-core/src/bin_resolver/providers/gitlab.rs
@@ -8,7 +8,7 @@ use snafu::ResultExt;
 use super::{ArchiveFormat, CandidateFilename, Provider};
 use crate::{
     Result,
-    bin_resolver::ResolvedBinary,
+    bin_resolver::{BinaryResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     cratespec::Forge,
@@ -68,11 +68,13 @@ impl GitlabProvider {
     /// for both `v{version}` and `{version}` tags.
     fn generate_urls(
         repo_url: &str,
-        name: &str,
+        crate_name: &str,
+        extra_binary_names: &[&str],
         version: &str,
         platform: &str,
     ) -> Vec<(String, ArchiveFormat)> {
-        let candidates = super::generate_candidate_filenames(name, version, platform);
+        let candidates =
+            super::generate_candidate_filenames(crate_name, extra_binary_names, version, platform);
         let tags = [format!("v{}", version), version.to_string()];
 
         let mut urls = Vec::new();
@@ -144,7 +146,11 @@ impl GitlabProvider {
 }
 
 impl Provider for GitlabProvider {
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<Option<ResolvedBinary>> {
+    fn kind(&self) -> BinaryProvider {
+        BinaryProvider::GitlabReleases
+    }
+
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -154,19 +160,34 @@ impl Provider for GitlabProvider {
                     "no repository URL available",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
+        let crate_name = krate.resolved.name.as_str();
+        let binary_names = krate.binary_names()?;
+        let extra_binary_names: Vec<&str> = binary_names
+            .iter()
+            .map(String::as_str)
+            .filter(|n| *n != crate_name)
+            .collect();
         let urls = Self::generate_urls(
             &repo_url,
-            &krate.resolved.name,
+            crate_name,
+            &extra_binary_names,
             &krate.resolved.version.to_string(),
             platform,
         );
 
-        // Probe sequentially with HEAD requests; stop at the first 200.
-        // If we hit a connection/timeout error, bail immediately rather than continuing
-        // to probe all ~160 candidate URLs against a dead server.
+        // Probe sequentially with HEAD requests
+        //
+        // If we hit a connection/timeout error, bail immediately rather than continuing to probe
+        // every candidate URL against a broken/unresponsive server. The candidate set is the full
+        // cross-product of names (crate + binary), platform aliases, archive formats, and tag
+        // variants, so the worst-case (no asset exists) is on the order of ~1,400 sequential
+        // HEADs. That only happens for a crate actually hosted on gitlab.com whose release lacks
+        // any matching asset (a slow fallback to a source build); `get_repo_url` short-circuits to
+        // `None` for every non-GitLab crate, which is the overwhelming majority and does zero
+        // probes.
         let mut found = None;
         for (url, format) in &urls {
             match self.head_probe(url) {
@@ -174,15 +195,13 @@ impl Provider for GitlabProvider {
                     found = Some((url.clone(), *format));
                     break;
                 }
-                Err(e) if HttpClient::is_connection_error(&e) => {
-                    tracing::debug!("GitLab HEAD probe failed with connection error, bailing: {:?}", e);
-                    self.reporter.report(|| {
-                        PrebuiltBinaryMessage::provider_has_no_binary(
-                            BinaryProvider::GitlabReleases,
-                            "server unreachable",
-                        )
-                    });
-                    return Ok(None);
+
+                // A transient probe failure (connection/timeout, rate limit, 5xx) means we cannot
+                // determine whether the asset exists. Stop probing rather than hammering a flaky or
+                // dead server, and report the result as inconclusive.
+                Err(e) if e.is_transient_http_error() => {
+                    tracing::debug!("GitLab HEAD probe failed transiently, bailing: {:?}", e);
+                    return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
                 }
                 Ok(false) | Err(_) => continue,
             }
@@ -194,22 +213,27 @@ impl Provider for GitlabProvider {
                     "no matching release found",
                 )
             });
-            return Ok(None);
+            return Ok(BinaryResolution::Nonexistent);
         };
 
         self.reporter
             .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::GitlabReleases));
 
-        let data = if let Some(data) = self.try_download(&url)? {
-            data
-        } else {
-            self.reporter.report(|| {
-                PrebuiltBinaryMessage::provider_has_no_binary(
-                    BinaryProvider::GitlabReleases,
-                    format!("failed to download asset: {}", url),
-                )
-            });
-            return Ok(None);
+        let data = match self.try_download(&url) {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::provider_has_no_binary(
+                        BinaryProvider::GitlabReleases,
+                        format!("Release asset not found: {}", url),
+                    )
+                });
+                return Ok(BinaryResolution::Nonexistent);
+            }
+            Err(e) if e.is_transient_http_error() => {
+                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+            }
+            Err(e) => return Err(e),
         };
 
         if self.verify_checksums {
@@ -259,7 +283,7 @@ impl Provider for GitlabProvider {
             })?;
         }
 
-        Ok(Some(ResolvedBinary {
+        Ok(BinaryResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GitlabReleases,
             path: final_path,
@@ -282,6 +306,7 @@ mod tests {
         let urls = GitlabProvider::generate_urls(
             "https://gitlab.com/owner/repo",
             "mytool",
+            &[],
             "1.2.3",
             "x86_64-unknown-linux-gnu",
         );
@@ -295,6 +320,7 @@ mod tests {
         let urls = GitlabProvider::generate_urls(
             "https://gitlab.com/owner/repo",
             "mytool",
+            &[],
             "1.2.3",
             "x86_64-unknown-linux-gnu",
         );
@@ -308,6 +334,7 @@ mod tests {
         let urls = GitlabProvider::generate_urls(
             "https://gitlab.com/owner/repo",
             "mytool",
+            &[],
             "1.2.3",
             "x86_64-unknown-linux-gnu",
         );
@@ -323,6 +350,7 @@ mod tests {
         let urls = GitlabProvider::generate_urls(
             "https://gitlab.com/owner/repo",
             "mytool",
+            &[],
             "1.2.3",
             "x86_64-unknown-linux-gnu",
         );
@@ -340,6 +368,14 @@ mod tests {
                 assert_eq!(*format, ArchiveFormat::Tar);
             } else if url.ends_with(".zip") {
                 assert_eq!(*format, ArchiveFormat::Zip);
+            } else if url.ends_with(".gz") {
+                assert_eq!(*format, ArchiveFormat::Gz);
+            } else if url.ends_with(".xz") {
+                assert_eq!(*format, ArchiveFormat::Xz);
+            } else if url.ends_with(".zst") {
+                assert_eq!(*format, ArchiveFormat::Zst);
+            } else if url.ends_with(".bz2") {
+                assert_eq!(*format, ArchiveFormat::Bz2);
             } else {
                 assert_eq!(*format, ArchiveFormat::NakedBinary);
             }

--- a/cgx-core/src/bin_resolver/providers/gitlab.rs
+++ b/cgx-core/src/bin_resolver/providers/gitlab.rs
@@ -2,13 +2,14 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
+use reqwest::StatusCode;
 use sha2::{Digest, Sha256};
 use snafu::ResultExt;
 
 use super::{ArchiveFormat, CandidateFilename, Provider};
 use crate::{
     Result,
-    bin_resolver::{BinaryResolution, ResolvedBinary},
+    bin_resolver::{ConclusiveResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedSource,
     cratespec::Forge,
@@ -89,22 +90,67 @@ impl GitlabProvider {
         urls
     }
 
-    /// Probe a URL with a HEAD request to check if the asset exists.
+    /// Probe a GitLab release download URL with a HEAD request to check if the asset exists.
     ///
-    /// Returns `Ok(true)` for a successful HTTP status, `Ok(false)` for 404 or another
-    /// non-success response, or `Err` if the request could not be completed.
-    /// The error case is used by the caller to bail early when the server is unreachable.
+    /// GitLab release asset URLs return success for existing assets. HTTP 404 and other ordinary
+    /// non-success statuses are treated as "this candidate is not present"; HTTP 429 is GitLab's
+    /// rate-limit signal and is returned as a provider throttle error.
     fn head_probe(&self, url: &str) -> Result<bool> {
-        let response = self.http_client.head(url)?;
+        let response = self
+            .http_client
+            .head_retrying_status(url, Self::should_retry_status)?;
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            return Err(Self::provider_throttled_error(url, response.status()));
+        }
         Ok(response.status().is_success())
     }
 
-    /// Download a file from the given URL.
+    /// Download a GitLab release asset from the given URL.
     ///
     /// Returns `Ok(Some(bytes))` on success, `Ok(None)` if the server returned 404 (resource
     /// does not exist), or `Err` for any other failure (network errors, non-404 HTTP errors).
     fn try_download(&self, url: &str) -> Result<Option<Bytes>> {
-        self.http_client.try_download(url)
+        let response = self
+            .http_client
+            .get_retrying_status(url, Self::should_retry_status)?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        if response.status() == StatusCode::TOO_MANY_REQUESTS {
+            return Err(Self::provider_throttled_error(url, response.status()));
+        }
+
+        if !response.status().is_success() {
+            return error::HttpStatusSnafu {
+                url: url.to_string(),
+                status: response.status().as_u16(),
+            }
+            .fail();
+        }
+
+        let bytes = response
+            .bytes()
+            .with_context(|_| error::HttpRequestSnafu { url: url.to_string() })?;
+
+        Ok(Some(bytes))
+    }
+
+    fn should_retry_status(status: StatusCode) -> bool {
+        // GitLab rate limiting is reported as HTTP 429, so that should not be retried.
+        // Ordinary server errors still use the standard HTTP retry path.
+        status.is_server_error()
+    }
+
+    fn provider_throttled_error(url: &str, status: StatusCode) -> error::Error {
+        // Build the provider-throttle error after GitLab-specific response classification has already
+        // identified HTTP 429 as rate limiting.
+        error::ProviderThrottledSnafu {
+            url: url.to_string(),
+            status: status.as_u16(),
+        }
+        .build()
     }
 
     fn verify_checksum(&self, data: &[u8], url: &str) -> Result<()> {
@@ -150,7 +196,7 @@ impl Provider for GitlabProvider {
         BinaryProvider::GitlabReleases
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -160,7 +206,7 @@ impl Provider for GitlabProvider {
                     "no repository URL available",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         let crate_name = krate.resolved.name.as_str();
@@ -196,14 +242,8 @@ impl Provider for GitlabProvider {
                     break;
                 }
 
-                // A transient probe failure (connection/timeout, rate limit, 5xx) means we cannot
-                // determine whether the asset exists. Stop probing rather than hammering a flaky or
-                // dead server, and report the result as inconclusive.
-                Err(e) if e.is_transient_http_error() => {
-                    tracing::debug!("GitLab HEAD probe failed transiently, bailing: {:?}", e);
-                    return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
-                }
-                Ok(false) | Err(_) => continue,
+                Err(e) => return Err(e),
+                Ok(false) => continue,
             }
         }
         let Some((url, format)) = found else {
@@ -213,7 +253,7 @@ impl Provider for GitlabProvider {
                     "no matching release found",
                 )
             });
-            return Ok(BinaryResolution::Nonexistent);
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         self.reporter
@@ -228,10 +268,7 @@ impl Provider for GitlabProvider {
                         format!("Release asset not found: {}", url),
                     )
                 });
-                return Ok(BinaryResolution::Nonexistent);
-            }
-            Err(e) if e.is_transient_http_error() => {
-                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+                return Ok(ConclusiveResolution::Nonexistent);
             }
             Err(e) => return Err(e),
         };
@@ -283,7 +320,7 @@ impl Provider for GitlabProvider {
             })?;
         }
 
-        Ok(BinaryResolution::Found(ResolvedBinary {
+        Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GitlabReleases,
             path: final_path,
@@ -293,13 +330,41 @@ impl Provider for GitlabProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{fs, time::Duration};
 
+    use assert_matches::assert_matches;
+    use httpmock::{Method::HEAD, prelude::*};
     use semver::Version;
     use url::Url;
 
     use super::*;
-    use crate::{crate_resolver::ResolvedSource, cratespec::Forge};
+    use crate::{
+        config::HttpConfig, crate_resolver::ResolvedSource, cratespec::Forge, error::Error,
+        messages::MessageReporter,
+    };
+
+    fn fast_retry_config() -> HttpConfig {
+        HttpConfig {
+            retries: 2,
+            backoff_base: Duration::from_millis(1),
+            backoff_max: Duration::from_millis(10),
+            ..Default::default()
+        }
+    }
+
+    fn test_provider() -> (GitlabProvider, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let http_client = HttpClient::new(&fast_retry_config()).unwrap();
+        (
+            GitlabProvider::new(
+                MessageReporter::null(),
+                temp_dir.path().to_path_buf(),
+                false,
+                http_client,
+            ),
+            temp_dir,
+        )
+    }
 
     #[test]
     fn test_url_generation_includes_version_patterns() {
@@ -550,5 +615,35 @@ repository = "https://gitlab.com/upstream/mytool"
 
         let url = GitlabProvider::get_repo_url(&krate).unwrap();
         assert_eq!(url, Some("https://gitlab.com/upstream/mytool".to_string()));
+    }
+
+    #[test]
+    fn head_probe_429_is_not_retried_and_becomes_provider_throttled() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(HEAD).path("/asset");
+            then.status(429).header("retry-after", "30");
+        });
+        let (provider, _temp_dir) = test_provider();
+
+        let result = provider.head_probe(&server.url("/asset"));
+
+        assert_matches!(result, Err(Error::ProviderThrottled { status: 429, .. }));
+        mock.assert_calls(1);
+    }
+
+    #[test]
+    fn head_probe_5xx_still_retries() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(HEAD).path("/asset");
+            then.status(500);
+        });
+        let (provider, _temp_dir) = test_provider();
+
+        let result = provider.head_probe(&server.url("/asset"));
+
+        assert_matches!(result, Err(Error::HttpStatus { status: 500, .. }));
+        mock.assert_calls(3);
     }
 }

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -4,13 +4,15 @@ mod github;
 mod gitlab;
 mod quickinstall;
 
+use std::collections::HashSet;
+
 pub(super) use archive::{ArchiveFormat, extract_binary};
 pub(super) use binstall::BinstallProvider;
 pub(super) use github::GithubProvider;
 pub(super) use gitlab::GitlabProvider;
 pub(super) use quickinstall::QuickinstallProvider;
 
-use crate::{Result, bin_resolver::ResolvedBinary, downloader::DownloadedCrate};
+use crate::{Result, bin_resolver::BinaryResolution, config::BinaryProvider, downloader::DownloadedCrate};
 
 /// Trait for providers that can resolve pre-built binaries.
 pub(super) trait Provider {
@@ -20,9 +22,15 @@ pub(super) trait Provider {
     /// metadata and the crate source directory. Providers that only need the metadata (like
     /// heuristic URL probers) can access it via `krate.resolved`.
     ///
-    /// Returns `Ok(Some(binary))` if found, `Ok(None)` if not available from this provider,
-    /// or `Err` for failures that should stop binary resolution.
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<Option<ResolvedBinary>>;
+    /// Returns a [`BinaryResolution`]: [`Found`](BinaryResolution::Found) with the binary,
+    /// [`Nonexistent`](BinaryResolution::Nonexistent) if this provider conclusively has no binary
+    /// for the crate, or [`Inconclusive`](BinaryResolution::Inconclusive) if a transient failure
+    /// (rate limit, network error) prevented a definitive answer. `Err` is reserved for genuinely
+    /// fatal or unexpected failures that should stop binary resolution entirely.
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution>;
+
+    /// The kind of this provider, used for progress reporting.
+    fn kind(&self) -> BinaryProvider;
 }
 
 /// A candidate release asset filename paired with instructions for extracting or copying it.
@@ -31,34 +39,89 @@ pub(super) struct CandidateFilename {
     pub format: ArchiveFormat,
 }
 
-/// Generate candidate filenames that a release asset might use for a given crate.
+/// Generate candidate filenames that might be used for a release asset for a given crate, version,
+/// and platform.
 ///
-/// Produces naming patterns common across GitHub and GitLab release assets, combining the crate
-/// name, platform triple, and version with various separators and archive suffixes. Each candidate
-/// carries its [`ArchiveFormat`] so callers never need to re-derive it.
+/// Produces naming patterns common across GitHub, GitLab, and elsewhere, combining candidate
+/// names, various forms of the platform string, the version, and archive suffixes with various
+/// separators. Each candidate carries its [`ArchiveFormat`] representing what the expected format
+/// would be for a given candiate file, if it is found to exist.
+///
+/// Names are tried in priority order: `crate_name` first, then any `extra_binary_names` — binaries
+/// the crate declares whose name differs from the crate name. This is what lets, for example,
+/// `cgx taplo-cli` find the `taplo`-named assets of the `taplo-cli` crate. For each name,
+/// variations with multiple forms of platform strings are generated. Duplicate filenames are
+/// removed.
 pub(super) fn generate_candidate_filenames(
-    name: &str,
+    crate_name: &str,
+    extra_binary_names: &[&str],
     version: &str,
     platform: &str,
 ) -> Vec<CandidateFilename> {
     let formats = ArchiveFormat::all_formats();
-    let mut candidates = Vec::new();
+    let platforms = platform_aliases(platform);
 
-    for &(format, suffix) in formats {
-        push_candidate_patterns(&mut candidates, name, version, platform, format, suffix);
+    // Crate name first, then binary-name fallbacks. On Windows, also try `{name}.exe` as the name
+    // component for projects that bake the extension into the asset name (e.g.
+    // `eza.exe_x86_64-pc-windows-gnu.tar.gz`); these come last as the least-likely form.
+    let mut names: Vec<String> = Vec::new();
+    names.push(crate_name.to_string());
+    names.extend(extra_binary_names.iter().map(|&n| n.to_string()));
+    if platform.contains("windows") {
+        names.push(format!("{}.exe", crate_name));
+        names.extend(extra_binary_names.iter().map(|n| format!("{}.exe", n)));
     }
 
-    // Some projects (e.g. eza) publish Windows release assets with the binary extension baked
-    // into the archive name: `eza.exe_x86_64-pc-windows-gnu.tar.gz`. Generate additional
-    // candidates with `{name}.exe` as the name component.
-    if platform.contains("windows") {
-        let exe_name = format!("{}.exe", name);
-        for &(format, suffix) in formats {
-            push_candidate_patterns(&mut candidates, &exe_name, version, platform, format, suffix);
+    let mut candidates = Vec::new();
+    for name in &names {
+        for platform_token in &platforms {
+            for &(format, suffix) in formats {
+                push_candidate_patterns(&mut candidates, name, version, platform_token, format, suffix);
+            }
         }
     }
 
+    // Dedup by filename, keeping the first (highest-priority) occurrence. Needed because a binary
+    // name may coincide with the crate name on exotic targets, or a short alias with the triple.
+    let mut seen = HashSet::new();
+    candidates.retain(|c| seen.insert(c.filename.clone()));
+
     candidates
+}
+
+/// Build the list of platform tokens to try for asset matching: the full target triple first (the
+/// most specific, lowest-false-positive form), then the shorter `{os}-{arch}` and `{arch}-{os}`
+/// forms many projects use in their asset names.
+///
+/// The os component is mapped from the triple: `*apple*`/`*darwin*` -> `darwin`, `*windows*` ->
+/// `windows`, `*linux*` -> `linux`. The arch is the triple's first component, used verbatim (so
+/// `x86_64`, `aarch64`, `armv7` all match as-is); no arch synonyms are invented, to avoid
+/// over-generating candidates that could match the wrong asset.
+fn platform_aliases(platform: &str) -> Vec<String> {
+    let mut aliases = vec![platform.to_string()];
+
+    let arch = platform.split('-').next().unwrap_or("");
+    let os = if platform.contains("windows") {
+        Some("windows")
+    } else if platform.contains("apple") || platform.contains("darwin") {
+        Some("darwin")
+    } else if platform.contains("linux") {
+        Some("linux")
+    } else {
+        None
+    };
+
+    if let Some(os) = os {
+        if !arch.is_empty() {
+            for alias in [format!("{}-{}", os, arch), format!("{}-{}", arch, os)] {
+                if !aliases.contains(&alias) {
+                    aliases.push(alias);
+                }
+            }
+        }
+    }
+
+    aliases
 }
 
 fn push_candidate_patterns(
@@ -109,4 +172,104 @@ fn push_candidate_patterns(
         filename: format!("{}_{}{}", name, platform, suffix),
         format,
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filenames(candidates: &[CandidateFilename]) -> Vec<&str> {
+        candidates.iter().map(|c| c.filename.as_str()).collect()
+    }
+
+    /// The taplo case: the crate is `taplo-cli`, but its GitHub assets are named after the `taplo`
+    /// binary, use a short `{os}-{arch}` platform token, and a bare `.gz` suffix. All three must
+    /// combine into a single candidate carrying the naked [`ArchiveFormat::Gz`] format.
+    #[test]
+    fn binary_name_short_platform_and_naked_gz_combine() {
+        let candidates =
+            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+
+        let target = candidates
+            .iter()
+            .find(|c| c.filename == "taplo-linux-x86_64.gz")
+            .expect("expected a taplo-linux-x86_64.gz candidate");
+        assert_eq!(target.format, ArchiveFormat::Gz);
+    }
+
+    /// Crate name + full triple + the first archive format is still generated first, so crates
+    /// whose assets already match the historical scheme keep matching the same asset (no
+    /// regression).
+    #[test]
+    fn crate_name_full_triple_is_first_candidate() {
+        let candidates =
+            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+        assert_eq!(
+            candidates[0].filename,
+            "taplo-cli-x86_64-unknown-linux-gnu-v0.10.0.tar"
+        );
+    }
+
+    /// Every crate-name candidate is ordered before any binary-name candidate.
+    #[test]
+    fn crate_name_candidates_precede_binary_name_candidates() {
+        let candidates =
+            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+        let names = filenames(&candidates);
+        let last_crate = names.iter().rposition(|n| n.starts_with("taplo-cli")).unwrap();
+        let first_binary = names
+            .iter()
+            .position(|n| n.starts_with("taplo-") && !n.starts_with("taplo-cli"))
+            .unwrap();
+        assert!(
+            last_crate < first_binary,
+            "all taplo-cli candidates should precede the taplo (binary) candidates"
+        );
+    }
+
+    /// Filenames are unique even when a binary name coincides with the crate name.
+    #[test]
+    fn candidates_are_deduplicated() {
+        let candidates = generate_candidate_filenames("foo", &["foo"], "1.0.0", "x86_64-unknown-linux-gnu");
+        let count = candidates.len();
+        let mut names = filenames(&candidates);
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), count, "candidate filenames should be unique");
+    }
+
+    /// On Windows, `{name}.exe` is also tried as the name component (for assets like
+    /// `eza.exe_x86_64-pc-windows-gnu.tar.gz`).
+    #[test]
+    fn windows_adds_exe_name_variant() {
+        let candidates = generate_candidate_filenames("mytool", &[], "1.0.0", "x86_64-pc-windows-msvc");
+        let names = filenames(&candidates);
+        assert!(
+            names.iter().any(|n| n.starts_with("mytool.exe")),
+            "expected a mytool.exe-prefixed candidate on Windows"
+        );
+    }
+
+    #[test]
+    fn platform_aliases_full_triple_first_then_short_forms() {
+        let aliases = platform_aliases("x86_64-unknown-linux-gnu");
+        assert_eq!(aliases[0], "x86_64-unknown-linux-gnu");
+        assert!(aliases.contains(&"linux-x86_64".to_string()));
+        assert!(aliases.contains(&"x86_64-linux".to_string()));
+    }
+
+    /// macOS triples use `apple`, but most asset names use `darwin`; the alias must bridge that.
+    #[test]
+    fn platform_aliases_maps_apple_to_darwin() {
+        let aliases = platform_aliases("aarch64-apple-darwin");
+        assert!(aliases.contains(&"darwin-aarch64".to_string()));
+        assert!(aliases.contains(&"aarch64-darwin".to_string()));
+    }
+
+    #[test]
+    fn platform_aliases_windows() {
+        let aliases = platform_aliases("x86_64-pc-windows-msvc");
+        assert!(aliases.contains(&"windows-x86_64".to_string()));
+        assert!(aliases.contains(&"x86_64-windows".to_string()));
+    }
 }

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -45,7 +45,7 @@ pub(super) struct CandidateFilename {
 /// Produces naming patterns common across GitHub, GitLab, and elsewhere, combining candidate
 /// names, various forms of the platform string, the version, and archive suffixes with various
 /// separators. Each candidate carries its [`ArchiveFormat`] representing what the expected format
-/// would be for a given candiate file, if it is found to exist.
+/// would be for a given candidate file, if it is found to exist.
 ///
 /// Names are tried in priority order: `crate_name` first, then any `extra_binary_names` — binaries
 /// the crate declares whose name differs from the crate name. This is what lets, for example,

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -12,7 +12,9 @@ pub(super) use github::GithubProvider;
 pub(super) use gitlab::GitlabProvider;
 pub(super) use quickinstall::QuickinstallProvider;
 
-use crate::{Result, bin_resolver::BinaryResolution, config::BinaryProvider, downloader::DownloadedCrate};
+use crate::{
+    Result, bin_resolver::ConclusiveResolution, config::BinaryProvider, downloader::DownloadedCrate,
+};
 
 /// Trait for providers that can resolve pre-built binaries.
 pub(super) trait Provider {
@@ -22,12 +24,17 @@ pub(super) trait Provider {
     /// metadata and the crate source directory. Providers that only need the metadata (like
     /// heuristic URL probers) can access it via `krate.resolved`.
     ///
-    /// Returns a [`BinaryResolution`]: [`Found`](BinaryResolution::Found) with the binary,
-    /// [`Nonexistent`](BinaryResolution::Nonexistent) if this provider conclusively has no binary
-    /// for the crate, or [`Inconclusive`](BinaryResolution::Inconclusive) if a transient failure
-    /// (rate limit, network error) prevented a definitive answer. `Err` is reserved for genuinely
-    /// fatal or unexpected failures that should stop binary resolution entirely.
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution>;
+    /// Returns [`ConclusiveResolution::Found`] with the binary,
+    /// [`ConclusiveResolution::Nonexistent`] if this provider conclusively has no binary for
+    /// the crate, or `Err` if the provider could not determine a conclusive outcome.
+    ///
+    /// If the provider returns `Err`, the resolution of the crate for this provider will be
+    /// considered inconclusive, that is to say it is not cached as either a positive or negative
+    /// result.  Providers should strive to produce only conclusive results, but of course
+    /// providers to fallible things like network I/O and parsing of data, in which case those
+    /// providers should return `Err` to indicate that they could not determine a conclusive
+    /// outcome.
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution>;
 
     /// The kind of this provider, used for progress reporting.
     fn kind(&self) -> BinaryProvider;

--- a/cgx-core/src/bin_resolver/providers/quickinstall.rs
+++ b/cgx-core/src/bin_resolver/providers/quickinstall.rs
@@ -7,7 +7,7 @@ use snafu::ResultExt;
 use super::{ArchiveFormat, Provider};
 use crate::{
     Result,
-    bin_resolver::ResolvedBinary,
+    bin_resolver::{BinaryResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedCrate,
     downloader::DownloadedCrate,
@@ -47,20 +47,31 @@ impl QuickinstallProvider {
 }
 
 impl Provider for QuickinstallProvider {
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<Option<ResolvedBinary>> {
+    fn kind(&self) -> BinaryProvider {
+        BinaryProvider::Quickinstall
+    }
+
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
         let url = Self::construct_url(&krate.resolved, platform);
 
         self.reporter
             .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Quickinstall));
 
-        let Ok(Some(data)) = self.download_file(&url) else {
-            self.reporter.report(|| {
-                PrebuiltBinaryMessage::provider_has_no_binary(
-                    BinaryProvider::Quickinstall,
-                    "download failed or binary not found",
-                )
-            });
-            return Ok(None);
+        let data = match self.download_file(&url) {
+            Ok(Some(data)) => data,
+            Ok(None) => {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::provider_has_no_binary(
+                        BinaryProvider::Quickinstall,
+                        "binary not found",
+                    )
+                });
+                return Ok(BinaryResolution::Nonexistent);
+            }
+            Err(e) if e.is_transient_http_error() => {
+                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+            }
+            Err(e) => return Err(e),
         };
 
         // TODO(#80): verify .sig (minisign) signatures when support is added
@@ -109,7 +120,7 @@ impl Provider for QuickinstallProvider {
             })?;
         }
 
-        Ok(Some(ResolvedBinary {
+        Ok(BinaryResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::Quickinstall,
             path: final_path,

--- a/cgx-core/src/bin_resolver/providers/quickinstall.rs
+++ b/cgx-core/src/bin_resolver/providers/quickinstall.rs
@@ -7,7 +7,7 @@ use snafu::ResultExt;
 use super::{ArchiveFormat, Provider};
 use crate::{
     Result,
-    bin_resolver::{BinaryResolution, ResolvedBinary},
+    bin_resolver::{ConclusiveResolution, ResolvedBinary},
     config::BinaryProvider,
     crate_resolver::ResolvedCrate,
     downloader::DownloadedCrate,
@@ -51,7 +51,7 @@ impl Provider for QuickinstallProvider {
         BinaryProvider::Quickinstall
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
         let url = Self::construct_url(&krate.resolved, platform);
 
         self.reporter
@@ -66,10 +66,7 @@ impl Provider for QuickinstallProvider {
                         "binary not found",
                     )
                 });
-                return Ok(BinaryResolution::Nonexistent);
-            }
-            Err(e) if e.is_transient_http_error() => {
-                return Ok(BinaryResolution::Inconclusive { source: Box::new(e) });
+                return Ok(ConclusiveResolution::Nonexistent);
             }
             Err(e) => return Err(e),
         };
@@ -120,7 +117,7 @@ impl Provider for QuickinstallProvider {
             })?;
         }
 
-        Ok(BinaryResolution::Found(ResolvedBinary {
+        Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::Quickinstall,
             path: final_path,

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -1,8 +1,6 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     fs,
-    hash::{Hash, Hasher},
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
@@ -30,6 +28,7 @@ use crate::{
 /// This generic wrapper is used for any cached data that has an expiration policy.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct CacheEntry<T> {
+    #[serde(flatten)]
     value: T,
     cached_at: DateTime<Utc>,
 }
@@ -59,6 +58,32 @@ impl<T> CacheEntry<T> {
 
 /// A cache entry for a resolved crate specification.
 type CrateResolveCacheEntry = CacheEntry<ResolvedCrate>;
+
+/// A cached binary-resolution outcome.
+///
+/// Only conclusive outcomes should be cached; a transient/inconclusive resolution failure should
+/// never be persisted.
+///
+/// The two variants distinguish a positive result (a pre-built binary was resolved) from a
+/// conclusive negative (we determined no pre-built binary is available).  Theoretically it's
+/// possible that we could have checked at exactly the moment when a crate was just published but
+/// artifacts not yet released, or that a maintainer could go back and publish artifacts for older
+/// versions long after release, but both of these are highly unlikely.  By caching this result, we
+/// can speed up subsequent runs and avoid the many network requests (and potential throttling)
+/// that would be required to check for a pre-built binary every time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "only a handful of these exist at a time (one per resolved crate); the size disparity between \
+              Found and Nonexistent does not matter and boxing would only add indirection"
+)]
+pub(crate) enum BinaryCacheEntry {
+    /// A pre-built binary was resolved.
+    Found(ResolvedBinary),
+    /// We conclusively determined that no pre-built binary is available.
+    Nonexistent,
+}
 
 /// Manages the various caches that cgx uses to operate.
 ///
@@ -175,95 +200,6 @@ impl Cache {
         }
     }
 
-    /// Get a cached binary resolution result, or resolve it using the provided resolver function.
-    ///
-    /// Binary resolution results never expire because crates are immutable. Once we determine
-    /// whether a binary exists for a specific version on a specific platform, that answer remains
-    /// valid forever. We cache both positive (binary found) and negative (no binary) results to
-    /// avoid repeatedly checking providers.
-    ///
-    /// Unlike crate resolution, there is no TTL check - the cache entry is permanent.
-    ///
-    /// # Arguments
-    ///
-    /// * `krate` - The resolved crate to find a binary for
-    /// * `resolver` - Function that attempts to find and download a pre-built binary
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Some(ResolvedBinary))` - Found a pre-built binary (either cached or freshly resolved)
-    /// * `Ok(None)` - No pre-built binary available (either cached negative result or resolver
-    ///   returned None)
-    /// * `Err(...)` - An error occurred during resolution
-    pub(crate) fn get_or_resolve_binary<F>(
-        &self,
-        krate: &ResolvedCrate,
-        resolver: F,
-    ) -> Result<Option<ResolvedBinary>>
-    where
-        F: FnOnce() -> Result<Option<ResolvedBinary>>,
-    {
-        // Check cache unless refresh mode is enabled
-        let use_cache = !self.inner.config.refresh;
-
-        if use_cache {
-            self.inner
-                .reporter
-                .report(|| PrebuiltBinaryMessage::cache_lookup(krate));
-
-            if let Ok(Some(entry)) = self.get_cached_binary(krate) {
-                match &entry.value {
-                    Some(binary) => {
-                        self.inner
-                            .reporter
-                            .report(|| PrebuiltBinaryMessage::cache_hit(&binary.path, binary.provider));
-                    }
-                    None => {
-                        // Negative cache hit - we previously determined no binary was available
-                        self.inner.reporter.report(|| {
-                            PrebuiltBinaryMessage::no_binary_found(
-                                krate,
-                                vec!["negative cache hit - no binary available".to_string()],
-                            )
-                        });
-                    }
-                }
-                // Return the cached result whether it's Some or None
-                return Ok(entry.value);
-            }
-
-            self.inner
-                .reporter
-                .report(|| PrebuiltBinaryMessage::cache_miss(krate));
-        }
-
-        // Call the resolver to attempt finding a binary
-        match resolver() {
-            Ok(result) => {
-                // Cache the result (whether Some or None)
-                let _ = self.put_cached_binary(krate, &result);
-
-                if let Some(ref _binary) = result {
-                    if let Ok(cache_path) = self.binary_cache_path(krate) {
-                        self.inner
-                            .reporter
-                            .report(|| PrebuiltBinaryMessage::cache_stored(&cache_path));
-                    }
-                } else {
-                    // Also report when we cache a negative result
-                    if let Ok(cache_path) = self.binary_cache_path(krate) {
-                        self.inner
-                            .reporter
-                            .report(|| PrebuiltBinaryMessage::cache_stored(&cache_path));
-                    }
-                }
-
-                Ok(result)
-            }
-            Err(e) => Err(e),
-        }
-    }
-
     /// Get a cached crate source code package, or download it using the provided downloader
     /// function.
     ///
@@ -279,7 +215,7 @@ impl Cache {
         downloader: F,
     ) -> Result<DownloadedCrate>
     where
-        F: FnOnce(&std::path::Path) -> Result<()>,
+        F: FnOnce(&Path) -> Result<()>,
     {
         self.inner
             .reporter
@@ -404,30 +340,44 @@ impl Cache {
         Ok(())
     }
 
-    /// Get a cached binary resolution result for the given [`ResolvedCrate`], if one exists.
+    /// Get the cached binary resolution outcome for the given [`ResolvedCrate`], if one exists.
     ///
-    /// Returns `None` if there is no cached entry or if reading the cache fails.
-    /// Note that a cached entry can contain `Some(ResolvedBinary)` or `None` - we cache
-    /// both positive and negative results.
-    fn get_cached_binary(&self, krate: &ResolvedCrate) -> Result<Option<CacheEntry<Option<ResolvedBinary>>>> {
-        let cache_file = self.binary_cache_path(krate)?;
-        if !cache_file.exists() {
-            return Ok(None);
+    /// Binary resolution results never expire because crates are immutable. Once we determine
+    /// whether a binary exists for a specific version on a specific platform, that answer remains
+    /// valid forever. We cache both positive (binary found) and negative (no binary) results to
+    /// avoid repeatedly checking providers.
+    ///
+    /// Unlike crate resolution, there is no TTL check - the cache entry is permanent.
+    ///
+    /// Returns `Ok(None)` when there is no cache entry for the crate, or `Ok(Some(entry))` carrying
+    /// the cached resolution outcome.
+    pub(crate) fn get_cached_binary(&self, krate: &ResolvedCrate) -> Result<Option<BinaryCacheEntry>> {
+        self.inner
+            .reporter
+            .report(|| PrebuiltBinaryMessage::cache_lookup(krate));
+
+        let entry = self.read_binary_cache_entry(krate);
+
+        match &entry {
+            Some(BinaryCacheEntry::Found(binary)) => self
+                .inner
+                .reporter
+                .report(|| PrebuiltBinaryMessage::positive_cache_hit(krate, &binary.path, binary.provider)),
+            Some(BinaryCacheEntry::Nonexistent) => self
+                .inner
+                .reporter
+                .report(|| PrebuiltBinaryMessage::negative_cache_hit(krate)),
+            None => self
+                .inner
+                .reporter
+                .report(|| PrebuiltBinaryMessage::cache_miss(krate)),
         }
 
-        let contents = fs::read_to_string(&cache_file).with_context(|_| error::IoSnafu {
-            path: cache_file.clone(),
-        })?;
-        let entry: CacheEntry<Option<ResolvedBinary>> =
-            serde_json::from_str(&contents).context(error::JsonSnafu)?;
-
-        Ok(Some(entry))
+        Ok(entry)
     }
 
-    /// Store a binary resolution result in the cache for the given [`ResolvedCrate`].
-    ///
-    /// This stores both positive results (Some(ResolvedBinary)) and negative results (None).
-    fn put_cached_binary(&self, krate: &ResolvedCrate, result: &Option<ResolvedBinary>) -> Result<()> {
+    /// Store a conclusive binary resolution outcome in the cache for the given [`ResolvedCrate`].
+    pub(crate) fn put_cached_binary(&self, krate: &ResolvedCrate, entry: &BinaryCacheEntry) -> Result<()> {
         let cache_file = self.binary_cache_path(krate)?;
 
         if let Some(parent) = cache_file.parent() {
@@ -436,14 +386,62 @@ impl Cache {
             })?;
         }
 
-        let entry = CacheEntry::new(result.clone());
+        let entry = CacheEntry::new(entry);
 
         let json = serde_json::to_string_pretty(&entry).context(error::JsonSnafu)?;
         fs::write(&cache_file, json).with_context(|_| error::IoSnafu {
             path: cache_file.clone(),
         })?;
 
+        self.inner
+            .reporter
+            .report(|| PrebuiltBinaryMessage::cache_stored(&cache_file));
+
         Ok(())
+    }
+
+    /// Read and deserialize the binary cache entry for the crate `krate`, returning `None` if the
+    /// cache entry is absent or unreadable.
+    ///
+    /// A corrupt or stale-format entry is treated as a miss (it will be re-resolved and
+    /// overwritten).
+    #[instrument(skip_all, fields(krate = %krate.name, version = %krate.version))]
+    fn read_binary_cache_entry(&self, krate: &ResolvedCrate) -> Option<BinaryCacheEntry> {
+        let cache_file = match self.binary_cache_path(krate) {
+            Ok(cache_file) => cache_file,
+            Err(e) => {
+                debug!(
+                    error = %e,
+                    "failed to compute binary cache path; this should not ever happen"
+                );
+                return None;
+            }
+        };
+
+        if !cache_file.exists() {
+            return None;
+        }
+
+        let contents = match fs::read_to_string(&cache_file) {
+            Ok(contents) => contents,
+            Err(e) => {
+                debug!(
+                    path = %cache_file.display(),
+                    error = %e,
+                    "ignoring unreadable binary cache entry");
+                return None;
+            }
+        };
+
+        match serde_json::from_str::<CacheEntry<BinaryCacheEntry>>(&contents) {
+            Ok(entry) => Some(entry.into_inner()),
+            Err(e) => {
+                debug!(path = %cache_file.display(),
+                    error = %e,
+                    "ignoring unparsable binary cache entry");
+                None
+            }
+        }
     }
 
     /// Get the filesystem path for the binary resolution cache file for a given [`ResolvedCrate`].
@@ -452,7 +450,7 @@ impl Cache {
     /// This ensures that binaries are cached per-platform, which is essential since pre-built
     /// binaries are platform-specific.
     fn binary_cache_path(&self, krate: &ResolvedCrate) -> Result<PathBuf> {
-        let hash = Self::compute_binary_cache_hash(krate)?;
+        let hash = Self::compute_binary_cache_hash(krate, build_context::TARGET)?;
         Ok(self
             .inner
             .config
@@ -467,10 +465,11 @@ impl Cache {
     /// - Crate name
     /// - Crate version
     /// - Resolved source (crates.io vs git vs forge, etc.)
-    /// - Current platform triple
+    /// - The target platform triple
     ///
-    /// This ensures that the same crate on different platforms gets different cache entries.
-    fn compute_binary_cache_hash(krate: &ResolvedCrate) -> Result<String> {
+    /// `platform` is a parameter so the hash is distinct and testable for a fixed platform. This
+    /// ensures the same crate on different platforms gets different cache entries.
+    fn compute_binary_cache_hash(krate: &ResolvedCrate, platform: &str) -> Result<String> {
         #[derive(Serialize)]
         struct BinaryCacheKey<'a> {
             name: &'a str,
@@ -483,7 +482,7 @@ impl Cache {
             name: &krate.name,
             version: &krate.version,
             source: &krate.source,
-            platform: build_context::TARGET,
+            platform,
         };
 
         let json = serde_json::to_string(&key).context(error::JsonSnafu)?;
@@ -764,35 +763,19 @@ impl Cache {
     ///
     /// Different sources (crates.io vs git vs forge) will produce different hashes
     /// even for the same crate name and version.
+    ///
+    /// Uses SHA-256 over the source's JSON serialization, so the resulting build-cache paths are
+    /// stable across toolchains and platforms (presuming, of course, that the JSON serialized
+    /// representation of the source is itself stable across toolchains and platforms, which we
+    /// hope that it is).
     fn compute_source_hash(source: &ResolvedSource) -> String {
-        let mut hasher = DefaultHasher::new();
-        match source {
-            ResolvedSource::CratesIo => {
-                "crates-io".hash(&mut hasher);
-            }
-            ResolvedSource::Registry { source: registry } => {
-                "registry".hash(&mut hasher);
-                match registry {
-                    RegistrySource::Named(name) => name.hash(&mut hasher),
-                    RegistrySource::IndexUrl(url) => url.as_str().hash(&mut hasher),
-                }
-            }
-            ResolvedSource::Git { repo, commit } => {
-                "git".hash(&mut hasher);
-                repo.hash(&mut hasher);
-                commit.hash(&mut hasher);
-            }
-            ResolvedSource::Forge { forge, commit } => {
-                "forge".hash(&mut hasher);
-                // Format Debug output of forge for hashing
-                format!("{:?}", forge).hash(&mut hasher);
-                commit.hash(&mut hasher);
-            }
-            ResolvedSource::LocalDir { .. } => {
-                panic!("BUG: Should not compute hash for LocalDir sources");
-            }
+        // It makes absolutely no sense to try to cache a local dir source!  Higher-level code
+        // should have already bypassed the cache for this source.
+        if matches!(source, ResolvedSource::LocalDir { .. }) {
+            panic!("BUG: Should not compute a build-cache hash for LocalDir sources");
         }
-        format!("{:016x}", hasher.finish())
+
+        source.source_hash()
     }
 
     /// Compute a hash of build options that affect the output binary.
@@ -807,29 +790,42 @@ impl Cache {
     /// Features are sorted before hashing to ensure consistent cache keys
     /// regardless of the order they're specified.
     fn compute_build_hash(options: &BuildOptions) -> String {
-        let mut hasher = DefaultHasher::new();
-
         // Sort features for consistency - order shouldn't matter for cache key
         let mut features = options.features.clone();
         features.sort();
-        features.hash(&mut hasher);
 
-        options.all_features.hash(&mut hasher);
-        options.no_default_features.hash(&mut hasher);
-        options.profile.hash(&mut hasher);
-        options.target.hash(&mut hasher);
-        options.build_target.hash(&mut hasher);
-        options.toolchain.hash(&mut hasher);
+        // Only the options that actually change the built binary are part of the key. `offline`,
+        // `jobs`, and `ignore_rust_version` affect build behavior but not output and are excluded;
+        // `locked` IS included because it affects dependency resolution (hence the binary).
+        //
+        // The key is serialized to JSON  and hashed with SHA-256 so build-cache paths are stable
+        // across toolchains.
+        #[derive(Serialize)]
+        struct BuildCacheKey<'a> {
+            features: &'a [String],
+            all_features: bool,
+            no_default_features: bool,
+            profile: &'a Option<String>,
+            target: &'a Option<String>,
+            build_target: &'a BuildTarget,
+            toolchain: &'a Option<String>,
+            locked: bool,
+        }
 
-        // locked affects dependency resolution, which affects the binary
-        options.locked.hash(&mut hasher);
+        let key = BuildCacheKey {
+            features: &features,
+            all_features: options.all_features,
+            no_default_features: options.no_default_features,
+            profile: &options.profile,
+            target: &options.target,
+            build_target: &options.build_target,
+            toolchain: &options.toolchain,
+            locked: options.locked,
+        };
 
-        // Explicitly NOT hashing these fields as they don't affect the binary output:
-        // - offline: affects network access, not binary
-        // - jobs: affects build parallelism, not binary
-        // - ignore_rust_version: affects cargo checks, not binary
-
-        format!("{:016x}", hasher.finish())
+        let json =
+            serde_json::to_string(&key).expect("serializing a BuildCacheKey of plain fields cannot fail");
+        Self::compute_hash(json.as_bytes())
     }
 
     /// Compute the expected binary name based on the build target.
@@ -920,6 +916,532 @@ mod tests {
             name: "serde".to_string(),
             version: Version::parse("1.0.1").unwrap(),
             source: ResolvedSource::CratesIo,
+        }
+    }
+
+    /// On-disk format / cache-key compatibility checks.
+    ///
+    /// These tests assert contents and paths that are persistent on disk, to detect when we've
+    /// made any changes that will break compatibility with existing cache entries.
+    ///
+    /// A test failure here isn't automatically a bug that you have to fix.  The consequences for
+    /// broken compat are pretty low: a cache miss followed by some otherwise-unnecessary rework
+    /// like crate resolution or maybe even rebuilding from source.  That's not the end of the
+    /// world, but if we're going to break compat we must do so deliberately; that's what these
+    /// tests are here for.
+    ///
+    /// If you have decided to make a breaking change, update the tests here so that they pass with
+    /// your new changes.  But that must always be a conscious decision.  God help you if I find
+    /// out you vibe-coded some change and your clanker blithely updated these tests to ignore the
+    /// break!
+    mod compat {
+        use chrono::{DateTime, Utc};
+
+        use super::*;
+        use crate::config::BinaryProvider;
+
+        /// A fixed timestamp so serialized output is deterministic.
+        fn fixed_cached_at() -> DateTime<Utc> {
+            "2024-01-15T12:30:00Z".parse().unwrap()
+        }
+
+        /// The binary resolution cache, which stores both positive and negative results for
+        /// whether a pre-built binary exists for a given crate.
+        mod resolved_binary {
+            use super::*;
+
+            /// A positive entry: a resolved binary was found and cached.
+            fn positive_entry() -> CacheEntry<BinaryCacheEntry> {
+                CacheEntry {
+                    value: BinaryCacheEntry::Found(ResolvedBinary {
+                        krate: ResolvedCrate {
+                            name: "eza".to_string(),
+                            version: Version::parse("0.23.1").unwrap(),
+                            source: ResolvedSource::CratesIo,
+                        },
+                        provider: BinaryProvider::GithubReleases,
+                        path: PathBuf::from("/cache/bin/eza"),
+                    }),
+                    cached_at: fixed_cached_at(),
+                }
+            }
+
+            /// A negative entry: we conclusively determined no binary is available.
+            fn negative_entry() -> CacheEntry<BinaryCacheEntry> {
+                CacheEntry {
+                    value: BinaryCacheEntry::Nonexistent,
+                    cached_at: fixed_cached_at(),
+                }
+            }
+
+            const POSITIVE_JSON: &str = r#"{
+  "outcome": "found",
+  "krate": {
+    "name": "eza",
+    "version": "0.23.1",
+    "source": "crates_io"
+  },
+  "provider": "github-releases",
+  "path": "/cache/bin/eza",
+  "cached_at": "2024-01-15T12:30:00Z"
+}"#;
+
+            const NEGATIVE_JSON: &str = r#"{
+  "outcome": "nonexistent",
+  "cached_at": "2024-01-15T12:30:00Z"
+}"#;
+
+            #[test]
+            fn positive_entry_serializes_to_expected_json() {
+                assert_eq!(
+                    serde_json::to_string_pretty(&positive_entry()).unwrap(),
+                    POSITIVE_JSON
+                );
+            }
+
+            #[test]
+            fn negative_entry_serializes_to_expected_json() {
+                assert_eq!(
+                    serde_json::to_string_pretty(&negative_entry()).unwrap(),
+                    NEGATIVE_JSON
+                );
+            }
+
+            #[test]
+            fn positive_entry_round_trips() {
+                let original = positive_entry();
+                let json = serde_json::to_string_pretty(&original).unwrap();
+                let back: CacheEntry<BinaryCacheEntry> = serde_json::from_str(&json).unwrap();
+                assert_eq!(back, original);
+                let from_literal: CacheEntry<BinaryCacheEntry> = serde_json::from_str(POSITIVE_JSON).unwrap();
+                assert_eq!(from_literal, original);
+            }
+
+            #[test]
+            fn negative_entry_round_trips() {
+                let original = negative_entry();
+                let json = serde_json::to_string_pretty(&original).unwrap();
+                let back: CacheEntry<BinaryCacheEntry> = serde_json::from_str(&json).unwrap();
+                assert_eq!(back, original);
+                let from_literal: CacheEntry<BinaryCacheEntry> = serde_json::from_str(NEGATIVE_JSON).unwrap();
+                assert_eq!(from_literal, original);
+            }
+        }
+
+        /// The crate resolution cache, which stores the resolved crate identity (name, version,
+        /// source) for a given [`CrateSpec`].  Since the resolved crate also has a
+        /// [`ResolvedSource`], this test also covers compat testing for that type as well.
+        mod resolved_crate {
+            use super::*;
+
+            fn crate_with(source: ResolvedSource) -> ResolvedCrate {
+                ResolvedCrate {
+                    name: "demo".to_string(),
+                    version: Version::parse("1.2.3").unwrap(),
+                    source,
+                }
+            }
+
+            const ON_DISK_JSON: &str = r#"{
+  "name": "demo",
+  "version": "1.2.3",
+  "source": "crates_io",
+  "cached_at": "2024-01-15T12:30:00Z"
+}"#;
+
+            #[test]
+            fn on_disk_cache_entry_round_trips_to_expected_json() {
+                let entry = CacheEntry {
+                    value: crate_with(ResolvedSource::CratesIo),
+                    cached_at: fixed_cached_at(),
+                };
+                assert_eq!(serde_json::to_string_pretty(&entry).unwrap(), ON_DISK_JSON);
+                let back: CacheEntry<ResolvedCrate> = serde_json::from_str(ON_DISK_JSON).unwrap();
+                assert_eq!(back, entry);
+            }
+
+            /// Assert a `ResolvedSource` serializes to exactly `expected` and round-trips back.
+            fn check(source: ResolvedSource, expected: &str) {
+                assert_eq!(serde_json::to_string_pretty(&source).unwrap(), expected);
+                let back: ResolvedSource = serde_json::from_str(expected).unwrap();
+                assert_eq!(back, source);
+            }
+
+            #[test]
+            fn crates_io() {
+                check(ResolvedSource::CratesIo, r#""crates_io""#);
+            }
+
+            #[test]
+            fn registry_named() {
+                check(
+                    ResolvedSource::Registry {
+                        source: RegistrySource::Named("my-registry".to_string()),
+                    },
+                    r#"{
+  "registry": {
+    "source": {
+      "named": "my-registry"
+    }
+  }
+}"#,
+                );
+            }
+
+            #[test]
+            fn registry_index_url() {
+                check(
+                    ResolvedSource::Registry {
+                        source: RegistrySource::IndexUrl(
+                            url::Url::parse("https://example.com/index").unwrap(),
+                        ),
+                    },
+                    r#"{
+  "registry": {
+    "source": {
+      "index_url": "https://example.com/index"
+    }
+  }
+}"#,
+                );
+            }
+
+            #[test]
+            fn git() {
+                check(
+                    ResolvedSource::Git {
+                        repo: "https://github.com/owner/repo.git".to_string(),
+                        commit: "abc123".to_string(),
+                    },
+                    r#"{
+  "git": {
+    "repo": "https://github.com/owner/repo.git",
+    "commit": "abc123"
+  }
+}"#,
+                );
+            }
+
+            #[test]
+            fn forge_github() {
+                check(
+                    ResolvedSource::Forge {
+                        forge: Forge::GitHub {
+                            custom_url: None,
+                            owner: "owner".to_string(),
+                            repo: "repo".to_string(),
+                        },
+                        commit: "abc123".to_string(),
+                    },
+                    r#"{
+  "forge": {
+    "forge": {
+      "git_hub": {
+        "custom_url": null,
+        "owner": "owner",
+        "repo": "repo"
+      }
+    },
+    "commit": "abc123"
+  }
+}"#,
+                );
+            }
+
+            #[test]
+            fn forge_gitlab() {
+                check(
+                    ResolvedSource::Forge {
+                        forge: Forge::GitLab {
+                            custom_url: None,
+                            owner: "owner".to_string(),
+                            repo: "repo".to_string(),
+                        },
+                        commit: "def456".to_string(),
+                    },
+                    r#"{
+  "forge": {
+    "forge": {
+      "git_lab": {
+        "custom_url": null,
+        "owner": "owner",
+        "repo": "repo"
+      }
+    },
+    "commit": "def456"
+  }
+}"#,
+                );
+            }
+
+            #[test]
+            fn local_dir() {
+                check(
+                    ResolvedSource::LocalDir {
+                        path: PathBuf::from("/some/local/path"),
+                    },
+                    r#"{
+  "local_dir": {
+    "path": "/some/local/path"
+  }
+}"#,
+                );
+            }
+        }
+
+        /// The resolve-cache key, which is a hash computed from a crate spec and used to construct
+        /// entries.
+        mod crate_spec_hash {
+            use semver::VersionReq;
+
+            use super::*;
+            use crate::git::GitSelector;
+
+            #[test]
+            fn crates_io() {
+                let spec = CrateSpec::CratesIo {
+                    name: "serde".to_string(),
+                    version: Some(VersionReq::parse("=1.0.0").unwrap()),
+                };
+                assert_eq!(
+                    Cache::compute_spec_hash(&spec).unwrap(),
+                    "79b48b0d3feee138ee1ea1f22108170f85431c6240de6571ed3693c1001a9974"
+                );
+            }
+
+            #[test]
+            fn registry_named() {
+                let spec = CrateSpec::Registry {
+                    source: RegistrySource::Named("my-registry".to_string()),
+                    name: "serde".to_string(),
+                    version: None,
+                };
+                assert_eq!(
+                    Cache::compute_spec_hash(&spec).unwrap(),
+                    "7a3b4789c6780ca2b848cc536fbb0ea1e034128e2e492ada1a31ce7f633c4f52"
+                );
+            }
+
+            #[test]
+            fn git() {
+                let spec = CrateSpec::Git {
+                    repo: "https://github.com/owner/repo.git".to_string(),
+                    selector: GitSelector::Tag("v1.0.0".to_string()),
+                    name: None,
+                    version: None,
+                };
+                assert_eq!(
+                    Cache::compute_spec_hash(&spec).unwrap(),
+                    "5d8eebf800c54c1e46ed66e72ff8b1c9bd7bfc88325aa2473b068aa69d9466a4"
+                );
+            }
+
+            #[test]
+            fn forge_github() {
+                let spec = CrateSpec::Forge {
+                    forge: Forge::GitHub {
+                        custom_url: None,
+                        owner: "owner".to_string(),
+                        repo: "repo".to_string(),
+                    },
+                    selector: GitSelector::DefaultBranch,
+                    name: None,
+                    version: None,
+                };
+                assert_eq!(
+                    Cache::compute_spec_hash(&spec).unwrap(),
+                    "9338fcc8761b894c6681a9100281143350ad2ded6bce067a4b39d2a787972ef2"
+                );
+            }
+
+            #[test]
+            fn local_dir() {
+                let spec = CrateSpec::LocalDir {
+                    path: PathBuf::from("/some/local/path"),
+                    name: None,
+                    version: None,
+                };
+                assert_eq!(
+                    Cache::compute_spec_hash(&spec).unwrap(),
+                    "e87d6dd1b220d02006524fbaac4d7c654b55eff1bd9a1332fd52a5e738a8fca5"
+                );
+            }
+        }
+
+        /// The binary-resolution-cache key, which is a hash computed from a resolved crate and the
+        /// target platform.
+        mod binary_cache_hash {
+            use super::*;
+
+            const PLATFORM: &str = "x86_64-unknown-linux-gnu";
+
+            #[test]
+            fn crates_io() {
+                let krate = ResolvedCrate {
+                    name: "eza".to_string(),
+                    version: Version::parse("0.23.1").unwrap(),
+                    source: ResolvedSource::CratesIo,
+                };
+                assert_eq!(
+                    Cache::compute_binary_cache_hash(&krate, PLATFORM).unwrap(),
+                    "e73c84363ece02d92a3dfe4ff390dcbe0dbe3381f050280505a1adb3916fad78"
+                );
+            }
+
+            #[test]
+            fn platform_changes_the_hash() {
+                let krate = ResolvedCrate {
+                    name: "eza".to_string(),
+                    version: Version::parse("0.23.1").unwrap(),
+                    source: ResolvedSource::CratesIo,
+                };
+                assert_ne!(
+                    Cache::compute_binary_cache_hash(&krate, "x86_64-unknown-linux-gnu").unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, "aarch64-apple-darwin").unwrap(),
+                );
+            }
+        }
+
+        /// The build-cache key, a hash computed from the resolved source and build options that
+        /// affect the output binary.
+        mod build_cache_hash {
+            use super::*;
+            use crate::builder::{BuildOptions, BuildTarget};
+
+            #[test]
+            fn source_hash_crates_io() {
+                assert_eq!(
+                    Cache::compute_source_hash(&ResolvedSource::CratesIo),
+                    "797cfdcfdf4d45ed0d3963577b0e549fe0c37295320d320d7173bfcf7bc42842"
+                );
+            }
+
+            #[test]
+            fn build_hash_default_options() {
+                assert_eq!(
+                    Cache::compute_build_hash(&BuildOptions::default()),
+                    "115fc6c55136730f0dbc99c9d90074d669d03b8ab9c61ccad2b76cb535f688af"
+                );
+            }
+
+            #[test]
+            fn build_hash_with_options() {
+                let options = BuildOptions {
+                    features: vec!["json".to_string(), "tls".to_string()],
+                    all_features: false,
+                    no_default_features: true,
+                    profile: Some("release".to_string()),
+                    target: Some("x86_64-unknown-linux-gnu".to_string()),
+                    build_target: BuildTarget::Bin("mybin".to_string()),
+                    toolchain: Some("stable".to_string()),
+                    locked: true,
+                    ..Default::default()
+                };
+                assert_eq!(
+                    Cache::compute_build_hash(&options),
+                    "122238fafcf514ae03c828f2b94c68a787ec9b3c69854aff6b51ae4b7f732c85"
+                );
+            }
+        }
+
+        /// The crate source cache directory layout, where crate source code is cached for reuse
+        /// across builds.
+        mod source_cache_paths {
+            use super::*;
+
+            fn assert_source_path(source: ResolvedSource, expected_suffix: &[&str]) {
+                let (cache, _temp) = test_cache();
+                let resolved = ResolvedCrate {
+                    name: "demo".to_string(),
+                    version: Version::parse("1.2.3").unwrap(),
+                    source,
+                };
+                let mut expected = cache.inner.config.cache_dir.join("sources");
+                for component in expected_suffix {
+                    expected = expected.join(component);
+                }
+                assert_eq!(cache.crate_source_cache_path(&resolved).unwrap(), expected);
+            }
+
+            #[test]
+            fn crates_io() {
+                assert_source_path(ResolvedSource::CratesIo, &["crates-io", "demo", "1.2.3"]);
+            }
+
+            #[test]
+            fn registry_named() {
+                assert_source_path(
+                    ResolvedSource::Registry {
+                        source: RegistrySource::Named("my-registry".to_string()),
+                    },
+                    &["registry", "my-registry", "demo", "1.2.3"],
+                );
+            }
+
+            #[test]
+            fn registry_index_url() {
+                assert_source_path(
+                    ResolvedSource::Registry {
+                        source: RegistrySource::IndexUrl(
+                            url::Url::parse("https://example.com/index").unwrap(),
+                        ),
+                    },
+                    &[
+                        "registry-index",
+                        "bf2749857dd97af7bf8b1b035bd103caee1276d7cf54cd24ea19dc9167bb0918",
+                        "demo",
+                        "1.2.3",
+                    ],
+                );
+            }
+
+            #[test]
+            fn git() {
+                // `sources/git/{sha256(repo_url)}/{commit}` (no name/version component)
+                assert_source_path(
+                    ResolvedSource::Git {
+                        repo: "https://github.com/owner/repo.git".to_string(),
+                        commit: "abc123".to_string(),
+                    },
+                    &[
+                        "git",
+                        "bc40893b43beea6303cb93d2e61df787840b4e09dcf293506e68491b9a082686",
+                        "abc123",
+                    ],
+                );
+            }
+
+            #[test]
+            fn forge_github() {
+                // `sources/github/{owner}/{repo}/{commit}` (no name/version component)
+                assert_source_path(
+                    ResolvedSource::Forge {
+                        forge: Forge::GitHub {
+                            custom_url: None,
+                            owner: "owner".to_string(),
+                            repo: "repo".to_string(),
+                        },
+                        commit: "abc123".to_string(),
+                    },
+                    &["github", "owner", "repo", "abc123"],
+                );
+            }
+
+            #[test]
+            fn forge_gitlab() {
+                // `sources/gitlab/{owner}/{repo}/{commit}` (no name/version component)
+                assert_source_path(
+                    ResolvedSource::Forge {
+                        forge: Forge::GitLab {
+                            custom_url: None,
+                            owner: "owner".to_string(),
+                            repo: "repo".to_string(),
+                        },
+                        commit: "def456".to_string(),
+                    },
+                    &["gitlab", "owner", "repo", "def456"],
+                );
+            }
         }
     }
 
@@ -1579,7 +2101,7 @@ mod tests {
         #[test]
         fn source_hash_distinguishes_crates_io() {
             let hash = Cache::compute_source_hash(&ResolvedSource::CratesIo);
-            assert_eq!(hash.len(), 16, "Hash should be 16 hex chars");
+            assert_eq!(hash.len(), 64, "SHA-256 hash should be 64 hex chars");
         }
 
         #[test]
@@ -1683,134 +2205,6 @@ mod tests {
             let hash2 = Cache::compute_spec_hash(&spec2).unwrap();
 
             assert_ne!(hash1, hash2);
-        }
-
-        #[test]
-        fn cache_path_format_crates_io() {
-            let (cache, _temp) = test_cache();
-            let resolved = test_resolved();
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("crates-io"));
-            assert!(path_str.contains("serde"));
-            assert!(path_str.contains("1.0.0"));
-        }
-
-        #[test]
-        fn cache_path_format_git() {
-            let (cache, _temp) = test_cache();
-            let resolved = ResolvedCrate {
-                name: "test".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                source: ResolvedSource::Git {
-                    repo: "https://github.com/test/test.git".to_string(),
-                    commit: "abc123".to_string(),
-                },
-            };
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("git"));
-            assert!(path_str.contains("abc123"));
-        }
-
-        #[test]
-        fn cache_path_format_github() {
-            let (cache, _temp) = test_cache();
-            let resolved = ResolvedCrate {
-                name: "test".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                source: ResolvedSource::Forge {
-                    forge: Forge::GitHub {
-                        custom_url: None,
-                        owner: "owner".to_string(),
-                        repo: "repo".to_string(),
-                    },
-                    commit: "abc123".to_string(),
-                },
-            };
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("github"));
-            assert!(path_str.contains("owner"));
-            assert!(path_str.contains("repo"));
-            assert!(path_str.contains("abc123"));
-        }
-
-        #[test]
-        fn cache_path_format_gitlab() {
-            let (cache, _temp) = test_cache();
-            let resolved = ResolvedCrate {
-                name: "test".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                source: ResolvedSource::Forge {
-                    forge: Forge::GitLab {
-                        custom_url: None,
-                        owner: "owner".to_string(),
-                        repo: "repo".to_string(),
-                    },
-                    commit: "def456".to_string(),
-                },
-            };
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("gitlab"));
-            assert!(path_str.contains("owner"));
-            assert!(path_str.contains("repo"));
-            assert!(path_str.contains("def456"));
-        }
-
-        #[test]
-        fn cache_path_format_registry_named() {
-            let (cache, _temp) = test_cache();
-            let resolved = ResolvedCrate {
-                name: "test".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                source: ResolvedSource::Registry {
-                    source: RegistrySource::Named("my-registry".to_string()),
-                },
-            };
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("registry"));
-            assert!(path_str.contains("my-registry"));
-            assert!(path_str.contains("test"));
-            assert!(path_str.contains("1.0.0"));
-        }
-
-        #[test]
-        fn cache_path_format_registry_index_url() {
-            let (cache, _temp) = test_cache();
-            let index_url = url::Url::parse("https://example.com/index").unwrap();
-            let resolved = ResolvedCrate {
-                name: "test".to_string(),
-                version: Version::parse("1.0.0").unwrap(),
-                source: ResolvedSource::Registry {
-                    source: RegistrySource::IndexUrl(index_url),
-                },
-            };
-
-            let path = cache.crate_source_cache_path(&resolved).unwrap();
-            let path_str = path.to_string_lossy();
-
-            assert!(path_str.contains("sources"));
-            assert!(path_str.contains("registry-index"));
-            assert!(path_str.contains("test"));
-            assert!(path_str.contains("1.0.0"));
         }
     }
 }

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -13,7 +13,7 @@ use tracing::*;
 
 use crate::{
     Result,
-    bin_resolver::ResolvedBinary,
+    bin_resolver::BinaryCacheEntry,
     builder::{BuildOptions, BuildTarget},
     config::Config,
     crate_resolver::{ResolvedCrate, ResolvedSource},
@@ -58,32 +58,6 @@ impl<T> CacheEntry<T> {
 
 /// A cache entry for a resolved crate specification.
 type CrateResolveCacheEntry = CacheEntry<ResolvedCrate>;
-
-/// A cached binary-resolution outcome.
-///
-/// Only conclusive outcomes should be cached; a transient/inconclusive resolution failure should
-/// never be persisted.
-///
-/// The two variants distinguish a positive result (a pre-built binary was resolved) from a
-/// conclusive negative (we determined no pre-built binary is available).  Theoretically it's
-/// possible that we could have checked at exactly the moment when a crate was just published but
-/// artifacts not yet released, or that a maintainer could go back and publish artifacts for older
-/// versions long after release, but both of these are highly unlikely.  By caching this result, we
-/// can speed up subsequent runs and avoid the many network requests (and potential throttling)
-/// that would be required to check for a pre-built binary every time.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "outcome", rename_all = "snake_case")]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "only a handful of these exist at a time (one per resolved crate); the size disparity between \
-              Found and Nonexistent does not matter and boxing would only add indirection"
-)]
-pub(crate) enum BinaryCacheEntry {
-    /// A pre-built binary was resolved.
-    Found(ResolvedBinary),
-    /// We conclusively determined that no pre-built binary is available.
-    Nonexistent,
-}
 
 /// Manages the various caches that cgx uses to operate.
 ///
@@ -357,27 +331,17 @@ impl Cache {
             .report(|| PrebuiltBinaryMessage::cache_lookup(krate));
 
         let entry = self.read_binary_cache_entry(krate);
-
-        match &entry {
-            Some(BinaryCacheEntry::Found(binary)) => self
-                .inner
+        if entry.is_none() {
+            self.inner
                 .reporter
-                .report(|| PrebuiltBinaryMessage::positive_cache_hit(krate, &binary.path, binary.provider)),
-            Some(BinaryCacheEntry::Nonexistent) => self
-                .inner
-                .reporter
-                .report(|| PrebuiltBinaryMessage::negative_cache_hit(krate)),
-            None => self
-                .inner
-                .reporter
-                .report(|| PrebuiltBinaryMessage::cache_miss(krate)),
+                .report(|| PrebuiltBinaryMessage::cache_miss(krate));
         }
 
         Ok(entry)
     }
 
-    /// Store a conclusive binary resolution outcome in the cache for the given [`ResolvedCrate`].
-    pub(crate) fn put_cached_binary(&self, krate: &ResolvedCrate, entry: &BinaryCacheEntry) -> Result<()> {
+    /// Store a binary-resolution cache entry for the given [`ResolvedCrate`].
+    pub(crate) fn put_cached_binary(&self, krate: &ResolvedCrate, entry: BinaryCacheEntry) -> Result<()> {
         let cache_file = self.binary_cache_path(krate)?;
 
         if let Some(parent) = cache_file.parent() {
@@ -862,6 +826,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::bin_resolver::{BinaryCacheEntry, ConclusiveResolution, ResolvedBinary};
 
     fn test_cache() -> (Cache, TempDir) {
         test_cache_with_timeout(Duration::from_secs(3600))
@@ -953,15 +918,23 @@ mod tests {
             /// A positive entry: a resolved binary was found and cached.
             fn positive_entry() -> CacheEntry<BinaryCacheEntry> {
                 CacheEntry {
-                    value: BinaryCacheEntry::Found(ResolvedBinary {
-                        krate: ResolvedCrate {
-                            name: "eza".to_string(),
-                            version: Version::parse("0.23.1").unwrap(),
-                            source: ResolvedSource::CratesIo,
-                        },
-                        provider: BinaryProvider::GithubReleases,
-                        path: PathBuf::from("/cache/bin/eza"),
-                    }),
+                    value: BinaryCacheEntry {
+                        outcome: ConclusiveResolution::Found(ResolvedBinary {
+                            krate: ResolvedCrate {
+                                name: "eza".to_string(),
+                                version: Version::parse("0.23.1").unwrap(),
+                                source: ResolvedSource::CratesIo,
+                            },
+                            provider: BinaryProvider::GithubReleases,
+                            path: PathBuf::from("/cache/bin/eza"),
+                        }),
+                        enabled_providers: vec![
+                            BinaryProvider::Binstall,
+                            BinaryProvider::GithubReleases,
+                            BinaryProvider::GitlabReleases,
+                            BinaryProvider::Quickinstall,
+                        ],
+                    },
                     cached_at: fixed_cached_at(),
                 }
             }
@@ -969,7 +942,13 @@ mod tests {
             /// A negative entry: we conclusively determined no binary is available.
             fn negative_entry() -> CacheEntry<BinaryCacheEntry> {
                 CacheEntry {
-                    value: BinaryCacheEntry::Nonexistent,
+                    value: BinaryCacheEntry {
+                        outcome: ConclusiveResolution::Nonexistent,
+                        enabled_providers: vec![
+                            BinaryProvider::GithubReleases,
+                            BinaryProvider::GitlabReleases,
+                        ],
+                    },
                     cached_at: fixed_cached_at(),
                 }
             }
@@ -983,11 +962,21 @@ mod tests {
   },
   "provider": "github-releases",
   "path": "/cache/bin/eza",
+  "enabled_providers": [
+    "binstall",
+    "github-releases",
+    "gitlab-releases",
+    "quickinstall"
+  ],
   "cached_at": "2024-01-15T12:30:00Z"
 }"#;
 
             const NEGATIVE_JSON: &str = r#"{
   "outcome": "nonexistent",
+  "enabled_providers": [
+    "github-releases",
+    "gitlab-releases"
+  ],
   "cached_at": "2024-01-15T12:30:00Z"
 }"#;
 
@@ -2205,6 +2194,65 @@ mod tests {
             let hash2 = Cache::compute_spec_hash(&spec2).unwrap();
 
             assert_ne!(hash1, hash2);
+        }
+    }
+
+    /// The cache's job for binary entries is pretty dumb at this level; just get and put cache
+    /// entry structs.
+    mod binary_cache {
+        use super::*;
+        use crate::config::BinaryProvider;
+
+        #[test]
+        fn put_then_get_round_trips_outcome_and_providers() {
+            let (cache, _temp) = test_cache();
+            let krate = test_resolved();
+            let providers = vec![BinaryProvider::Binstall, BinaryProvider::GithubReleases];
+
+            assert_matches!(cache.get_cached_binary(&krate), Ok(None));
+
+            cache
+                .put_cached_binary(
+                    &krate,
+                    BinaryCacheEntry {
+                        outcome: ConclusiveResolution::Nonexistent,
+                        enabled_providers: providers.clone(),
+                    },
+                )
+                .unwrap();
+
+            let entry = cache.get_cached_binary(&krate).unwrap().unwrap();
+            assert_eq!(entry.outcome, ConclusiveResolution::Nonexistent);
+            assert_eq!(entry.enabled_providers, providers);
+        }
+
+        #[test]
+        fn put_overwrites_previous_entry() {
+            let (cache, _temp) = test_cache();
+            let krate = test_resolved();
+
+            cache
+                .put_cached_binary(
+                    &krate,
+                    BinaryCacheEntry {
+                        outcome: ConclusiveResolution::Nonexistent,
+                        enabled_providers: vec![BinaryProvider::GitlabReleases],
+                    },
+                )
+                .unwrap();
+
+            let found = BinaryCacheEntry {
+                outcome: ConclusiveResolution::Found(ResolvedBinary {
+                    krate: test_resolved(),
+                    provider: BinaryProvider::GithubReleases,
+                    path: PathBuf::from("/cache/bin/serde"),
+                }),
+                enabled_providers: vec![BinaryProvider::GithubReleases],
+            };
+            cache.put_cached_binary(&krate, found.clone()).unwrap();
+
+            let entry = cache.get_cached_binary(&krate).unwrap().unwrap();
+            assert_eq!(entry, found);
         }
     }
 }

--- a/cgx-core/src/crate_resolver.rs
+++ b/cgx-core/src/crate_resolver.rs
@@ -5,6 +5,7 @@ use std::{
 
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use snafu::OptionExt;
 
 use crate::{
@@ -67,6 +68,7 @@ pub trait CrateResolver: std::fmt::Debug + Send + Sync + 'static {
 /// selectors (like branch names or tags), [`ResolvedSource`] variants contain only concrete,
 /// immutable references (like commit hashes).
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ResolvedSource {
     /// A crate from Crates.io
     CratesIo,
@@ -100,6 +102,16 @@ pub enum ResolvedSource {
         /// The path to the directory containing the crate
         path: PathBuf,
     },
+}
+
+impl ResolvedSource {
+    /// Compute the stable hash used to distinguish resolved crate sources in cache paths.
+    pub(crate) fn source_hash(&self) -> String {
+        let json = serde_json::to_string(self).expect("BUG: serializing a ResolvedSource cannot fail");
+        let mut hasher = Sha256::new();
+        hasher.update(json.as_bytes());
+        crate::helpers::format_hex_lower(hasher.finalize())
+    }
 }
 
 /// Create the default [`CrateResolver`] implementation, respecting the given config and using the

--- a/cgx-core/src/cratespec.rs
+++ b/cgx-core/src/cratespec.rs
@@ -432,6 +432,7 @@ impl CrateSpec {
 /// Registries can be specified either by a named configuration in `.cargo/config.toml` or by
 /// directly providing the index URL.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum RegistrySource {
     /// A named registry configured in `.cargo/config.toml` (corresponds to `--registry`).
     Named(String),
@@ -442,6 +443,7 @@ pub enum RegistrySource {
 
 /// Supported software forges where crates can be hosted
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Forge {
     GitHub {
         /// Custom URL for Github Enterprise instances; None for github.com

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -291,6 +291,9 @@ pub enum Error {
     #[snafu(display("HTTP {status} from {url}"))]
     HttpStatus { url: String, status: u16 },
 
+    #[snafu(display("Provider request to {url} was throttled: HTTP {status}"))]
+    ProviderThrottled { url: String, status: u16 },
+
     #[snafu(display(
         "Failed to prefetch {} configured tool(s): {}",
         failures.len(),
@@ -306,35 +309,10 @@ pub enum Error {
 }
 
 impl Error {
-    /// Check whether an error is transient: a failure whose outcome is inconclusive because a
-    /// later attempt might succeed.
-    ///
-    /// Returns `true` for connection/timeout failures and for the throttling/server HTTP statuses
-    /// that retries already target: 403 (GitHub returns this for rate limiting), 429, and any 5xx.
-    ///
-    /// This transient/not-transient distinction is important in cases where we want to know if
-    /// some operation has failed because the resource we are trying to get simply doesn't exist
-    /// (or is invalid), or if there is some transient issue (most commonly throttling on the part
-    /// of the remote HTTP endpoint, but could also be transient network glitches) that should not
-    /// be stored in the cache as a definitive "this thing doesn't exist; do not look for it again"
-    /// result.
-    pub(crate) fn is_transient_http_error(&self) -> bool {
-        match self {
-            Self::HttpRequest { source, .. } => {
-                source.is_connect() || source.is_timeout() || source.is_request()
-            }
-            Self::HttpStatus { status, .. } => *status == 403 || *status == 429 || *status >= 500,
-            _ => false,
-        }
-    }
-
-    /// Check if a given error is 1) an HTTP error, and 2) one that is retryable (i.e. a 5xx or 429
-    /// status, or a connection/timeout error).
+    /// Check whether an HTTP operation error should be retried by [`crate::http::HttpClient`].
     pub(crate) fn is_retryable_http_error(&self) -> bool {
         match self {
-            Self::HttpStatus { status, .. } => {
-                *status == StatusCode::TOO_MANY_REQUESTS.as_u16() || *status >= 500
-            }
+            Self::HttpStatus { .. } => true,
             Self::HttpRequest { source, .. } => {
                 source.is_connect() || source.is_timeout() || source.is_request()
             }
@@ -352,49 +330,3 @@ impl From<crate::git::Error> for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_is_transient_http_statuses() {
-        // Throttling / server statuses are transient: a retry might succeed.
-        for status in [403u16, 429, 500, 503] {
-            let err = Error::HttpStatus {
-                url: "http://example.com".to_string(),
-                status,
-            };
-            assert!(err.is_transient_http_error(), "expected {status} to be transient");
-        }
-
-        // A conclusive client error (e.g. 404) is not transient.
-        let not_found = Error::HttpStatus {
-            url: "http://example.com".to_string(),
-            status: 404,
-        };
-        assert!(!not_found.is_transient_http_error());
-
-        // HttpClientBuild is not transient
-        let build_err = Error::HttpClientBuild {
-            message: "test".to_string(),
-        };
-        assert!(!build_err.is_transient_http_error());
-    }
-
-    #[test]
-    fn test_is_transient_non_http_errors_are_not_transient() {
-        let errors: Vec<Error> = vec![
-            Error::HttpClientBuild {
-                message: "bad config".to_string(),
-            },
-            Error::InvalidHttpTimeout {
-                value: "not-a-duration".to_string(),
-                source: humantime::parse_duration("not-a-duration").unwrap_err(),
-            },
-        ];
-        for err in &errors {
-            assert!(!err.is_transient_http_error(), "Expected false for {:?}", err);
-        }
-    }
-}

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -224,6 +224,16 @@ pub enum Error {
     PrebuiltBinaryRequired { name: String, version: String },
 
     #[snafu(display(
+        "Prebuilt binary required (--prebuilt-binary always) but resolution could not be completed for \
+         crate '{name}' version '{version}'"
+    ))]
+    PrebuiltBinaryResolutionFailed {
+        name: String,
+        version: String,
+        source: Box<Error>,
+    },
+
+    #[snafu(display(
         "Prebuilt binary required (--prebuilt-binary always) but {reason}, which requires building crate \
          '{name}' version '{version}' from source"
     ))]
@@ -295,6 +305,44 @@ pub enum Error {
     },
 }
 
+impl Error {
+    /// Check whether an error is transient: a failure whose outcome is inconclusive because a
+    /// later attempt might succeed.
+    ///
+    /// Returns `true` for connection/timeout failures and for the throttling/server HTTP statuses
+    /// that retries already target: 403 (GitHub returns this for rate limiting), 429, and any 5xx.
+    ///
+    /// This transient/not-transient distinction is important in cases where we want to know if
+    /// some operation has failed because the resource we are trying to get simply doesn't exist
+    /// (or is invalid), or if there is some transient issue (most commonly throttling on the part
+    /// of the remote HTTP endpoint, but could also be transient network glitches) that should not
+    /// be stored in the cache as a definitive "this thing doesn't exist; do not look for it again"
+    /// result.
+    pub(crate) fn is_transient_http_error(&self) -> bool {
+        match self {
+            Self::HttpRequest { source, .. } => {
+                source.is_connect() || source.is_timeout() || source.is_request()
+            }
+            Self::HttpStatus { status, .. } => *status == 403 || *status == 429 || *status >= 500,
+            _ => false,
+        }
+    }
+
+    /// Check if a given error is 1) an HTTP error, and 2) one that is retryable (i.e. a 5xx or 429
+    /// status, or a connection/timeout error).
+    pub(crate) fn is_retryable_http_error(&self) -> bool {
+        match self {
+            Self::HttpStatus { status, .. } => {
+                *status == StatusCode::TOO_MANY_REQUESTS.as_u16() || *status >= 500
+            }
+            Self::HttpRequest { source, .. } => {
+                source.is_connect() || source.is_timeout() || source.is_request()
+            }
+            _ => false,
+        }
+    }
+}
+
 impl From<crate::git::Error> for Error {
     fn from(e: crate::git::Error) -> Self {
         Self::Git {
@@ -304,3 +352,49 @@ impl From<crate::git::Error> for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_transient_http_statuses() {
+        // Throttling / server statuses are transient: a retry might succeed.
+        for status in [403u16, 429, 500, 503] {
+            let err = Error::HttpStatus {
+                url: "http://example.com".to_string(),
+                status,
+            };
+            assert!(err.is_transient_http_error(), "expected {status} to be transient");
+        }
+
+        // A conclusive client error (e.g. 404) is not transient.
+        let not_found = Error::HttpStatus {
+            url: "http://example.com".to_string(),
+            status: 404,
+        };
+        assert!(!not_found.is_transient_http_error());
+
+        // HttpClientBuild is not transient
+        let build_err = Error::HttpClientBuild {
+            message: "test".to_string(),
+        };
+        assert!(!build_err.is_transient_http_error());
+    }
+
+    #[test]
+    fn test_is_transient_non_http_errors_are_not_transient() {
+        let errors: Vec<Error> = vec![
+            Error::HttpClientBuild {
+                message: "bad config".to_string(),
+            },
+            Error::InvalidHttpTimeout {
+                value: "not-a-duration".to_string(),
+                source: humantime::parse_duration("not-a-duration").unwrap_err(),
+            },
+        ];
+        for err in &errors {
+            assert!(!err.is_transient_http_error(), "Expected false for {:?}", err);
+        }
+    }
+}

--- a/cgx-core/src/http.rs
+++ b/cgx-core/src/http.rs
@@ -107,7 +107,7 @@ impl HttpClient {
 
         operation
             .retry(backoff)
-            .when(Self::is_retryable_error)
+            .when(error::Error::is_retryable_http_error)
             .notify(|err, dur| {
                 tracing::debug!("HTTP request failed, retrying in {:?}: {:?}", dur, err);
             })
@@ -137,7 +137,7 @@ impl HttpClient {
 
         operation
             .retry(backoff)
-            .when(Self::is_retryable_error)
+            .when(error::Error::is_retryable_http_error)
             .notify(|err, dur| {
                 tracing::debug!("HTTP HEAD request failed, retrying in {:?}: {:?}", dur, err);
             })
@@ -172,19 +172,6 @@ impl HttpClient {
             .with_context(|_| error::HttpRequestSnafu { url: url.to_string() })?;
 
         Ok(Some(bytes))
-    }
-
-    /// Check if an error indicates a connection/timeout failure (vs a logical HTTP error).
-    ///
-    /// This is used by the GitLab provider to bail early when the server is unreachable,
-    /// rather than continuing to probe ~160 candidate URLs against a dead server.
-    pub fn is_connection_error(err: &error::Error) -> bool {
-        match err {
-            error::Error::HttpRequest { source, .. } => {
-                source.is_connect() || source.is_timeout() || source.is_request()
-            }
-            _ => false,
-        }
     }
 
     fn build_backoff(&self) -> ExponentialBuilder {
@@ -223,18 +210,6 @@ impl HttpClient {
 
         // All other responses (including 4xx other than 429) are returned as-is
         Ok(response)
-    }
-
-    fn is_retryable_error(err: &error::Error) -> bool {
-        match err {
-            error::Error::HttpStatus { status, .. } => {
-                *status == reqwest::StatusCode::TOO_MANY_REQUESTS.as_u16() || *status >= 500
-            }
-            error::Error::HttpRequest { source, .. } => {
-                source.is_connect() || source.is_timeout() || source.is_request()
-            }
-            _ => false,
-        }
     }
 }
 
@@ -291,22 +266,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_connection_error() {
-        // HttpStatus is not a connection error
-        let status_err = error::Error::HttpStatus {
-            url: "http://example.com".to_string(),
-            status: 500,
-        };
-        assert!(!HttpClient::is_connection_error(&status_err));
-
-        // HttpClientBuild is not a connection error
-        let build_err = error::Error::HttpClientBuild {
-            message: "test".to_string(),
-        };
-        assert!(!HttpClient::is_connection_error(&build_err));
-    }
-
-    #[test]
     fn test_construction_with_custom_timeout() {
         let config = HttpConfig {
             timeout: Duration::from_secs(120),
@@ -340,34 +299,6 @@ mod tests {
             ..Default::default()
         };
         HttpClient::new(&config).unwrap();
-    }
-
-    #[test]
-    fn test_is_connection_error_various_non_http_errors() {
-        let errors: Vec<error::Error> = vec![
-            error::Error::HttpStatus {
-                url: "http://example.com".to_string(),
-                status: 429,
-            },
-            error::Error::HttpStatus {
-                url: "http://example.com".to_string(),
-                status: 503,
-            },
-            error::Error::HttpClientBuild {
-                message: "bad config".to_string(),
-            },
-            error::Error::InvalidHttpTimeout {
-                value: "not-a-duration".to_string(),
-                source: humantime::parse_duration("not-a-duration").unwrap_err(),
-            },
-        ];
-        for err in &errors {
-            assert!(
-                !HttpClient::is_connection_error(err),
-                "Expected false for {:?}",
-                err
-            );
-        }
     }
 
     fn fast_retry_config() -> HttpConfig {

--- a/cgx-core/src/http.rs
+++ b/cgx-core/src/http.rs
@@ -2,8 +2,11 @@ use std::time::Duration;
 
 use backon::{BlockingRetryable, ExponentialBuilder};
 pub use bytes::Bytes;
-use reqwest::blocking::{Client, Response};
 pub use reqwest::header::{ACCEPT, AUTHORIZATION, HeaderMap, HeaderValue};
+use reqwest::{
+    StatusCode,
+    blocking::{Client, Response},
+};
 use snafu::ResultExt;
 
 use crate::{Result, config::HttpConfig, error};
@@ -88,6 +91,31 @@ impl HttpClient {
     /// Returns the response even if the status is non-success (except for retryable statuses);
     /// callers must inspect the status and handle non-2xx as needed.
     pub fn get_with_headers(&self, url: &str, headers: &HeaderMap) -> Result<Response> {
+        self.get_with_headers_retrying_status(url, headers, Self::standard_should_retry_status)
+    }
+
+    /// Perform a GET request with a custom status retry policy.
+    ///
+    /// Transport errors continue to use the standard retry policy; `should_retry_status` controls
+    /// only HTTP response statuses.
+    pub(crate) fn get_retrying_status(
+        &self,
+        url: &str,
+        should_retry_status: fn(StatusCode) -> bool,
+    ) -> Result<Response> {
+        self.get_with_headers_retrying_status(url, &HeaderMap::new(), should_retry_status)
+    }
+
+    /// Perform a GET request with custom headers and a custom status retry policy.
+    ///
+    /// Transport errors continue to use the standard retry policy; `should_retry_status` controls
+    /// only HTTP response statuses.
+    pub(crate) fn get_with_headers_retrying_status(
+        &self,
+        url: &str,
+        headers: &HeaderMap,
+        should_retry_status: fn(StatusCode) -> bool,
+    ) -> Result<Response> {
         let backoff = self.build_backoff();
         let url_owned = url.to_string();
         let headers = headers.clone();
@@ -102,7 +130,7 @@ impl HttpClient {
                 url: url_owned.clone(),
             })?;
 
-            Self::classify_retryable_status(response, &url_owned)
+            Self::classify_retryable_status(response, &url_owned, should_retry_status)
         };
 
         operation
@@ -120,6 +148,18 @@ impl HttpClient {
     /// Returns the response even if the status is non-success (except for retryable statuses);
     /// callers must inspect the status and handle non-2xx as needed.
     pub fn head(&self, url: &str) -> Result<Response> {
+        self.head_retrying_status(url, Self::standard_should_retry_status)
+    }
+
+    /// Perform a HEAD request with a custom status retry policy.
+    ///
+    /// Transport errors continue to use the standard retry policy; `should_retry_status` controls
+    /// only HTTP response statuses.
+    pub(crate) fn head_retrying_status(
+        &self,
+        url: &str,
+        should_retry_status: fn(StatusCode) -> bool,
+    ) -> Result<Response> {
         let backoff = self.build_backoff();
         let url_owned = url.to_string();
 
@@ -132,7 +172,7 @@ impl HttpClient {
                     url: url_owned.clone(),
                 })?;
 
-            Self::classify_retryable_status(response, &url_owned)
+            Self::classify_retryable_status(response, &url_owned, should_retry_status)
         };
 
         operation
@@ -155,7 +195,7 @@ impl HttpClient {
     pub fn try_download(&self, url: &str) -> Result<Option<Bytes>> {
         let response = self.get(url)?;
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+        if response.status() == StatusCode::NOT_FOUND {
             return Ok(None);
         }
 
@@ -182,16 +222,24 @@ impl HttpClient {
             .with_jitter()
     }
 
+    /// Return whether a status should be retried by the default HTTP policy.
+    pub(crate) fn standard_should_retry_status(status: StatusCode) -> bool {
+        status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+    }
+
     /// Convert retryable HTTP status codes into errors that trigger retry.
     ///
     /// Returns `Err(HttpStatus)` only for status codes that we consider retriable, so the
     /// retry policy can act on them. `Ok(response)` does not imply success; it only
     /// means the response is not retryable and should be handled by the caller.
-    fn classify_retryable_status(response: Response, url: &str) -> Result<Response> {
+    fn classify_retryable_status(
+        response: Response,
+        url: &str,
+        should_retry_status: fn(StatusCode) -> bool,
+    ) -> Result<Response> {
         let status = response.status();
 
-        // 429 Too Many Requests - retryable
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        if should_retry_status(status) {
             return error::HttpStatusSnafu {
                 url: url.to_string(),
                 status: status.as_u16(),
@@ -199,16 +247,7 @@ impl HttpClient {
             .fail();
         }
 
-        // 5xx Server Errors - retryable
-        if status.is_server_error() {
-            return error::HttpStatusSnafu {
-                url: url.to_string(),
-                status: status.as_u16(),
-            }
-            .fail();
-        }
-
-        // All other responses (including 4xx other than 429) are returned as-is
+        // All other responses are returned as-is.
         Ok(response)
     }
 }
@@ -314,6 +353,14 @@ mod tests {
         use httpmock::prelude::*;
 
         use super::*;
+
+        fn retry_server_errors_only(status: StatusCode) -> bool {
+            status.is_server_error()
+        }
+
+        fn never_retry_status(_: StatusCode) -> bool {
+            false
+        }
 
         #[test]
         fn test_get_200_returned_directly() {
@@ -449,6 +496,87 @@ mod tests {
             let result = client.get(&server.url("/once"));
             assert_matches!(result, Err(error::Error::HttpStatus { status: 500, .. }));
             mock.assert_calls(1);
+        }
+
+        #[test]
+        fn test_custom_status_retry_predicate_returns_429_without_retrying() {
+            let server = MockServer::start();
+            let mock = server.mock(|when, then| {
+                when.method(GET).path("/ratelimit");
+                then.status(429);
+            });
+
+            let client = HttpClient::new(&fast_retry_config()).unwrap();
+            let response = client
+                .get_retrying_status(&server.url("/ratelimit"), retry_server_errors_only)
+                .unwrap();
+            assert_eq!(response.status(), 429);
+            mock.assert_calls(1);
+        }
+
+        #[test]
+        fn test_custom_status_retry_predicate_still_retries_5xx() {
+            let server = MockServer::start();
+            let mock = server.mock(|when, then| {
+                when.method(GET).path("/error");
+                then.status(500);
+            });
+
+            let config = HttpConfig {
+                retries: 1,
+                backoff_base: Duration::from_millis(1),
+                backoff_max: Duration::from_millis(10),
+                ..Default::default()
+            };
+            let client = HttpClient::new(&config).unwrap();
+            let result = client.get_retrying_status(&server.url("/error"), retry_server_errors_only);
+            assert_matches!(result, Err(error::Error::HttpStatus { status: 500, .. }));
+            mock.assert_calls(2);
+        }
+
+        #[test]
+        fn test_custom_status_retry_predicate_still_retries_transport_errors() {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let url = format!("http://{}/closed", listener.local_addr().unwrap());
+            let request_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let accepting = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+            let request_count_for_thread = std::sync::Arc::clone(&request_count);
+            let accepting_for_thread = std::sync::Arc::clone(&accepting);
+            let server = std::thread::spawn(move || {
+                let deadline = std::time::Instant::now() + Duration::from_secs(2);
+                while accepting_for_thread.load(std::sync::atomic::Ordering::SeqCst)
+                    && std::time::Instant::now() < deadline
+                {
+                    match listener.accept() {
+                        Ok((stream, _addr)) => {
+                            request_count_for_thread.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            drop(stream);
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(Duration::from_millis(5));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            let config = HttpConfig {
+                retries: 1,
+                backoff_base: Duration::from_millis(1),
+                backoff_max: Duration::from_millis(10),
+                ..Default::default()
+            };
+            let client = HttpClient::new(&config).unwrap();
+            let result = client.get_retrying_status(&url, never_retry_status);
+            accepting.store(false, std::sync::atomic::Ordering::SeqCst);
+            server.join().unwrap();
+
+            assert_matches!(result, Err(error::Error::HttpRequest { .. }));
+            assert!(
+                request_count.load(std::sync::atomic::Ordering::SeqCst) >= 2,
+                "transport errors should still use the standard retry path"
+            );
         }
     }
 
@@ -599,6 +727,26 @@ mod tests {
             let client = HttpClient::new(&config).unwrap();
             let result = client.head(&server.url("/head-ratelimit"));
             assert_matches!(result, Err(error::Error::HttpStatus { status: 429, .. }));
+            mock.assert_calls(2);
+        }
+
+        #[test]
+        fn test_head_retries_on_5xx() {
+            let server = MockServer::start();
+            let mock = server.mock(|when, then| {
+                when.method(HEAD).path("/head-error");
+                then.status(500);
+            });
+
+            let config = HttpConfig {
+                retries: 1,
+                backoff_base: Duration::from_millis(1),
+                backoff_max: Duration::from_millis(10),
+                ..Default::default()
+            };
+            let client = HttpClient::new(&config).unwrap();
+            let result = client.head(&server.url("/head-error"));
+            assert_matches!(result, Err(error::Error::HttpStatus { status: 500, .. }));
             mock.assert_calls(2);
         }
     }

--- a/cgx-core/src/messages/mod.rs
+++ b/cgx-core/src/messages/mod.rs
@@ -14,7 +14,7 @@ pub use build_cache::BuildCacheMessage;
 pub use cgx::{CgxMessage, Provenance};
 pub use crate_resolution::CrateResolutionMessage;
 pub use git::GitMessage;
-pub use prebuilt_binary::PrebuiltBinaryMessage;
+pub use prebuilt_binary::{PrebuiltBinaryMessage, ProviderChangeReason};
 pub use runner::RunnerMessage;
 use serde::{Deserialize, Serialize};
 pub use source::SourceMessage;

--- a/cgx-core/src/messages/prebuilt_binary.rs
+++ b/cgx-core/src/messages/prebuilt_binary.rs
@@ -5,6 +5,19 @@ use serde::{Deserialize, Serialize};
 use super::Message;
 use crate::{bin_resolver::ResolvedBinary, config::BinaryProvider, crate_resolver::ResolvedCrate};
 
+/// Why a cached binary-resolution entry was discarded because the enabled set of binary providers
+/// changed since the entry was written.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderChangeReason {
+    /// A provider is now enabled that was not enabled when the cache entry was created, so the
+    /// cached outcome might no longer be correct (this provider was never consulted).
+    RequiredProviderNotEnabled(BinaryProvider),
+    /// The provider that produced the cached binary is no longer enabled, so the binary must not be
+    /// served.
+    SourceProviderDisabled(BinaryProvider),
+}
+
 /// Messages related to prebuilt binary resolution and binary resolution cache operations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "event", rename_all = "snake_case")]
@@ -22,6 +35,12 @@ pub enum PrebuiltBinaryMessage {
     NegativeCacheHit { krate: ResolvedCrate },
     /// No cached prebuilt binary resolution found
     CacheMiss { krate: ResolvedCrate },
+    /// A cached prebuilt binary resolution existed but was discarded because the enabled set of
+    /// binary providers changed, so the crate will be re-resolved.
+    CacheInvalidatedByProviderChange {
+        krate: ResolvedCrate,
+        reason: ProviderChangeReason,
+    },
     /// Checking a specific binary provider for prebuilt binaries
     CheckingProvider {
         krate: ResolvedCrate,
@@ -80,6 +99,13 @@ impl PrebuiltBinaryMessage {
 
     pub fn cache_miss(krate: &ResolvedCrate) -> Self {
         Self::CacheMiss { krate: krate.clone() }
+    }
+
+    pub fn cache_invalidated_by_provider_change(krate: &ResolvedCrate, reason: ProviderChangeReason) -> Self {
+        Self::CacheInvalidatedByProviderChange {
+            krate: krate.clone(),
+            reason,
+        }
     }
 
     pub fn checking_provider(krate: &ResolvedCrate, provider: BinaryProvider) -> Self {

--- a/cgx-core/src/messages/prebuilt_binary.rs
+++ b/cgx-core/src/messages/prebuilt_binary.rs
@@ -11,8 +11,15 @@ use crate::{bin_resolver::ResolvedBinary, config::BinaryProvider, crate_resolver
 pub enum PrebuiltBinaryMessage {
     /// Looking up prebuilt binary resolution in cache
     CacheLookup { krate: ResolvedCrate },
-    /// Found cached prebuilt binary resolution
-    CacheHit { path: PathBuf, provider: BinaryProvider },
+    /// A positive prebuilt binary cache hit: a previously-resolved binary was found in the cache.
+    PositiveCacheHit {
+        krate: ResolvedCrate,
+        path: PathBuf,
+        provider: BinaryProvider,
+    },
+    /// A negative prebuilt binary cache hit: we previously determined, conclusively, that no
+    /// prebuilt binary is available for this crate.
+    NegativeCacheHit { krate: ResolvedCrate },
     /// No cached prebuilt binary resolution found
     CacheMiss { krate: ResolvedCrate },
     /// Checking a specific binary provider for prebuilt binaries
@@ -40,6 +47,10 @@ pub enum PrebuiltBinaryMessage {
         krate: ResolvedCrate,
         reasons: Vec<String>,
     },
+    /// Prebuilt binary resolution was inconclusive: a transient failure (such as a rate limit or
+    /// network error) prevented at least one provider from providing a definitive answer, so the
+    /// result is not cached and the crate falls back to building from source.
+    ResolutionInconclusive { reason: String },
     /// Prebuilt binary cannot be used due to build customization
     DisqualifiedDueToCustomization { reason: String },
     /// Prebuilt binaries are disabled in config
@@ -51,11 +62,20 @@ impl PrebuiltBinaryMessage {
         Self::CacheLookup { krate: krate.clone() }
     }
 
-    pub fn cache_hit(path: &std::path::Path, provider: BinaryProvider) -> Self {
-        Self::CacheHit {
+    pub fn positive_cache_hit(
+        krate: &ResolvedCrate,
+        path: &std::path::Path,
+        provider: BinaryProvider,
+    ) -> Self {
+        Self::PositiveCacheHit {
+            krate: krate.clone(),
             path: path.to_path_buf(),
             provider,
         }
+    }
+
+    pub fn negative_cache_hit(krate: &ResolvedCrate) -> Self {
+        Self::NegativeCacheHit { krate: krate.clone() }
     }
 
     pub fn cache_miss(krate: &ResolvedCrate) -> Self {
@@ -109,6 +129,12 @@ impl PrebuiltBinaryMessage {
         Self::NoBinaryFound {
             krate: krate.clone(),
             reasons,
+        }
+    }
+
+    pub fn resolution_inconclusive(reason: impl Into<String>) -> Self {
+        Self::ResolutionInconclusive {
+            reason: reason.into(),
         }
     }
 

--- a/cgx/tests/integration/defaults.rs
+++ b/cgx/tests/integration/defaults.rs
@@ -128,10 +128,11 @@ fn messages_with_prebuilt_binary() {
         "Expected CrateResolution::CacheHit on second run"
     );
     assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::CacheHit { .. }))),
-        "Expected PrebuiltBinary::CacheHit on second run (pre-built binary cached)"
+        messages.iter().any(|m| matches!(
+            m,
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::PositiveCacheHit { .. })
+        )),
+        "Expected PrebuiltBinary::PositiveCacheHit on second run (pre-built binary cached)"
     );
     assert!(
         messages.iter().any(|m| matches!(

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -298,10 +298,11 @@ fn cache_flow_switching_modes() {
 
     // Verify we hit the binary resolution cache and reused the prebuilt binary on the third run.
     assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::CacheHit { .. }))),
-        "Expected PrebuiltBinaryMessage::CacheHit on third run"
+        messages.iter().any(|m| matches!(
+            m,
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::PositiveCacheHit { .. })
+        )),
+        "Expected PrebuiltBinaryMessage::PositiveCacheHit on third run"
     );
     assert_prebuilt(&messages);
 }
@@ -425,6 +426,15 @@ fn negative_cache_persists() {
             Message::PrebuiltBinary(PrebuiltBinaryMessage::CacheLookup { .. })
         )),
         "Expected PrebuiltBinary::CacheLookup on second run"
+    );
+
+    // The second run should be a negative cache hit (we previously determined no binary exists)
+    assert!(
+        messages.iter().any(|m| matches!(
+            m,
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::NegativeCacheHit { .. })
+        )),
+        "Expected PrebuiltBinary::NegativeCacheHit on second run"
     );
 
     // Should NOT see provider checking messages (proves we used the cache)
@@ -578,6 +588,56 @@ fn github_provider_resolves_binary() {
     });
     let binary = resolved.expect("Expected PrebuiltBinaryMessage::Resolved");
     assert_eq!(binary.provider, BinaryProvider::GithubReleases);
+
+    assert!(
+        !messages
+            .iter()
+            .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+        "Should not have BuildMessage::Started when using prebuilt binary"
+    );
+}
+
+/// Regression test for #206: `taplo-cli` resolves its prebuilt binary from GitHub releases.
+///
+/// This exercises all three of the asset-matching heuristics the fix added: the asset is named after
+/// the `taplo` binary (not the `taplo-cli` crate), uses a short `{os}-{arch}` platform token
+/// (`taplo-linux-x86_64`, not the full triple), and on Linux/macOS is a bare `.gz` (a gzipped
+/// binary, not a tarball). `--no-exec` runs the full download+extract path — so the naked-`.gz`
+/// extraction is covered end to end — without executing the binary, sidestepping any glibc/musl
+/// run-host mismatch. Gated to the OS/arch combinations for which taplo publishes an asset that the
+/// `{os}-{arch}` alias matches.
+#[test]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+fn github_provider_resolves_taplo_cli_via_binary_name() {
+    let mut cgx = Cgx::with_test_fs();
+
+    let (assert, messages) = cgx
+        .cmd
+        .with_json_messages()
+        .arg("--prebuilt-binary")
+        .arg("always")
+        .arg("--prebuilt-binary-sources")
+        .arg("github-releases")
+        .arg("--no-exec")
+        .arg("taplo-cli@=0.10.0")
+        .assert_with_messages();
+
+    // `--no-exec` prints the resolved binary path; it is named after the `taplo` binary target.
+    assert.success().stdout(predicates::str::contains("taplo"));
+
+    let binary = messages
+        .iter()
+        .find_map(|m| match m {
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { binary }) => Some(binary),
+            _ => None,
+        })
+        .expect("Expected PrebuiltBinaryMessage::Resolved");
+    assert_eq!(binary.provider, BinaryProvider::GithubReleases);
+
+    assert_prebuilt(&messages);
 
     assert!(
         !messages
@@ -1025,10 +1085,11 @@ fn prebuilt_binary_second_invocation_fully_cached() {
     );
 
     assert!(
-        messages
-            .iter()
-            .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::CacheHit { .. }))),
-        "Expected PrebuiltBinaryMessage::CacheHit: proves binary resolution was served from cache"
+        messages.iter().any(|m| matches!(
+            m,
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::PositiveCacheHit { .. })
+        )),
+        "Expected PrebuiltBinaryMessage::PositiveCacheHit: proves binary resolution was served from cache"
     );
 
     // --- Absence of network activity: what MUST NOT be present ---
@@ -1105,4 +1166,96 @@ fn default_resolves_via_quickinstall() {
             .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
         "Should not have BuildMessage::Started when using prebuilt binary"
     );
+}
+
+/// Live regression test for the transient-failure caching bug (filed alongside the #206 taplo fix):
+/// a GitHub rate-limit (throttle) during prebuilt-binary resolution must NOT be cached as a
+/// negative, so a later authenticated run still resolves the prebuilt binary instead of being stuck
+/// with a poisoned "no binary" answer.
+///
+/// This is the automated form of the manual check that initially discovered the bug. It is
+/// `#[ignore]` by default because it deliberately exhausts GitHub's unauthenticated per-IP rate
+/// limit and requires a real `GITHUB_TOKEN` in the environment. Run it explicitly (re-running
+/// needs the hourly limit to have reset):
+///
+/// ```sh
+/// GITHUB_TOKEN=$(gh auth token) \
+///   cargo test -p cgx --test integration -- --ignored transient_throttle_is_not_cached_as_negative
+/// ```
+#[test]
+#[ignore = "exhausts GitHub's unauthenticated rate limit and requires a real GITHUB_TOKEN; run manually"]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos", target_os = "windows"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+fn transient_throttle_is_not_cached_as_negative() {
+    let token = std::env::var("GITHUB_TOKEN")
+        .expect("this test requires a real GITHUB_TOKEN to prove the non-caching behavior");
+
+    // Provoke a throttle: run unauthenticated against a fresh cache until GitHub rate-limits us.
+    // taplo-cli@0.10.0 publishes a GitHub binary, so an un-throttled unauthenticated run *succeeds*
+    // (and we discard its cache); the first run that *fails* is the throttled one, whose cache we
+    // keep for the verification step. `--prebuilt-binary always` makes a throttle surface as a
+    // non-zero exit (PrebuiltBinaryResolutionFailed) rather than a slow fall-back to a source build.
+    const MAX_WARMUP_RUNS: usize = 80;
+    let mut throttled = None;
+    for _ in 0..MAX_WARMUP_RUNS {
+        let mut cgx = Cgx::with_test_fs();
+        let assert = cgx
+            .cmd
+            .env_remove("GITHUB_TOKEN")
+            .arg("--prebuilt-binary")
+            .arg("always")
+            .arg("--prebuilt-binary-sources")
+            .arg("github-releases")
+            .arg("--no-exec")
+            .arg("taplo-cli@=0.10.0")
+            .assert();
+        let output = assert.get_output();
+        if output.status.success() {
+            // Not throttled yet; discard this cache and keep warming up.
+            continue;
+        }
+
+        // Confirm we actually hit the inconclusive (throttle) path, not some other failure: the
+        // `always`-mode inconclusive error is PrebuiltBinaryResolutionFailed.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("resolution could not be completed"),
+            "expected an inconclusive resolution failure (throttle), got stderr: {stderr}"
+        );
+        throttled = Some(cgx);
+        break;
+    }
+
+    let throttled = throttled
+        .expect("GitHub never rate-limited us within the warmup budget; cannot exercise the throttle path");
+
+    // Verify the throttle was not cached as a negative: reuse the throttled run's cache, now WITH a
+    // token, and confirm the prebuilt binary resolves. Under the old bug the throttle would have
+    // cached a negative and this run would instead fail / fall back to a source build.
+    let mut cgx = throttled.reset();
+    let (assert, messages) = cgx
+        .cmd
+        .with_json_messages()
+        .env("GITHUB_TOKEN", &token)
+        .arg("--prebuilt-binary")
+        .arg("always")
+        .arg("--prebuilt-binary-sources")
+        .arg("github-releases")
+        .arg("--no-exec")
+        .arg("taplo-cli@=0.10.0")
+        .assert_with_messages();
+
+    assert.success().stdout(predicates::str::contains("taplo"));
+
+    let binary = messages
+        .iter()
+        .find_map(|m| match m {
+            Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { binary }) => Some(binary),
+            _ => None,
+        })
+        .expect("expected PrebuiltBinaryMessage::Resolved after the throttle was not cached");
+    assert_eq!(binary.provider, BinaryProvider::GithubReleases);
+    assert_prebuilt(&messages);
 }

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -599,8 +599,8 @@ fn github_provider_resolves_binary() {
 
 /// Regression test for #206: `taplo-cli` resolves its prebuilt binary from GitHub releases.
 ///
-/// This exercises all three of the asset-matching heuristics the fix added: the asset is named after
-/// the `taplo` binary (not the `taplo-cli` crate), uses a short `{os}-{arch}` platform token
+/// This exercises all three of the asset-matching heuristics the fix added: the asset is named
+/// after the `taplo` binary (not the `taplo-cli` crate), uses a short `{os}-{arch}` platform token
 /// (`taplo-linux-x86_64`, not the full triple), and on Linux/macOS is a bare `.gz` (a gzipped
 /// binary, not a tarball). `--no-exec` runs the full download+extract path — so the naked-`.gz`
 /// extraction is covered end to end — without executing the binary, sidestepping any glibc/musl

--- a/deny.toml
+++ b/deny.toml
@@ -75,10 +75,11 @@ skip = [
   # rustls-native-certs. Unavoidable until upstreams converge or we change
   # reqwest's TLS backend.
   { name = "openssl-probe", version = "0.1.6" },
-  # anstream/anstyle-query/anstyle-wincon, socket2, hyper-util, and tokio still
-  # pull windows-sys 0.60.x; ctrlc, gix-sec, and mio have moved to 0.61.x.
-  # Unavoidable until the laggards bump.
-  { name = "windows-sys", version = "0.60" },
+  # windows-sys 0.59 is pulled by etcetera 0.10 and home 0.5.11, while the rest
+  # of the tree is on 0.61. The releases that move both to windows-sys 0.61
+  # (etcetera 0.11, home 0.5.12) require rustc 1.87/1.88 respectively, above our
+  # 1.85.1 MSRV. Revisit when we raise the MSRV.
+  { name = "windows-sys", version = "0.59" },
 ]
 skip-tree = [
   # vergen-gix (build dep) uses older gix 0.71


### PR DESCRIPTION
This branch started out just fixing #206 by extending the heuristics used to discover prebuilt binary releases for a given crate, so that `cgx taplo-cli` would correctly use the pre-built binaries published by `taplo`.  This involves checking for the crate's binary name (in this case, `taplo-cli` is the crate name, but it compiles to a binary called `taplo`) as well as the crate name itself when looking at forge release artifacts, and also trying different arrangements of the architecture and OS.

This change then necessitated some additional refactoring, and I added some `compat` tests to the `cache` module to ensure that future changes that break compatibility with existing user caches are caught.

While I was at it I also fixed a bug in the way pre-built binary cache results are used.  Choosing different binary providers will now do the right thing, ignoring an existing cache entry if the enabled providers weren't enabled when the entry was computed or if the cached binary came from a provider that isn't currently enabled.

Closes #206 