### PR TITLE
Implement smart prebuilt binary fallback to alternative ABI-compatible targets

### DIFF
--- a/.github/workflows/full-platform-tests.yml
+++ b/.github/workflows/full-platform-tests.yml
@@ -141,6 +141,21 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: cargo test --workspace ${{ env.TARGET_FLAG }}
 
+      # The first "Run tests" pass runs on whatever Rosetta state the runner ships with (GitHub's
+      # Apple Silicon runners have no Rosetta by default), exercising the negative branch of the
+      # self-adapting Rosetta fallback test. Install Rosetta and re-run only the prebuilt-binary
+      # tests so the positive branch (resolving an x86_64-apple-darwin asset under Rosetta) is also
+      # exercised. Nightly-only, since it is on the Mac ARM64 job of this workflow.
+      - name: Install Rosetta 2 (Mac ARM64)
+        if: matrix.name == 'Mac ARM64'
+        run: softwareupdate --install-rosetta --agree-to-license
+
+      - name: Re-run prebuilt-binary tests under Rosetta (Mac ARM64)
+        if: matrix.name == 'Mac ARM64'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo test -p cgx --test integration prebuilt_binaries
+
   test-musl:
     name: Test (Linux musl ${{ matrix.name }})
     needs: should-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -6,6 +6,8 @@ use std::os::unix::fs::PermissionsExt;
 use providers::{BinstallProvider, GithubProvider, GitlabProvider, Provider, QuickinstallProvider};
 use serde::{Deserialize, Serialize};
 use snafu::{IntoError, ResultExt};
+use tempfile::TempDir;
+use tracing::warn;
 
 use crate::{
     Result,
@@ -34,6 +36,14 @@ pub struct ResolvedBinary {
 
     /// Path to the executable cgx should run
     pub path: std::path::PathBuf,
+
+    /// The target this binary was published for.
+    ///
+    /// In most cases this is just the host's target, but there are many edge cases where a
+    /// prebuilt binary will be published for a target that doesn't match the host's target but is
+    /// compatible with the host (the most common is a musl linux binary used on a glibc linux
+    /// host).
+    pub target: String,
 }
 
 pub trait BinaryResolver {
@@ -92,7 +102,7 @@ pub(crate) fn create_resolver(
     cache: Cache,
     reporter: MessageReporter,
     http_client: HttpClient,
-) -> impl BinaryResolver {
+) -> Result<impl BinaryResolver> {
     DefaultBinaryResolver::new(config, cache, reporter, http_client)
 }
 
@@ -145,56 +155,77 @@ struct DefaultBinaryResolver {
     cache: Cache,
     reporter: MessageReporter,
     mode: UsePrebuiltBinaries,
+    /// Staging area where the providers download and extract candidate binaries before
+    /// [`Self::relocate_to_bin_dir`] moves the winner to its durable home.
+    #[expect(
+        dead_code,
+        reason = "held for its Drop impl: the staging directory must stay alive for the providers that \
+                  write into it, and dropping it is what cleans the staging area up"
+    )]
+    staging: TempDir,
     providers: Vec<Box<dyn Provider + Send + Sync>>,
 }
 
 impl DefaultBinaryResolver {
-    fn new(config: Config, cache: Cache, reporter: MessageReporter, http_client: HttpClient) -> Self {
-        let providers = {
-            let cache_dir = &config.cache_dir;
-            let verify = config.prebuilt_binaries.verify_checksums;
+    fn new(config: Config, cache: Cache, reporter: MessageReporter, http_client: HttpClient) -> Result<Self> {
+        let staging = Self::create_staging_dir(&config)?;
+        let verify = config.prebuilt_binaries.verify_checksums;
 
-            config
-                .prebuilt_binaries
-                .binary_providers
-                .iter()
-                .map(|provider_type| -> Box<dyn Provider + Send + Sync> {
-                    match provider_type {
-                        BinaryProvider::Binstall => Box::new(BinstallProvider::new(
-                            reporter.clone(),
-                            cache_dir.clone(),
-                            verify,
-                            http_client.clone(),
-                        )),
-                        BinaryProvider::GithubReleases => Box::new(GithubProvider::new(
-                            reporter.clone(),
-                            cache_dir.clone(),
-                            verify,
-                            http_client.clone(),
-                        )),
-                        BinaryProvider::GitlabReleases => Box::new(GitlabProvider::new(
-                            reporter.clone(),
-                            cache_dir.clone(),
-                            verify,
-                            http_client.clone(),
-                        )),
-                        BinaryProvider::Quickinstall => Box::new(QuickinstallProvider::new(
-                            reporter.clone(),
-                            cache_dir.clone(),
-                            http_client.clone(),
-                        )),
-                    }
-                })
-                .collect()
-        };
+        let providers = config
+            .prebuilt_binaries
+            .binary_providers
+            .iter()
+            .map(|provider_type| -> Box<dyn Provider + Send + Sync> {
+                match provider_type {
+                    BinaryProvider::Binstall => Box::new(BinstallProvider::new(
+                        reporter.clone(),
+                        &staging,
+                        verify,
+                        http_client.clone(),
+                    )),
+                    BinaryProvider::GithubReleases => Box::new(GithubProvider::new(
+                        reporter.clone(),
+                        &staging,
+                        verify,
+                        http_client.clone(),
+                    )),
+                    BinaryProvider::GitlabReleases => Box::new(GitlabProvider::new(
+                        reporter.clone(),
+                        &staging,
+                        verify,
+                        http_client.clone(),
+                    )),
+                    BinaryProvider::Quickinstall => Box::new(QuickinstallProvider::new(
+                        reporter.clone(),
+                        &staging,
+                        http_client.clone(),
+                    )),
+                }
+            })
+            .collect();
 
-        Self::with_providers(config, cache, reporter, providers)
+        Ok(Self::with_providers(config, cache, reporter, staging, providers))
+    }
+
+    /// Create the resolver's staging directory on the same filesystem as `bin_dir`, so that
+    /// relocation into `bin_dir` never crosses filesystems.
+    fn create_staging_dir(config: &Config) -> Result<TempDir> {
+        std::fs::create_dir_all(&config.bin_dir).with_context(|_| error::IoSnafu {
+            path: config.bin_dir.clone(),
+        })?;
+        tempfile::Builder::new()
+            .prefix("cgx-bin-resolver-temp")
+            .tempdir_in(&config.bin_dir)
+            .with_context(|_| error::TempDirInCreationSnafu {
+                parent: config.bin_dir.clone(),
+            })
     }
 
     fn with_providers(
         config: Config,
         cache: Cache,
         reporter: MessageReporter,
+        staging: TempDir,
         providers: Vec<Box<dyn Provider + Send + Sync>>,
     ) -> Self {
         let mode = config.prebuilt_binaries.use_prebuilt_binaries;
@@ -203,6 +234,7 @@ impl DefaultBinaryResolver {
             cache,
             reporter,
             mode,
+            staging,
             providers,
         }
     }
@@ -324,7 +356,7 @@ impl DefaultBinaryResolver {
     /// Returns `None` (so resolution falls through to the providers) when there is no entry or it
     /// is stale for the current configuration.
     fn get_cached_resolution(&self, krate: &ResolvedCrate) -> Option<ConclusiveResolution> {
-        let entry = self.cache.get_cached_binary(krate).ok()??;
+        let entry = self.cache.get_cached_binary_resolution(krate).ok()??;
         let enabled = &self.config.prebuilt_binaries.binary_providers;
 
         // If a provider that is enabled now was not enabled when this cache entry was written, then we
@@ -349,6 +381,19 @@ impl DefaultBinaryResolver {
                         ProviderChangeReason::SourceProviderDisabled(binary.provider),
                     )
                 });
+                return None;
+            }
+
+            // A positive entry points at a binary under `bin_dir`; if that file has been deleted
+            // since the entry was written, serving the entry would hand out a dangling path.
+            if !binary.path.exists() {
+                self.reporter.report(|| {
+                    PrebuiltBinaryMessage::cache_invalidated_by_missing_binary(krate, &binary.path)
+                });
+                warn!(
+                    "Cached binary resolution for {}@{} points to missing file {:?}; ignoring cache entry",
+                    krate.name, krate.version, binary.path
+                );
                 return None;
             }
         }
@@ -414,25 +459,24 @@ impl DefaultBinaryResolver {
         Ok(Self::combine_resolutions(results))
     }
 
-    /// Relocate a resolved binary from the provider's internal path to the `bin_dir` structure.
+    /// Move a resolved binary from the transient staging area to its durable home under
+    /// `bin_dir`.
     ///
-    /// Pre-built binaries are copied into `bin_dir` so the path cgx returns is stable and separate
-    /// from provider-specific download/cache directories.
+    /// The provider leaves the binary in the resolver's staging directory, which gets cleaned up
+    /// when the resolver is dropped; this rename is what makes the binary outlive the resolution
+    /// at a stable path under `bin_dir`. The staging temp dir is created on `bin_dir`'s
+    /// filesystem, so the rename never crosses filesystems.
     fn relocate_to_bin_dir(
         &self,
         mut binary: ResolvedBinary,
         krate: &ResolvedCrate,
         target: &TargetTriple,
     ) -> Result<ResolvedBinary> {
-        let source_hash = krate.source.source_hash();
-
-        // Build target directory: bin_dir/<crate>-<version>/<source-hash>/prebuilt-<provider>-<platform>/
-        let target_dir = self
-            .config
-            .bin_dir
-            .join(format!("{}-{}", krate.name, krate.version))
-            .join(source_hash)
-            .join(format!("prebuilt-{:?}-{}", binary.provider, target.as_str()));
+        let target_dir = self.cache.crate_bin_root(krate).join(format!(
+            "prebuilt-{:?}-{}",
+            binary.provider,
+            target.as_str()
+        ));
 
         std::fs::create_dir_all(&target_dir).with_context(|_| error::IoSnafu {
             path: target_dir.clone(),
@@ -445,8 +489,7 @@ impl DefaultBinaryResolver {
 
         let target_path = target_dir.join(binary_name);
 
-        // Copy (don't move) so the provider's cache remains intact
-        std::fs::copy(&binary.path, &target_path).with_context(|_| error::CopyBinarySnafu {
+        std::fs::rename(&binary.path, &target_path).with_context(|_| error::RenameFileSnafu {
             src: binary.path.clone(),
             dst: target_path.clone(),
         })?;
@@ -537,7 +580,8 @@ impl BinaryResolver for DefaultBinaryResolver {
         let resolution = self.resolve_via_providers(krate, target)?;
 
         // For a found binary, relocate it into `bin_dir` (so the cached/returned path is stable and
-        // separate from provider caches) and report it. Report the terminal non-found states too.
+        // outlives the transient staging area) and report it. Report the terminal non-found states
+        // too.
         let resolution = match resolution {
             BinaryResolution::Found(binary) => {
                 let relocated = self.relocate_to_bin_dir(binary, resolved_krate, target)?;
@@ -569,7 +613,7 @@ impl BinaryResolver for DefaultBinaryResolver {
                 outcome,
                 enabled_providers: self.config.prebuilt_binaries.binary_providers.clone(),
             };
-            self.cache.put_cached_binary(resolved_krate, entry)?;
+            self.cache.put_cached_binary_resolution(resolved_krate, entry)?;
         }
 
         Self::apply_mode(resolution, self.mode, resolved_krate)
@@ -623,6 +667,7 @@ mod tests {
                     krate: test_downloaded_crate().resolved,
                     provider,
                     path,
+                    target: build_context::TARGET.to_string(),
                 }),
                 calls: Arc::new(AtomicUsize::new(0)),
             }
@@ -698,8 +743,9 @@ mod tests {
             outcome,
             calls: calls.clone(),
         })];
+        let staging = DefaultBinaryResolver::create_staging_dir(&config).unwrap();
         (
-            DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), providers),
+            DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), staging, providers),
             calls,
         )
     }
@@ -716,7 +762,8 @@ mod tests {
         let mut config = config;
         config.prebuilt_binaries.use_prebuilt_binaries = UsePrebuiltBinaries::Auto;
         config.prebuilt_binaries.binary_providers = enabled;
-        DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), providers)
+        let staging = DefaultBinaryResolver::create_staging_dir(&config).unwrap();
+        DefaultBinaryResolver::with_providers(config, cache, MessageReporter::null(), staging, providers)
     }
 
     fn test_downloaded_crate() -> DownloadedCrate {
@@ -735,6 +782,7 @@ mod tests {
             krate: test_downloaded_crate().resolved,
             provider: BinaryProvider::GithubReleases,
             path: PathBuf::from("/fake/bin/serde"),
+            target: build_context::TARGET.to_string(),
         }
     }
 
@@ -827,7 +875,7 @@ mod tests {
     #[test]
     fn test_disqualification_custom_target() {
         let options = BuildOptions {
-            target: Some(TargetTriple::from_static("x86_64-unknown-linux-musl").unwrap()),
+            target: Some(TargetTriple::from_static("x86_64-unknown-linux-musl")),
             ..Default::default()
         };
         assert_eq!(
@@ -1077,6 +1125,7 @@ mod tests {
             krate: test_downloaded_crate().resolved,
             provider: BinaryProvider::GithubReleases,
             path: src,
+            target: build_context::TARGET.to_string(),
         };
         let (resolver, calls) = resolver_with(
             cache,
@@ -1104,6 +1153,7 @@ mod tests {
             krate: test_downloaded_crate().resolved,
             provider: BinaryProvider::GithubReleases,
             path: src.clone(),
+            target: build_context::TARGET.to_string(),
         };
         let (resolver, _calls) = resolver_with(
             cache,
@@ -1145,7 +1195,7 @@ mod tests {
         assert_eq!(result, None);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_matches!(
-            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            cache.get_cached_binary_resolution(&test_downloaded_crate().resolved),
             Ok(None),
             "an inconclusive resolution must not be persisted"
         );
@@ -1194,7 +1244,7 @@ mod tests {
             .unwrap();
 
         assert_matches!(
-            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            cache.get_cached_binary_resolution(&test_downloaded_crate().resolved),
             Ok(Some(BinaryCacheEntry {
                 outcome: ConclusiveResolution::Nonexistent,
                 ..
@@ -1223,7 +1273,7 @@ mod tests {
         );
         assert_eq!(calls.load(Ordering::SeqCst), 1);
         assert_matches!(
-            cache.get_cached_binary(&test_downloaded_crate().resolved),
+            cache.get_cached_binary_resolution(&test_downloaded_crate().resolved),
             Ok(None)
         );
     }
@@ -1313,6 +1363,60 @@ mod tests {
             gh2_calls.load(Ordering::SeqCst),
             0,
             "cache hit must not re-consult providers"
+        );
+    }
+
+    /// A positive cache entry whose relocated binary has been deleted from `bin_dir` must not be
+    /// served as a dangling path: the entry is invalidated, the providers are consulted again, and
+    /// the returned path exists.
+    #[test]
+    fn positive_cache_hit_with_deleted_binary_reresolves() {
+        let (cache, config, temp) = test_env();
+        let src = temp.path().join("serde");
+        std::fs::write(&src, b"binary").unwrap();
+
+        let first = StubProvider::found(BinaryProvider::GithubReleases, src.clone());
+        let first_calls = first.calls.clone();
+        let r1 = resolver_with_enabled_providers(
+            cache.clone(),
+            config.clone(),
+            vec![BinaryProvider::GithubReleases],
+            vec![Box::new(first)],
+        );
+        let relocated = r1
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap()
+            .unwrap();
+        assert_eq!(first_calls.load(Ordering::SeqCst), 1);
+        assert!(relocated.path.exists());
+
+        std::fs::remove_file(&relocated.path).unwrap();
+        // A real provider stages a fresh copy on every consultation; recreate the file the stub
+        // hands out so the re-resolution has something to relocate.
+        std::fs::write(&src, b"binary").unwrap();
+
+        let second = StubProvider::found(BinaryProvider::GithubReleases, src);
+        let second_calls = second.calls.clone();
+        let r2 = resolver_with_enabled_providers(
+            cache,
+            config,
+            vec![BinaryProvider::GithubReleases],
+            vec![Box::new(second)],
+        );
+        let result = r2
+            .resolve(&test_downloaded_crate(), &BuildOptions::default())
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            second_calls.load(Ordering::SeqCst),
+            1,
+            "a positive entry pointing at a deleted binary must be re-resolved via providers"
+        );
+        assert!(
+            result.path.exists(),
+            "the re-resolved binary path must exist, got {}",
+            result.path.display()
         );
     }
 

--- a/cgx-core/src/bin_resolver/mod.rs
+++ b/cgx-core/src/bin_resolver/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     error::{self, Error},
     http::HttpClient,
     messages::{MessageReporter, PrebuiltBinaryMessage, ProviderChangeReason},
+    target::TargetTriple,
 };
 
 /// A resolved binary is a pre-built executable that cgx found and prepared, so the crate can run
@@ -366,7 +367,11 @@ impl DefaultBinaryResolver {
 
     /// Consult each configured provider in order, short-circuiting on the first `Found`, and fold
     /// the results with [`Self::combine_resolutions`].
-    fn resolve_via_providers(&self, krate: &DownloadedCrate, platform: &str) -> Result<BinaryResolution> {
+    fn resolve_via_providers(
+        &self,
+        krate: &DownloadedCrate,
+        target: &TargetTriple,
+    ) -> Result<BinaryResolution> {
         if self.providers.is_empty() {
             return error::NoProvidersConfiguredSnafu.fail();
         }
@@ -389,7 +394,7 @@ impl DefaultBinaryResolver {
             // If a provider fails for a given crate input, that is likely a bug in the provider
             // code somewhere, but such a bug should not cause the binary resolution process itself
             // to return an error, nor should it result in a permanent negative cache entry.
-            let resolution = match provider.try_resolve(krate, platform) {
+            let resolution = match provider.try_resolve(krate, target) {
                 Ok(resolution) => BinaryResolution::from(resolution),
                 Err(source) => {
                     self.reporter
@@ -417,7 +422,7 @@ impl DefaultBinaryResolver {
         &self,
         mut binary: ResolvedBinary,
         krate: &ResolvedCrate,
-        platform: &str,
+        target: &TargetTriple,
     ) -> Result<ResolvedBinary> {
         let source_hash = krate.source.source_hash();
 
@@ -427,7 +432,7 @@ impl DefaultBinaryResolver {
             .bin_dir
             .join(format!("{}-{}", krate.name, krate.version))
             .join(source_hash)
-            .join(format!("prebuilt-{:?}-{}", binary.provider, platform));
+            .join(format!("prebuilt-{:?}-{}", binary.provider, target.as_str()));
 
         std::fs::create_dir_all(&target_dir).with_context(|_| error::IoSnafu {
             path: target_dir.clone(),
@@ -527,15 +532,15 @@ impl BinaryResolver for DefaultBinaryResolver {
 
         // Always use the build target platform for pre-built binaries. If the user overrides this by
         // specifying a custom target, execution is not supposed to reach this point.
-        let platform: &'static str = build_context::TARGET;
+        let target = TargetTriple::host();
 
-        let resolution = self.resolve_via_providers(krate, platform)?;
+        let resolution = self.resolve_via_providers(krate, target)?;
 
         // For a found binary, relocate it into `bin_dir` (so the cached/returned path is stable and
         // separate from provider caches) and report it. Report the terminal non-found states too.
         let resolution = match resolution {
             BinaryResolution::Found(binary) => {
-                let relocated = self.relocate_to_bin_dir(binary, resolved_krate, platform)?;
+                let relocated = self.relocate_to_bin_dir(binary, resolved_krate, target)?;
                 self.reporter
                     .report(|| PrebuiltBinaryMessage::resolved(&relocated));
                 BinaryResolution::Found(relocated)
@@ -643,7 +648,11 @@ mod tests {
             BinaryProvider::GithubReleases
         }
 
-        fn try_resolve(&self, _krate: &DownloadedCrate, _platform: &str) -> Result<ConclusiveResolution> {
+        fn try_resolve(
+            &self,
+            _krate: &DownloadedCrate,
+            _target: &TargetTriple,
+        ) -> Result<ConclusiveResolution> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             match &self.outcome {
                 StubOutcome::Found(binary) => Ok(ConclusiveResolution::Found(binary.clone())),
@@ -818,7 +827,7 @@ mod tests {
     #[test]
     fn test_disqualification_custom_target() {
         let options = BuildOptions {
-            target: Some("x86_64-unknown-linux-musl".to_string()),
+            target: Some(TargetTriple::from_static("x86_64-unknown-linux-musl").unwrap()),
             ..Default::default()
         };
         assert_eq!(

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -4,13 +4,12 @@ use std::{
     borrow::Cow,
     collections::HashMap,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
 use leon::{Template, Values};
 use serde::Deserialize;
 use snafu::ResultExt;
-use target_lexicon::{OperatingSystem, Triple};
+use target_lexicon::OperatingSystem;
 
 use super::{ArchiveFormat, Provider};
 use crate::{
@@ -22,6 +21,7 @@ use crate::{
     error,
     http::HttpClient,
     messages::PrebuiltBinaryMessage,
+    target::TargetTriple,
 };
 
 /// Provider for binaries described by `[package.metadata.binstall]` in a crate manifest.
@@ -48,7 +48,10 @@ impl BinstallProvider {
     }
 
     /// Read and parse `[package.metadata.binstall]` from the crate's Cargo.toml.
-    fn read_binstall_metadata(krate: &DownloadedCrate, target: &str) -> Result<Option<BinstallMeta>> {
+    fn read_binstall_metadata(
+        krate: &DownloadedCrate,
+        target: &TargetTriple,
+    ) -> Result<Option<BinstallMeta>> {
         let doc = krate.parsed_cargo_toml()?;
         BinstallMetaRaw::try_from_cargo_toml(&doc).map(|raw| raw.map(|meta| meta.render_for_target(target)))
     }
@@ -79,11 +82,10 @@ impl Provider for BinstallProvider {
         BinaryProvider::Binstall
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
         let resolved = &krate.resolved;
-        let target_info = BinstallTargetInfo::from_str(platform)?;
 
-        let Some(meta) = Self::read_binstall_metadata(krate, platform)? else {
+        let Some(meta) = Self::read_binstall_metadata(krate, target)? else {
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::Binstall,
@@ -105,7 +107,6 @@ impl Provider for BinstallProvider {
 
         let pkg_fmt = meta.pkg_fmt.as_deref();
         let format = archive_format_from_pkg_fmt(pkg_fmt)?;
-        let binary_ext = target_info.binary_ext();
         let repo_url = Self::get_repo_url(krate)?;
         let version_string = resolved.version.to_string();
         let suffixes = binstall_archive_suffixes(pkg_fmt);
@@ -125,12 +126,10 @@ impl Provider for BinstallProvider {
             let ctx = BinstallTemplateContext {
                 name: &resolved.name,
                 version: &version_string,
-                target: platform,
+                target,
                 archive_suffix: Some(suffix),
-                binary_ext,
                 bin: &binary_name,
                 repo: repo_url.as_deref(),
-                target_info: &target_info,
                 kind: BinstallTemplateKind::PackageUrl,
             };
 
@@ -194,12 +193,10 @@ impl Provider for BinstallProvider {
             let ctx = BinstallTemplateContext {
                 name: &resolved.name,
                 version: &version_string,
-                target: platform,
+                target,
                 archive_suffix: Some(selected_suffix),
-                binary_ext,
                 bin: &binary_name,
                 repo: repo_url.as_deref(),
-                target_info: &target_info,
                 kind: BinstallTemplateKind::BinDir,
             };
             let rendered_path = ctx.render_template(bin_dir_template)?;
@@ -227,13 +224,13 @@ impl Provider for BinstallProvider {
             .join("binstall")
             .join(&resolved.name)
             .join(resolved.version.to_string())
-            .join(platform);
+            .join(target.as_str());
 
         std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
             path: final_dir.clone(),
         })?;
 
-        let final_path = final_dir.join(format!("{}{}", binary_name, std::env::consts::EXE_SUFFIX));
+        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
         std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
             path: final_path.clone(),
         })?;
@@ -308,14 +305,14 @@ impl BinstallMetaRaw {
     }
 
     /// Render the binstall metadata for a specific target, applying any overrides for that target.
-    fn render_for_target(&self, target: &str) -> BinstallMeta {
+    fn render_for_target(&self, target: &TargetTriple) -> BinstallMeta {
         let mut meta = BinstallMeta {
             pkg_url: self.pkg_url.clone(),
             pkg_fmt: self.pkg_fmt.clone(),
             bin_dir: self.bin_dir.clone(),
         };
 
-        if let Some(overrides) = self.overrides.get(target) {
+        if let Some(overrides) = self.overrides.get(target.as_str()) {
             if let Some(pkg_url) = &overrides.pkg_url {
                 meta.pkg_url = Some(pkg_url.clone());
             }
@@ -331,45 +328,19 @@ impl BinstallMetaRaw {
     }
 }
 
-/// Target-derived values exposed to binstall templates.
-///
-/// This keeps the provider-facing API as a plain target triple string while using
-/// [`target_lexicon::Triple`] internally to render cargo-binstall-compatible target placeholders.
-struct BinstallTargetInfo {
-    triple: Triple,
+/// Extension trait pattern to add some binstall-specific functionality to the [`TargetTriple`]
+/// type.
+trait BinstallTargetTripleExt {
+    fn binstall_os_name(&self) -> Cow<'static, str>;
 }
 
-impl BinstallTargetInfo {
-    /// The OS name in this target triple, normalized to the value cargo-binstall uses for
-    /// `{ os-name }` in templates.
-    fn normalized_os_name(&self) -> Cow<'static, str> {
-        match self.triple.operating_system {
+impl BinstallTargetTripleExt for TargetTriple {
+    fn binstall_os_name(&self) -> Cow<'static, str> {
+        // Binstall uses "macos" as the OS name for both Darwin and MacOSX targets
+        match self.operating_system() {
             OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => Cow::Borrowed("macos"),
             os => os.into_str(),
         }
-    }
-
-    /// The executable filename extension implied by this target.
-    fn binary_ext(&self) -> &'static str {
-        match self.triple.operating_system {
-            OperatingSystem::Windows => ".exe",
-            _ => "",
-        }
-    }
-}
-
-impl FromStr for BinstallTargetInfo {
-    type Err = error::Error;
-
-    fn from_str(target: &str) -> Result<Self> {
-        let triple = Triple::from_str(target).map_err(|source| {
-            error::InvalidTargetTripleSnafu {
-                target: target.to_string(),
-                message: source.to_string(),
-            }
-            .build()
-        })?;
-        Ok(Self { triple })
     }
 }
 
@@ -377,16 +348,16 @@ impl FromStr for BinstallTargetInfo {
 ///
 /// Cargo-binstall exposes these keys independently of the full `{ target }` triple so package
 /// authors can construct asset names like `wasmtime-{ target-arch }-{ target-family }`.
-impl Values for BinstallTargetInfo {
+impl Values for TargetTriple {
     /// Return the value for one target placeholder key, or `None` when this context does not own
     /// it.
     fn get_value(&self, key: &str) -> Option<Cow<'_, str>> {
         match key {
-            "target-family" => Some(self.triple.operating_system.into_str()),
-            "os-name" => Some(self.normalized_os_name()),
-            "target-arch" => Some(self.triple.architecture.into_str()),
-            "target-libc" => Some(self.triple.environment.into_str()),
-            "target-vendor" => Some(Cow::Borrowed(self.triple.vendor.as_str())),
+            "target-family" => Some(self.operating_system().into_str()),
+            "os-name" => Some(self.binstall_os_name()),
+            "target-arch" => Some(self.architecture().into_str()),
+            "target-libc" => Some(self.environment().into_str()),
+            "target-vendor" => Some(Cow::Borrowed(self.vendor().as_str())),
             _ => None,
         }
     }
@@ -412,12 +383,10 @@ enum BinstallTemplateKind {
 struct BinstallTemplateContext<'a> {
     name: &'a str,
     version: &'a str,
-    target: &'a str,
+    target: &'a TargetTriple,
     archive_suffix: Option<&'a str>,
-    binary_ext: &'a str,
     bin: &'a str,
     repo: Option<&'a str>,
-    target_info: &'a BinstallTargetInfo,
     kind: BinstallTemplateKind,
 }
 
@@ -448,7 +417,7 @@ impl BinstallTemplateContext<'_> {
 /// Supplies package, archive, binary, and delegated target values to [`leon`] during rendering.
 ///
 /// This is the main template namespace for Binstall metadata. Unknown keys are delegated to
-/// [`BinstallTargetInfo`] so target placeholders share the same rendering path as ordinary package
+/// [`TargetTriple`] so target placeholders share the same rendering path as ordinary package
 /// placeholders.
 impl Values for BinstallTemplateContext<'_> {
     /// Return the value for one Binstall template key in the namespace selected by `kind`.
@@ -457,9 +426,9 @@ impl Values for BinstallTemplateContext<'_> {
             "name" => Some(Cow::Borrowed(self.name)),
             "version" => Some(Cow::Borrowed(self.version)),
             "repo" => self.repo.map(Cow::Borrowed),
-            "target" => Some(Cow::Borrowed(self.target)),
+            "target" => Some(self.target.as_cow()),
             "bin" => Some(Cow::Borrowed(self.bin)),
-            "binary-ext" => Some(Cow::Borrowed(self.binary_ext)),
+            "binary-ext" => Some(Cow::Borrowed(self.target.binary_ext())),
             "archive-suffix" if matches!(self.kind, BinstallTemplateKind::PackageUrl) => {
                 self.archive_suffix.map(Cow::Borrowed)
             }
@@ -468,9 +437,9 @@ impl Values for BinstallTemplateContext<'_> {
             }
             "format" => match self.kind {
                 BinstallTemplateKind::PackageUrl => self.archive_format_from_suffix(),
-                BinstallTemplateKind::BinDir => Some(Cow::Borrowed(self.binary_ext)),
+                BinstallTemplateKind::BinDir => Some(Cow::Borrowed(self.target.binary_ext())),
             },
-            key => self.target_info.get_value(key),
+            key => self.target.get_value(key),
         }
     }
 }
@@ -542,6 +511,10 @@ mod tests {
         }
     }
 
+    fn target_triple(target: &str) -> TargetTriple {
+        TargetTriple::from_owned(target.to_string()).unwrap()
+    }
+
     fn test_provider(verify_checksums: bool) -> (BinstallProvider, tempfile::TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         let http_client = HttpClient::new(&fast_retry_config()).unwrap();
@@ -604,17 +577,14 @@ mod tests {
     }
 
     fn render_pkg_template(template: &str, target: &str, archive_suffix: &str) -> String {
-        let target_info = BinstallTargetInfo::from_str(target).unwrap();
-        let binary_ext = target_info.binary_ext();
+        let target = target_triple(target);
         let ctx = BinstallTemplateContext {
             name: "package-name",
             version: "1.0.0",
-            target,
+            target: &target,
             archive_suffix: Some(archive_suffix),
-            binary_ext,
             bin: "tool",
             repo: Some("https://github.com/example/package-name"),
-            target_info: &target_info,
             kind: BinstallTemplateKind::PackageUrl,
         };
 
@@ -622,17 +592,14 @@ mod tests {
     }
 
     fn render_bin_dir_template(template: &str, target: &str, archive_suffix: &str) -> String {
-        let target_info = BinstallTargetInfo::from_str(target).unwrap();
-        let binary_ext = target_info.binary_ext();
+        let target = target_triple(target);
         let ctx = BinstallTemplateContext {
             name: "package-name",
             version: "1.0.0",
-            target,
+            target: &target,
             archive_suffix: Some(archive_suffix),
-            binary_ext,
             bin: "tool",
             repo: Some("https://github.com/example/package-name"),
-            target_info: &target_info,
             kind: BinstallTemplateKind::BinDir,
         };
 
@@ -721,8 +688,8 @@ mod tests {
 
     #[test]
     fn binary_ext_is_derived_from_target() {
-        let windows = BinstallTargetInfo::from_str("x86_64-pc-windows-msvc").unwrap();
-        let macos = BinstallTargetInfo::from_str("aarch64-apple-darwin").unwrap();
+        let windows = target_triple("x86_64-pc-windows-msvc");
+        let macos = target_triple("aarch64-apple-darwin");
 
         assert_eq!(windows.binary_ext(), ".exe");
         assert_eq!(macos.binary_ext(), "");
@@ -742,17 +709,14 @@ mod tests {
 
     #[test]
     fn render_template_missing_repo_returns_error() {
-        let target_info = BinstallTargetInfo::from_str("x86_64-unknown-linux-gnu").unwrap();
-        let binary_ext = target_info.binary_ext();
+        let target = target_triple("x86_64-unknown-linux-gnu");
         let ctx = BinstallTemplateContext {
             name: "tool",
             version: "1.0.0",
-            target: "x86_64-unknown-linux-gnu",
+            target: &target,
             archive_suffix: Some(".tar.gz"),
-            binary_ext,
             bin: "tool",
             repo: None,
-            target_info: &target_info,
             kind: BinstallTemplateKind::PackageUrl,
         };
         let template = "{ repo }/download/{ name }";
@@ -893,7 +857,8 @@ mod tests {
 
         let doc: toml::Value = toml::from_str(toml_content).unwrap();
         let raw = BinstallMetaRaw::try_from_cargo_toml(&doc).unwrap().unwrap();
-        let meta = raw.render_for_target("x86_64-pc-windows-msvc");
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let meta = raw.render_for_target(&target);
 
         assert_eq!(meta.pkg_fmt.as_deref(), Some("zip"));
         assert_eq!(
@@ -915,7 +880,8 @@ mod tests {
 
         let doc: toml::Value = toml::from_str(toml_content).unwrap();
         let raw = BinstallMetaRaw::try_from_cargo_toml(&doc).unwrap().unwrap();
-        let meta = raw.render_for_target("aarch64-apple-darwin");
+        let target = target_triple("aarch64-apple-darwin");
+        let meta = raw.render_for_target(&target);
 
         assert_eq!(meta.pkg_fmt.as_deref(), Some("tgz"));
         assert_eq!(
@@ -938,7 +904,8 @@ mod tests {
 
         let doc: toml::Value = toml::from_str(toml_content).unwrap();
         let raw = BinstallMetaRaw::try_from_cargo_toml(&doc).unwrap().unwrap();
-        let meta = raw.render_for_target("aarch64-apple-darwin");
+        let target = target_triple("aarch64-apple-darwin");
+        let meta = raw.render_for_target(&target);
 
         assert_eq!(meta.pkg_fmt.as_deref(), Some("txz"));
         assert_eq!(meta.pkg_url.as_deref(), Some("https://example.com/default"));
@@ -967,7 +934,8 @@ mod tests {
 
         let doc: toml::Value = toml::from_str(toml_content).unwrap();
         let raw = BinstallMetaRaw::try_from_cargo_toml(&doc).unwrap().unwrap();
-        let meta = raw.render_for_target("x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let meta = raw.render_for_target(&target);
 
         assert!(meta.pkg_url.is_none());
     }
@@ -1127,12 +1095,13 @@ bin-dir = "{{ name }}-{{ target }}/{{ bin }}{{ binary-ext }}"
         let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
         let (provider, _provider_dir) = test_provider(false);
 
-        let result = provider.try_resolve(&krate, "x86_64-unknown-linux-gnu").unwrap();
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
 
         let ConclusiveResolution::Found(binary) = result else {
             panic!("expected binstall provider to resolve rendered bin-dir asset")
         };
-        let expected_binary_filename = format!("tool{}", std::env::consts::EXE_SUFFIX);
+        let expected_binary_filename = format!("tool{}", target.binary_ext());
         assert_eq!(
             binary.path.file_name().unwrap().to_string_lossy(),
             expected_binary_filename
@@ -1168,7 +1137,8 @@ bin-dir = "{{ bin }}{{ binary-ext }}"
         let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
         let (provider, _provider_dir) = test_provider(false);
 
-        let result = provider.try_resolve(&krate, "x86_64-pc-windows-msvc").unwrap();
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let result = provider.try_resolve(&krate, &target).unwrap();
 
         assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
         mock.assert_calls(1);
@@ -1200,7 +1170,8 @@ bin-dir = "release/{{format}}/{{target-arch}}/{{bin}}{{binary-ext}}"
         let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
         let (provider, _provider_dir) = test_provider(false);
 
-        let result = provider.try_resolve(&krate, "x86_64-pc-windows-msvc").unwrap();
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let result = provider.try_resolve(&krate, &target).unwrap();
 
         assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
         mock.assert_calls(1);
@@ -1232,7 +1203,8 @@ pkg-fmt = "tgz"
         let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
         let (provider, _provider_dir) = test_provider(false);
 
-        let result = provider.try_resolve(&krate, "x86_64-unknown-linux-gnu").unwrap();
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
 
         assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
         mock.assert_calls(1);
@@ -1265,7 +1237,8 @@ bin-dir = "missing/tool"
         let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
         let (provider, _provider_dir) = test_provider(false);
 
-        let result = provider.try_resolve(&krate, "x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target);
 
         assert_matches::assert_matches!(
             result,

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -47,15 +47,6 @@ impl BinstallProvider {
         }
     }
 
-    /// Read and parse `[package.metadata.binstall]` from the crate's Cargo.toml.
-    fn read_binstall_metadata(
-        krate: &DownloadedCrate,
-        target: &TargetTriple,
-    ) -> Result<Option<BinstallMeta>> {
-        let doc = krate.parsed_cargo_toml()?;
-        BinstallMetaRaw::try_from_cargo_toml(&doc).map(|raw| raw.map(|meta| meta.render_for_target(target)))
-    }
-
     /// Get the repository URL for a crate, for use in `{ repo }` template variable.
     ///
     /// If the crate came from a forge, the forge URL is used directly. This handles the fork
@@ -85,7 +76,8 @@ impl Provider for BinstallProvider {
     fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
         let resolved = &krate.resolved;
 
-        let Some(meta) = Self::read_binstall_metadata(krate, target)? else {
+        let doc = krate.parsed_cargo_toml()?;
+        let Some(raw_meta) = BinstallMetaRaw::try_from_cargo_toml(&doc)? else {
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::Binstall,
@@ -95,164 +87,172 @@ impl Provider for BinstallProvider {
             return Ok(ConclusiveResolution::Nonexistent);
         };
 
-        let Some(ref pkg_url_template) = meta.pkg_url else {
-            self.reporter.report(|| {
-                PrebuiltBinaryMessage::provider_has_no_binary(
-                    BinaryProvider::Binstall,
-                    "binstall metadata has no pkg-url",
-                )
-            });
-            return Ok(ConclusiveResolution::Nonexistent);
-        };
-
-        let pkg_fmt = meta.pkg_fmt.as_deref();
-        let format = archive_format_from_pkg_fmt(pkg_fmt)?;
         let repo_url = Self::get_repo_url(krate)?;
         let version_string = resolved.version.to_string();
-        let suffixes = binstall_archive_suffixes(pkg_fmt);
         let binary_name = krate.default_binary_name()?;
 
+        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
+
+        // Try the exact host target first, then each ABI-compatible fallback target. Overrides are
+        // applied per candidate, so a crate whose base `pkg-url` renders one ABI but has an override
+        // for a compatible sibling still resolves. The first target whose asset downloads wins.
         let mut last_url = String::new();
-        let mut selected_suffix = "";
+        let mut had_pkg_url = false;
 
-        let temp_dir = tempfile::tempdir().with_context(|_| error::TempDirCreationSnafu {
-            parent: self.cache_dir.clone(),
-        })?;
-
-        let archive_path = temp_dir.path().join(format.canonical_filename());
-        let mut downloaded = false;
-
-        for &suffix in suffixes {
-            let ctx = BinstallTemplateContext {
-                name: &resolved.name,
-                version: &version_string,
-                target,
-                archive_suffix: Some(suffix),
-                bin: &binary_name,
-                repo: repo_url.as_deref(),
-                kind: BinstallTemplateKind::PackageUrl,
+        for candidate_target in target.compatible_targets() {
+            let meta = raw_meta.render_for_target(&candidate_target);
+            let Some(ref pkg_url_template) = meta.pkg_url else {
+                continue;
             };
+            had_pkg_url = true;
 
-            let url = ctx.render_template(pkg_url_template)?;
+            let pkg_fmt = meta.pkg_fmt.as_deref();
+            let format = archive_format_from_pkg_fmt(pkg_fmt)?;
+            let suffixes = binstall_archive_suffixes(pkg_fmt);
+            let archive_path = temp_dir.path().join(format.canonical_filename());
 
-            self.reporter
-                .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Binstall));
+            let mut downloaded = false;
+            let mut selected_suffix = "";
+            for &suffix in suffixes {
+                let ctx = BinstallTemplateContext {
+                    name: &resolved.name,
+                    version: &version_string,
+                    target: &candidate_target,
+                    archive_suffix: Some(suffix),
+                    bin: &binary_name,
+                    repo: repo_url.as_deref(),
+                    kind: BinstallTemplateKind::PackageUrl,
+                };
 
-            match self.try_download_to_file(&url, &archive_path) {
-                Ok(true) => {
-                    downloaded = true;
-                    last_url = url;
-                    selected_suffix = suffix;
-                    break;
+                let url = ctx.render_template(pkg_url_template)?;
+
+                self.reporter
+                    .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Binstall));
+
+                match self.try_download_to_file(&url, &archive_path) {
+                    Ok(true) => {
+                        downloaded = true;
+                        last_url = url;
+                        selected_suffix = suffix;
+                        break;
+                    }
+                    Ok(false) => {
+                        last_url = url;
+                    }
+                    Err(e) => return Err(e),
                 }
-                Ok(false) => {
-                    last_url = url;
-                }
-                Err(e) => return Err(e),
             }
-        }
 
-        if !downloaded {
-            // If not binary found and no transient error then it just means this crate legit
-            // doesn't have a prebuilt binary for this platform in any of the places we know to
-            // look.
-            self.reporter.report(|| {
-                PrebuiltBinaryMessage::provider_has_no_binary(
-                    BinaryProvider::Binstall,
-                    format!("download failed: {}", last_url),
-                )
-            });
-            return Ok(ConclusiveResolution::Nonexistent);
-        }
-        let url = last_url;
+            if !downloaded {
+                // No asset for this compatible target; try the next one.
+                continue;
+            }
+            let url = last_url.clone();
 
-        if self.verify_checksums {
-            let asset_filename = super::checksum::asset_filename_from_url(&url);
-            let checksum_url = format!("{}.sha256", url);
-            let checksum_path = temp_dir.path().join("checksum.sha256");
-            let checksum_found =
-                self.try_download_to_file(&checksum_url, &checksum_path)
+            if self.verify_checksums {
+                let asset_filename = super::checksum::asset_filename_from_url(&url);
+                let checksum_url = format!("{}.sha256", url);
+                let checksum_path = temp_dir.path().join("checksum.sha256");
+                let checksum_found =
+                    self.try_download_to_file(&checksum_url, &checksum_path)
+                        .map_err(|source| {
+                            super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source)
+                        })?;
+                if checksum_found {
+                    super::checksum::verify_sha256_checksum(
+                        &archive_path,
+                        &checksum_path,
+                        asset_filename,
+                        &self.reporter,
+                    )
                     .map_err(|source| {
                         super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source)
                     })?;
-            if checksum_found {
-                super::checksum::verify_sha256_checksum(
-                    &archive_path,
-                    &checksum_path,
-                    asset_filename,
-                    &self.reporter,
-                )
-                .map_err(|source| {
-                    super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source)
-                })?;
+                }
             }
-        }
 
-        let extract_dir = temp_dir.path().join("extracted");
-        let binary_path = if let Some(bin_dir_template) = meta.bin_dir.as_deref() {
-            let ctx = BinstallTemplateContext {
-                name: &resolved.name,
-                version: &version_string,
-                target,
-                archive_suffix: Some(selected_suffix),
-                bin: &binary_name,
-                repo: repo_url.as_deref(),
-                kind: BinstallTemplateKind::BinDir,
-            };
-            let rendered_path = ctx.render_template(bin_dir_template)?;
-            super::extract_binary_at_archive_relative_path(
-                &archive_path,
-                format,
-                &binary_name,
-                Path::new(&rendered_path),
-                &extract_dir,
-            )
-        } else {
-            let expected_binary_names = super::expected_binary_names(&binary_name, None, &resolved.name);
-            super::extract_binary_by_candidate_names(
-                &archive_path,
-                format,
-                &expected_binary_names,
-                &extract_dir,
-            )
-        }
-        .map_err(|source| super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source))?;
+            let extract_dir = temp_dir.path().join("extracted");
+            let binary_path = if let Some(bin_dir_template) = meta.bin_dir.as_deref() {
+                let ctx = BinstallTemplateContext {
+                    name: &resolved.name,
+                    version: &version_string,
+                    target: &candidate_target,
+                    archive_suffix: Some(selected_suffix),
+                    bin: &binary_name,
+                    repo: repo_url.as_deref(),
+                    kind: BinstallTemplateKind::BinDir,
+                };
+                let rendered_path = ctx.render_template(bin_dir_template)?;
+                super::extract_binary_at_archive_relative_path(
+                    &archive_path,
+                    format,
+                    &binary_name,
+                    Path::new(&rendered_path),
+                    &extract_dir,
+                )
+            } else {
+                let expected_binary_names = super::expected_binary_names(&binary_name, None, &resolved.name);
+                super::extract_binary_by_candidate_names(
+                    &archive_path,
+                    format,
+                    &expected_binary_names,
+                    &extract_dir,
+                )
+            }
+            .map_err(|source| {
+                super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source)
+            })?;
 
-        let final_dir = self
-            .cache_dir
-            .join("binaries")
-            .join("binstall")
-            .join(&resolved.name)
-            .join(resolved.version.to_string())
-            .join(target.as_str());
+            // The cache directory is keyed on the host target, not the compatible target that
+            // actually matched, so a fallback binary caches under the same key as an exact match.
+            let final_dir = self
+                .cache_dir
+                .join("binaries")
+                .join("binstall")
+                .join(&resolved.name)
+                .join(resolved.version.to_string())
+                .join(target.as_str());
 
-        std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
-            path: final_dir.clone(),
-        })?;
+            std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
+                path: final_dir.clone(),
+            })?;
 
-        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
-        std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
-            path: final_path.clone(),
-        })?;
-
-        #[cfg(unix)]
-        {
-            let mut perms = std::fs::metadata(&final_path)
-                .with_context(|_| error::IoSnafu {
-                    path: final_path.clone(),
-                })?
-                .permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
+            let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
+            std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
                 path: final_path.clone(),
             })?;
+
+            #[cfg(unix)]
+            {
+                let mut perms = std::fs::metadata(&final_path)
+                    .with_context(|_| error::IoSnafu {
+                        path: final_path.clone(),
+                    })?
+                    .permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
+                    path: final_path.clone(),
+                })?;
+            }
+
+            return Ok(ConclusiveResolution::Found(ResolvedBinary {
+                krate: resolved.clone(),
+                provider: BinaryProvider::Binstall,
+                path: final_path,
+            }));
         }
 
-        Ok(ConclusiveResolution::Found(ResolvedBinary {
-            krate: resolved.clone(),
-            provider: BinaryProvider::Binstall,
-            path: final_path,
-        }))
+        // No compatible target yielded a downloadable asset. If no candidate even had a `pkg-url`,
+        // the metadata simply does not describe a package URL; otherwise every rendered URL failed
+        // to download, meaning the crate has no prebuilt binary for this host or its fallbacks.
+        let reason = if had_pkg_url {
+            format!("download failed: {}", last_url)
+        } else {
+            "binstall metadata has no pkg-url".to_string()
+        };
+        self.reporter
+            .report(|| PrebuiltBinaryMessage::provider_has_no_binary(BinaryProvider::Binstall, reason));
+        Ok(ConclusiveResolution::Nonexistent)
     }
 }
 
@@ -1208,6 +1208,91 @@ pkg-fmt = "tgz"
 
         assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
         mock.assert_calls(1);
+    }
+
+    /// On a `x86_64-unknown-linux-gnu` host, a crate whose `pkg-url` renders the (absent) gnu asset
+    /// must fall back to the ABI-compatible `x86_64-unknown-linux-musl` asset. The gnu URLs are
+    /// explicitly mocked to 404 so the fallback path is exercised deterministically.
+    #[test]
+    fn resolves_via_musl_fallback_on_gnu_host() {
+        let server = MockServer::start();
+        let asset = tar_gz_with_binary("tool");
+        let gnu_tgz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-gnu.tgz");
+            then.status(404);
+        });
+        let gnu_tar_gz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-gnu.tar.gz");
+            then.status(404);
+        });
+        let musl = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-musl.tgz");
+            then.status(200).body(asset);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}-{{ target }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        // The gnu asset was probed (both suffixes) and missing, then the musl fallback resolved.
+        gnu_tgz.assert_calls(1);
+        gnu_tar_gz.assert_calls(1);
+        musl.assert_calls(1);
+    }
+
+    /// A `x86_64-unknown-linux-gnu` host resolves a crate that only declares a musl asset through a
+    /// per-target override keyed on `x86_64-unknown-linux-musl`.
+    #[test]
+    fn resolves_via_musl_override_on_gnu_host() {
+        let server = MockServer::start();
+        let asset = tar_gz_with_binary("tool");
+        let musl = server.mock(|when, then| {
+            when.method(GET).path("/musl/package-name.tgz");
+            then.status(200).body(asset);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{base}"
+
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{base}/musl/{{ name }}{{ archive-suffix }}"
+"#,
+            base = server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        musl.assert_calls(1);
     }
 
     #[test]

--- a/cgx-core/src/bin_resolver/providers/binstall.rs
+++ b/cgx-core/src/bin_resolver/providers/binstall.rs
@@ -1,8 +1,6 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -10,6 +8,7 @@ use leon::{Template, Values};
 use serde::Deserialize;
 use snafu::ResultExt;
 use target_lexicon::OperatingSystem;
+use tempfile::TempDir;
 
 use super::{ArchiveFormat, Provider};
 use crate::{
@@ -27,7 +26,7 @@ use crate::{
 /// Provider for binaries described by `[package.metadata.binstall]` in a crate manifest.
 pub(in crate::bin_resolver) struct BinstallProvider {
     reporter: crate::messages::MessageReporter,
-    cache_dir: PathBuf,
+    staging_dir: PathBuf,
     verify_checksums: bool,
     http_client: HttpClient,
 }
@@ -35,13 +34,15 @@ pub(in crate::bin_resolver) struct BinstallProvider {
 impl BinstallProvider {
     pub(in crate::bin_resolver) fn new(
         reporter: crate::messages::MessageReporter,
-        cache_dir: PathBuf,
+        staging_dir: &TempDir,
         verify_checksums: bool,
         http_client: HttpClient,
     ) -> Self {
         Self {
             reporter,
-            cache_dir,
+            staging_dir: staging_dir
+                .path()
+                .join(<&'static str>::from(BinaryProvider::Binstall)),
             verify_checksums,
             http_client,
         }
@@ -91,27 +92,47 @@ impl Provider for BinstallProvider {
         let version_string = resolved.version.to_string();
         let binary_name = krate.default_binary_name()?;
 
-        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
+        let work_dir = super::recreate_staging_work_dir(&self.staging_dir, resolved)?;
 
         // Try the exact host target first, then each ABI-compatible fallback target. Overrides are
         // applied per candidate, so a crate whose base `pkg-url` renders one ABI but has an override
         // for a compatible sibling still resolves. The first target whose asset downloads wins.
-        let mut last_url = String::new();
+        //
+        // Broken metadata (an unknown `pkg-fmt`, a template that cannot render for this target) only
+        // disqualifies the candidate it belongs to, not the whole provider — this is what lets a
+        // universal pseudo-target skip a `{ target-arch }` template, and keeps a typo'd override
+        // for a sibling target from making every resolution of the crate inconclusive. The host's
+        // own metadata error is preserved and returned if nothing else resolves, so a crate whose
+        // only metadata is broken still yields an uncacheable inconclusive result, exactly as if
+        // the fallback loop did not exist.
+        let mut first_url: Option<String> = None;
+        let mut attempted_urls = HashSet::new();
         let mut had_pkg_url = false;
+        let mut host_metadata_error: Option<error::Error> = None;
 
-        for candidate_target in target.compatible_targets() {
+        'candidates: for candidate_target in target.compatible_targets() {
             let meta = raw_meta.render_for_target(&candidate_target);
             let Some(ref pkg_url_template) = meta.pkg_url else {
                 continue;
             };
             had_pkg_url = true;
+            let is_host = candidate_target == *target;
 
             let pkg_fmt = meta.pkg_fmt.as_deref();
-            let format = archive_format_from_pkg_fmt(pkg_fmt)?;
+            let format = match archive_format_from_pkg_fmt(pkg_fmt) {
+                Ok(format) => format,
+                Err(error) => {
+                    tracing::warn!("Skipping binstall candidate target {candidate_target}: {error}");
+                    if is_host {
+                        host_metadata_error.get_or_insert(error);
+                    }
+                    continue;
+                }
+            };
             let suffixes = binstall_archive_suffixes(pkg_fmt);
-            let archive_path = temp_dir.path().join(format.canonical_filename());
+            let archive_path = work_dir.join(format.canonical_filename());
 
-            let mut downloaded = false;
+            let mut downloaded_url: Option<String> = None;
             let mut selected_suffix = "";
             for &suffix in suffixes {
                 let ctx = BinstallTemplateContext {
@@ -124,35 +145,48 @@ impl Provider for BinstallProvider {
                     kind: BinstallTemplateKind::PackageUrl,
                 };
 
-                let url = ctx.render_template(pkg_url_template)?;
+                let url = match ctx.render_template(pkg_url_template) {
+                    Ok(url) => url,
+                    Err(error) => {
+                        tracing::warn!("Skipping binstall candidate target {candidate_target}: {error}");
+                        if is_host {
+                            host_metadata_error.get_or_insert(error);
+                        }
+                        continue 'candidates;
+                    }
+                };
+
+                // A template with no target-derived placeholder renders identical URLs for
+                // every compatible target; re-probing one would only repeat the same answer (and
+                // multiply the exposure to transient network errors).
+                if !attempted_urls.insert(url.clone()) {
+                    continue;
+                }
+                first_url.get_or_insert_with(|| url.clone());
 
                 self.reporter
                     .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Binstall));
 
                 match self.try_download_to_file(&url, &archive_path) {
                     Ok(true) => {
-                        downloaded = true;
-                        last_url = url;
+                        downloaded_url = Some(url);
                         selected_suffix = suffix;
                         break;
                     }
-                    Ok(false) => {
-                        last_url = url;
-                    }
+                    Ok(false) => {}
                     Err(e) => return Err(e),
                 }
             }
 
-            if !downloaded {
+            let Some(url) = downloaded_url else {
                 // No asset for this compatible target; try the next one.
                 continue;
-            }
-            let url = last_url.clone();
+            };
 
             if self.verify_checksums {
                 let asset_filename = super::checksum::asset_filename_from_url(&url);
                 let checksum_url = format!("{}.sha256", url);
-                let checksum_path = temp_dir.path().join("checksum.sha256");
+                let checksum_path = work_dir.join("checksum.sha256");
                 let checksum_found =
                     self.try_download_to_file(&checksum_url, &checksum_path)
                         .map_err(|source| {
@@ -171,7 +205,7 @@ impl Provider for BinstallProvider {
                 }
             }
 
-            let extract_dir = temp_dir.path().join("extracted");
+            let extract_dir = work_dir.join("extracted");
             let binary_path = if let Some(bin_dir_template) = meta.bin_dir.as_deref() {
                 let ctx = BinstallTemplateContext {
                     name: &resolved.name,
@@ -203,52 +237,30 @@ impl Provider for BinstallProvider {
                 super::provider_asset_preparation_failed(BinaryProvider::Binstall, &url, source)
             })?;
 
-            // The cache directory is keyed on the host target, not the compatible target that
-            // actually matched, so a fallback binary caches under the same key as an exact match.
-            let final_dir = self
-                .cache_dir
-                .join("binaries")
-                .join("binstall")
-                .join(&resolved.name)
-                .join(resolved.version.to_string())
-                .join(target.as_str());
-
-            std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
-                path: final_dir.clone(),
-            })?;
-
-            let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
-            std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
-                path: final_path.clone(),
-            })?;
-
-            #[cfg(unix)]
-            {
-                let mut perms = std::fs::metadata(&final_path)
-                    .with_context(|_| error::IoSnafu {
-                        path: final_path.clone(),
-                    })?
-                    .permissions();
-                perms.set_mode(0o755);
-                std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
-                    path: final_path.clone(),
-                })?;
-            }
-
+            let staged_path = super::stage_extracted_binary(&work_dir, &binary_name, target, &binary_path)?;
             return Ok(ConclusiveResolution::Found(ResolvedBinary {
                 krate: resolved.clone(),
                 provider: BinaryProvider::Binstall,
-                path: final_path,
+                path: staged_path,
+                target: candidate_target.to_string(),
             }));
         }
 
+        // Nothing resolved and the exact host target's own metadata was broken: propagate that
+        // error so the outcome is inconclusive (and stays uncached).
+        if let Some(error) = host_metadata_error {
+            return Err(error);
+        }
+
         // No compatible target yielded a downloadable asset. If no candidate even had a `pkg-url`,
-        // the metadata simply does not describe a package URL; otherwise every rendered URL failed
-        // to download, meaning the crate has no prebuilt binary for this host or its fallbacks.
-        let reason = if had_pkg_url {
-            format!("download failed: {}", last_url)
-        } else {
-            "binstall metadata has no pkg-url".to_string()
+        // the metadata simply does not describe a package URL; otherwise every attempted URL failed
+        // to download, meaning the crate has no prebuilt binary for this host or its fallbacks. The
+        // diagnostic names the FIRST attempted URL, the most-preferred candidate, which is the
+        // one the user would expect to exist.
+        let reason = match (had_pkg_url, first_url) {
+            (true, Some(url)) => format!("download failed: {}", url),
+            (true, None) => "no pkg-url could be rendered for any compatible target".to_string(),
+            (false, _) => "binstall metadata has no pkg-url".to_string(),
         };
         self.reporter
             .report(|| PrebuiltBinaryMessage::provider_has_no_binary(BinaryProvider::Binstall, reason));
@@ -331,16 +343,17 @@ impl BinstallMetaRaw {
 /// Extension trait pattern to add some binstall-specific functionality to the [`TargetTriple`]
 /// type.
 trait BinstallTargetTripleExt {
-    fn binstall_os_name(&self) -> Cow<'static, str>;
+    fn binstall_os_name(&self) -> Option<Cow<'static, str>>;
 }
 
 impl BinstallTargetTripleExt for TargetTriple {
-    fn binstall_os_name(&self) -> Cow<'static, str> {
+    /// The binstall `{ os-name }` value, or `None` for an opaque target whose OS is unknown.
+    fn binstall_os_name(&self) -> Option<Cow<'static, str>> {
         // Binstall uses "macos" as the OS name for both Darwin and MacOSX targets
-        match self.operating_system() {
+        self.operating_system().map(|os| match os {
             OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => Cow::Borrowed("macos"),
             os => os.into_str(),
-        }
+        })
     }
 }
 
@@ -349,15 +362,17 @@ impl BinstallTargetTripleExt for TargetTriple {
 /// Cargo-binstall exposes these keys independently of the full `{ target }` triple so package
 /// authors can construct asset names like `wasmtime-{ target-arch }-{ target-family }`.
 impl Values for TargetTriple {
-    /// Return the value for one target placeholder key, or `None` when this context does not own
-    /// it.
+    /// Return the value for one target placeholder key, or `None` when this context does not
+    /// contain it, including every target-derived key of an opaque target, whose components are
+    /// unknown. A `None` makes [`leon`] fail the render, which the caller treats as "this template
+    /// cannot apply to this candidate target".
     fn get_value(&self, key: &str) -> Option<Cow<'_, str>> {
         match key {
-            "target-family" => Some(self.operating_system().into_str()),
-            "os-name" => Some(self.binstall_os_name()),
-            "target-arch" => Some(self.architecture().into_str()),
-            "target-libc" => Some(self.environment().into_str()),
-            "target-vendor" => Some(Cow::Borrowed(self.vendor().as_str())),
+            "target-family" => self.operating_system().map(|os| os.into_str()),
+            "os-name" => self.binstall_os_name(),
+            "target-arch" => self.architecture().map(|architecture| architecture.into_str()),
+            "target-libc" => self.environment().map(|environment| environment.into_str()),
+            "target-vendor" => self.vendor().map(|vendor| Cow::Borrowed(vendor.as_str())),
             _ => None,
         }
     }
@@ -489,7 +504,7 @@ fn binstall_archive_suffixes(pkg_fmt: Option<&str>) -> &'static [&'static str] {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, io::Write, time::Duration};
+    use std::{fs, io::Write, sync::mpsc, time::Duration};
 
     use flate2::{Compression, write::GzEncoder};
     use httpmock::prelude::*;
@@ -498,8 +513,12 @@ mod tests {
 
     use super::*;
     use crate::{
-        config::HttpConfig, crate_resolver::ResolvedSource, cratespec::Forge, error::Error,
-        messages::MessageReporter,
+        config::HttpConfig,
+        crate_resolver::ResolvedSource,
+        cratespec::Forge,
+        error::Error,
+        messages::{Message, MessageReporter},
+        testdata::target_triple,
     };
 
     fn fast_retry_config() -> HttpConfig {
@@ -511,25 +530,23 @@ mod tests {
         }
     }
 
-    fn target_triple(target: &str) -> TargetTriple {
-        TargetTriple::from_owned(target.to_string()).unwrap()
+    fn test_provider(verify_checksums: bool) -> (BinstallProvider, TempDir) {
+        test_provider_with_reporter(verify_checksums, MessageReporter::null())
     }
 
-    fn test_provider(verify_checksums: bool) -> (BinstallProvider, tempfile::TempDir) {
+    fn test_provider_with_reporter(
+        verify_checksums: bool,
+        reporter: MessageReporter,
+    ) -> (BinstallProvider, TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         let http_client = HttpClient::new(&fast_retry_config()).unwrap();
         (
-            BinstallProvider::new(
-                MessageReporter::null(),
-                temp_dir.path().to_path_buf(),
-                verify_checksums,
-                http_client,
-            ),
+            BinstallProvider::new(reporter, &temp_dir, verify_checksums, http_client),
             temp_dir,
         )
     }
 
-    fn downloaded_crate_with_toml(cargo_toml: &str) -> (DownloadedCrate, tempfile::TempDir) {
+    fn downloaded_crate_with_toml(cargo_toml: &str) -> (DownloadedCrate, TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         fs::write(temp_dir.path().join("Cargo.toml"), cargo_toml).unwrap();
         (
@@ -576,7 +593,7 @@ mod tests {
         archive_data
     }
 
-    fn render_pkg_template(template: &str, target: &str, archive_suffix: &str) -> String {
+    fn render_pkg_template(template: &str, target: &'static str, archive_suffix: &str) -> String {
         let target = target_triple(target);
         let ctx = BinstallTemplateContext {
             name: "package-name",
@@ -591,7 +608,7 @@ mod tests {
         ctx.render_template(template).unwrap()
     }
 
-    fn render_bin_dir_template(template: &str, target: &str, archive_suffix: &str) -> String {
+    fn render_bin_dir_template(template: &str, target: &'static str, archive_suffix: &str) -> String {
         let target = target_triple(target);
         let ctx = BinstallTemplateContext {
             name: "package-name",
@@ -1252,7 +1269,15 @@ pkg-fmt = "tgz"
         let target = target_triple("x86_64-unknown-linux-gnu");
         let result = provider.try_resolve(&krate, &target).unwrap();
 
-        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        let ConclusiveResolution::Found(binary) = result else {
+            panic!("expected the musl fallback to resolve a binary")
+        };
+        // The resolved binary must record the compatible target that actually matched (the musl
+        // sibling).
+        assert_eq!(
+            serde_json::to_value(&binary).unwrap()["target"],
+            serde_json::json!("x86_64-unknown-linux-musl")
+        );
         // The gnu asset was probed (both suffixes) and missing, then the musl fallback resolved.
         gnu_tgz.assert_calls(1);
         gnu_tar_gz.assert_calls(1);
@@ -1293,6 +1318,325 @@ pkg-url = "{base}/musl/{{ name }}{{ archive-suffix }}"
 
         assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
         musl.assert_calls(1);
+    }
+
+    /// On a macOS host, a crate whose `{ target }`-templated asset exists only as a
+    /// `universal-apple-darwin` fat binary resolves through the universal pseudo-target, which
+    /// renders into the template even though it is not a parseable triple.
+    #[test]
+    fn resolves_via_universal_fallback_on_mac_host() {
+        let server = MockServer::start();
+        let asset = tar_gz_with_binary("tool");
+        let host_tgz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-apple-darwin.tgz");
+            then.status(404);
+        });
+        let host_tar_gz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-apple-darwin.tar.gz");
+            then.status(404);
+        });
+        let universal = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-universal-apple-darwin.tgz");
+            then.status(200).body(asset);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}-{{ target }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-apple-darwin");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        host_tgz.assert_calls(1);
+        host_tar_gz.assert_calls(1);
+        universal.assert_calls(1);
+    }
+
+    /// A binstall override keyed on `universal-apple-darwin` — a real cargo-binstall convention —
+    /// is honored even though universal is not a parseable target triple.
+    #[test]
+    fn resolves_via_universal_override_on_mac_host() {
+        let server = MockServer::start();
+        let asset = tar_gz_with_binary("tool");
+        let universal = server.mock(|when, then| {
+            when.method(GET).path("/universal/package-name.tgz");
+            then.status(200).body(asset);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{base}"
+
+[package.metadata.binstall]
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.universal-apple-darwin]
+pkg-url = "{base}/universal/{{ name }}{{ archive-suffix }}"
+"#,
+            base = server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-apple-darwin");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        universal.assert_calls(1);
+    }
+
+    /// A `{ target-arch }` template cannot render for the opaque universal pseudo-targets (their
+    /// architecture is unknown); those candidates are skipped rather than aborting the provider,
+    /// so the outcome is still a cacheable `Nonexistent`.
+    #[test]
+    fn target_arch_template_skips_universal_candidates() {
+        let server = MockServer::start();
+        let host_tgz = server.mock(|when, then| {
+            when.method(GET).path("/package-name-x86_64.tgz");
+            then.status(404);
+        });
+        let host_tar_gz = server.mock(|when, then| {
+            when.method(GET).path("/package-name-x86_64.tar.gz");
+            then.status(404);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ target-arch }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-apple-darwin");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Nonexistent);
+        host_tgz.assert_calls(1);
+        host_tar_gz.assert_calls(1);
+    }
+
+    /// A broken binstall override for an ABI-compatible sibling target must not abort the whole
+    /// provider. With valid host metadata but no downloadable asset anywhere, the provider must
+    /// conclude `Nonexistent` (a cacheable negative) instead of returning an error that forces a
+    /// re-probe of every provider on every subsequent run.
+    #[test]
+    fn broken_fallback_override_does_not_abort_provider() {
+        let server = MockServer::start();
+        let gnu_tgz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-gnu.tgz");
+            then.status(404);
+        });
+        let gnu_tar_gz = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-gnu.tar.gz");
+            then.status(404);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}-{{ target }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-fmt = "bogus"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Nonexistent);
+        gnu_tgz.assert_calls(1);
+        gnu_tar_gz.assert_calls(1);
+    }
+
+    /// Broken base metadata for the exact host target must not prevent a working per-target
+    /// override for an ABI-compatible sibling from resolving.
+    #[test]
+    fn broken_host_metadata_rescued_by_working_fallback_override() {
+        let server = MockServer::start();
+        let asset = tar_gz_with_binary("tool");
+        let musl = server.mock(|when, then| {
+            when.method(GET)
+                .path("/package-name-1.0.0-x86_64-unknown-linux-musl.tgz");
+            then.status(200).body(asset);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}-{{ target }}{{ archive-suffix }}"
+pkg-fmt = "bogus"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Found(_));
+        musl.assert_calls(1);
+    }
+
+    /// When the exact host target's own metadata is broken and no fallback rescues it, the error
+    /// must still propagate so the failure is treated as inconclusive and never cached as a
+    /// conclusive negative.
+    #[test]
+    fn broken_host_metadata_with_no_fallback_still_errors() {
+        let cargo_toml = r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "https://example.com/repo"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/{ name }-{ version }-{ target }{ archive-suffix }"
+pkg-fmt = "bogus"
+"#;
+        let (krate, _crate_dir) = downloaded_crate_with_toml(cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let result = provider.try_resolve(&krate, &target);
+
+        assert_matches::assert_matches!(result, Err(Error::UnsupportedArchiveFormat { .. }));
+    }
+
+    /// When no compatible target yields a download, the diagnostic must name the URL of the FIRST
+    /// candidate actually attempted (the host target's), not whichever fallback happened to be
+    /// tried last.
+    #[test]
+    fn failure_reason_reports_first_attempted_url() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(GET);
+            then.status(404);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}-{{ target }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (sender, receiver) = mpsc::sync_channel(64);
+        let (provider, _provider_dir) = test_provider_with_reporter(false, MessageReporter::channel(sender));
+
+        // The msvc host has two ABI-compatible fallbacks (gnu, gnullvm) tried after it.
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+        assert_matches::assert_matches!(result, ConclusiveResolution::Nonexistent);
+
+        let reason = receiver
+            .try_iter()
+            .find_map(|message| match message {
+                Message::PrebuiltBinary(PrebuiltBinaryMessage::ProviderHasNoBinary { reason, .. }) => {
+                    Some(reason)
+                }
+                _ => None,
+            })
+            .expect("expected a ProviderHasNoBinary message");
+        assert!(
+            reason.contains("x86_64-pc-windows-msvc"),
+            "failure reason must name the host-target URL, got: {reason}"
+        );
+    }
+
+    /// A `pkg-url` template with no target-derived placeholders renders the same URL for every
+    /// compatible target; that URL must be probed only once, not once per compatible target.
+    #[test]
+    fn identical_urls_are_probed_only_once() {
+        let server = MockServer::start();
+        let tgz = server.mock(|when, then| {
+            when.method(GET).path("/package-name-1.0.0.tgz");
+            then.status(404);
+        });
+        let tar_gz = server.mock(|when, then| {
+            when.method(GET).path("/package-name-1.0.0.tar.gz");
+            then.status(404);
+        });
+        let cargo_toml = format!(
+            r#"
+[package]
+name = "package-name"
+version = "1.0.0"
+default-run = "tool"
+repository = "{}"
+
+[package.metadata.binstall]
+pkg-url = "{{ repo }}/{{ name }}-{{ version }}{{ archive-suffix }}"
+pkg-fmt = "tgz"
+"#,
+            server.base_url()
+        );
+        let (krate, _crate_dir) = downloaded_crate_with_toml(&cargo_toml);
+        let (provider, _provider_dir) = test_provider(false);
+
+        // The msvc host has two ABI-compatible fallbacks (gnu, gnullvm), so a naive loop over
+        // compatible targets probes each identical URL three times.
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let result = provider.try_resolve(&krate, &target).unwrap();
+
+        assert_matches::assert_matches!(result, ConclusiveResolution::Nonexistent);
+        tgz.assert_calls(1);
+        tar_gz.assert_calls(1);
     }
 
     #[test]

--- a/cgx-core/src/bin_resolver/providers/github.rs
+++ b/cgx-core/src/bin_resolver/providers/github.rs
@@ -1,10 +1,9 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use reqwest::StatusCode;
 use serde::Deserialize;
 use snafu::ResultExt;
+use tempfile::TempDir;
 
 use super::Provider;
 use crate::{
@@ -25,7 +24,7 @@ use crate::{
 
 pub(in crate::bin_resolver) struct GithubProvider {
     reporter: crate::messages::MessageReporter,
-    cache_dir: PathBuf,
+    staging_dir: PathBuf,
     verify_checksums: bool,
     http_client: HttpClient,
 }
@@ -44,13 +43,15 @@ struct ReleaseAsset {
 impl GithubProvider {
     pub(in crate::bin_resolver) fn new(
         reporter: crate::messages::MessageReporter,
-        cache_dir: PathBuf,
+        staging_dir: &TempDir,
         verify_checksums: bool,
         http_client: HttpClient,
     ) -> Self {
         Self {
             reporter,
-            cache_dir,
+            staging_dir: staging_dir
+                .path()
+                .join(<&'static str>::from(BinaryProvider::GithubReleases)),
             verify_checksums,
             http_client,
         }
@@ -358,9 +359,9 @@ impl Provider for GithubProvider {
         let expected_binary_names =
             super::expected_binary_names(&binary_name, Some(&candidate.binary_basename), crate_name);
 
-        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
+        let work_dir = super::recreate_staging_work_dir(&self.staging_dir, &krate.resolved)?;
 
-        let archive_path = temp_dir.path().join(candidate.format.canonical_filename());
+        let archive_path = work_dir.join(candidate.format.canonical_filename());
         match self.try_download_to_file(download_url, &archive_path) {
             Ok(true) => {}
             Ok(false) => {
@@ -377,7 +378,7 @@ impl Provider for GithubProvider {
 
         if self.verify_checksums {
             let checksum_url = format!("{}.sha256", download_url);
-            let checksum_path = temp_dir.path().join("checksum.sha256");
+            let checksum_path = work_dir.join("checksum.sha256");
             let checksum_found =
                 self.try_download_to_file(&checksum_url, &checksum_path)
                     .map_err(|source| {
@@ -404,7 +405,7 @@ impl Provider for GithubProvider {
             }
         }
 
-        let extract_dir = temp_dir.path().join("extracted");
+        let extract_dir = work_dir.join("extracted");
         let binary_path = super::extract_binary_by_candidate_names(
             &archive_path,
             candidate.format,
@@ -415,40 +416,12 @@ impl Provider for GithubProvider {
             super::provider_asset_preparation_failed(BinaryProvider::GithubReleases, download_url, source)
         })?;
 
-        let final_dir = self
-            .cache_dir
-            .join("binaries")
-            .join("github")
-            .join(&krate.resolved.name)
-            .join(krate.resolved.version.to_string())
-            .join(target.as_str());
-
-        std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
-            path: final_dir.clone(),
-        })?;
-
-        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
-        std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
-            path: final_path.clone(),
-        })?;
-
-        #[cfg(unix)]
-        {
-            let mut perms = std::fs::metadata(&final_path)
-                .with_context(|_| error::IoSnafu {
-                    path: final_path.clone(),
-                })?
-                .permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
-                path: final_path.clone(),
-            })?;
-        }
-
+        let staged_path = super::stage_extracted_binary(&work_dir, &binary_name, target, &binary_path)?;
         Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GithubReleases,
-            path: final_path,
+            path: staged_path,
+            target: candidate.target.to_string(),
         }))
     }
 }
@@ -477,16 +450,11 @@ mod tests {
         }
     }
 
-    fn test_provider() -> (GithubProvider, tempfile::TempDir) {
+    fn test_provider() -> (GithubProvider, TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         let http_client = HttpClient::new(&fast_retry_config()).unwrap();
         (
-            GithubProvider::new(
-                MessageReporter::null(),
-                temp_dir.path().to_path_buf(),
-                false,
-                http_client,
-            ),
+            GithubProvider::new(MessageReporter::null(), &temp_dir, false, http_client),
             temp_dir,
         )
     }

--- a/cgx-core/src/bin_resolver/providers/github.rs
+++ b/cgx-core/src/bin_resolver/providers/github.rs
@@ -358,9 +358,7 @@ impl Provider for GithubProvider {
         let expected_binary_names =
             super::expected_binary_names(&binary_name, Some(&candidate.binary_basename), crate_name);
 
-        let temp_dir = tempfile::tempdir().with_context(|_| error::TempDirCreationSnafu {
-            parent: self.cache_dir.clone(),
-        })?;
+        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
 
         let archive_path = temp_dir.path().join(candidate.format.canonical_filename());
         match self.try_download_to_file(download_url, &archive_path) {

--- a/cgx-core/src/bin_resolver/providers/github.rs
+++ b/cgx-core/src/bin_resolver/providers/github.rs
@@ -20,6 +20,7 @@ use crate::{
         SMALL_DOWNLOAD_LIMIT_BYTES,
     },
     messages::PrebuiltBinaryMessage,
+    target::TargetTriple,
 };
 
 pub(in crate::bin_resolver) struct GithubProvider {
@@ -257,7 +258,7 @@ impl Provider for GithubProvider {
         BinaryProvider::GithubReleases
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -326,7 +327,7 @@ impl Provider for GithubProvider {
             .filter(|n| *n != crate_name)
             .collect();
         let candidates =
-            super::generate_candidate_filenames(crate_name, &extra_binary_names, &version, platform);
+            super::generate_candidate_filenames(crate_name, &extra_binary_names, &version, target);
 
         let asset_map: std::collections::HashMap<&str, &str> = assets
             .iter()
@@ -422,13 +423,13 @@ impl Provider for GithubProvider {
             .join("github")
             .join(&krate.resolved.name)
             .join(krate.resolved.version.to_string())
-            .join(platform);
+            .join(target.as_str());
 
         std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
             path: final_dir.clone(),
         })?;
 
-        let final_path = final_dir.join(format!("{}{}", binary_name, std::env::consts::EXE_SUFFIX));
+        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
         std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
             path: final_path.clone(),
         })?;

--- a/cgx-core/src/bin_resolver/providers/gitlab.rs
+++ b/cgx-core/src/bin_resolver/providers/gitlab.rs
@@ -16,6 +16,7 @@ use crate::{
     error,
     http::HttpClient,
     messages::PrebuiltBinaryMessage,
+    target::TargetTriple,
 };
 
 /// A generated GitLab release asset candidate and the metadata needed to consume it.
@@ -102,11 +103,11 @@ impl GitlabProvider {
         crate_name: &str,
         extra_binary_names: &[&str],
         version: &str,
-        platform: &str,
+        target: &TargetTriple,
     ) -> Vec<GitlabReleaseAssetCandidate> {
         // Generate candidate filenames for the crate and platform
         let filename_candidates =
-            super::generate_candidate_filenames(crate_name, extra_binary_names, version, platform);
+            super::generate_candidate_filenames(crate_name, extra_binary_names, version, target);
 
         // Make a separate Gitlab release asset candidate for each possible variant the release tag
         // might have (with or without a leading "v" prefix).
@@ -187,7 +188,7 @@ impl Provider for GitlabProvider {
         BinaryProvider::GitlabReleases
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
+    fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
         let repo_url = if let Some(url) = Self::get_repo_url(krate)? {
             url
         } else {
@@ -212,7 +213,7 @@ impl Provider for GitlabProvider {
             crate_name,
             &extra_binary_names,
             &krate.resolved.version.to_string(),
-            platform,
+            target,
         );
 
         // Probe sequentially with HEAD requests
@@ -322,13 +323,13 @@ impl Provider for GitlabProvider {
             .join("gitlab")
             .join(&krate.resolved.name)
             .join(krate.resolved.version.to_string())
-            .join(platform);
+            .join(target.as_str());
 
         std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
             path: final_dir.clone(),
         })?;
 
-        let final_path = final_dir.join(format!("{}{}", binary_name, std::env::consts::EXE_SUFFIX));
+        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
         std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
             path: final_path.clone(),
         })?;
@@ -392,6 +393,10 @@ mod tests {
         )
     }
 
+    fn target_triple(target: &'static str) -> TargetTriple {
+        TargetTriple::from_static(target).unwrap()
+    }
+
     #[test]
     fn test_release_asset_candidate_generation_includes_version_patterns() {
         let candidates = GitlabProvider::generate_release_asset_candidates(
@@ -399,7 +404,7 @@ mod tests {
             "mytool",
             &[],
             "1.2.3",
-            "x86_64-unknown-linux-gnu",
+            &target_triple("x86_64-unknown-linux-gnu"),
         );
 
         assert!(
@@ -421,7 +426,7 @@ mod tests {
             "mytool",
             &[],
             "1.2.3",
-            "x86_64-unknown-linux-gnu",
+            &target_triple("x86_64-unknown-linux-gnu"),
         );
 
         assert!(
@@ -443,7 +448,7 @@ mod tests {
             "mytool",
             &[],
             "1.2.3",
-            "x86_64-unknown-linux-gnu",
+            &target_triple("x86_64-unknown-linux-gnu"),
         );
 
         assert!(
@@ -471,7 +476,7 @@ mod tests {
             "mytool",
             &[],
             "1.2.3",
-            "x86_64-unknown-linux-gnu",
+            &target_triple("x86_64-unknown-linux-gnu"),
         );
 
         for candidate in &candidates {

--- a/cgx-core/src/bin_resolver/providers/gitlab.rs
+++ b/cgx-core/src/bin_resolver/providers/gitlab.rs
@@ -256,9 +256,7 @@ impl Provider for GitlabProvider {
         let expected_binary_names =
             super::expected_binary_names(&binary_name, Some(&candidate.binary_basename_hint), crate_name);
 
-        let temp_dir = tempfile::tempdir().with_context(|_| error::TempDirCreationSnafu {
-            parent: self.cache_dir.clone(),
-        })?;
+        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
 
         let archive_path = temp_dir
             .path()

--- a/cgx-core/src/bin_resolver/providers/gitlab.rs
+++ b/cgx-core/src/bin_resolver/providers/gitlab.rs
@@ -1,9 +1,7 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use reqwest::StatusCode;
-use snafu::ResultExt;
+use tempfile::TempDir;
 
 use super::{ArchiveFormat, CandidateFilename, Provider};
 use crate::{
@@ -47,11 +45,14 @@ struct GitlabReleaseAssetCandidate {
     /// some projects publish assets under a name that differs from the crate's default
     /// binary name.
     binary_basename_hint: String,
+
+    /// The compatible target whose platform token produced this candidate's filename.
+    target: TargetTriple,
 }
 
 pub(in crate::bin_resolver) struct GitlabProvider {
     reporter: crate::messages::MessageReporter,
-    cache_dir: PathBuf,
+    staging_dir: PathBuf,
     verify_checksums: bool,
     http_client: HttpClient,
 }
@@ -59,13 +60,15 @@ pub(in crate::bin_resolver) struct GitlabProvider {
 impl GitlabProvider {
     pub(in crate::bin_resolver) fn new(
         reporter: crate::messages::MessageReporter,
-        cache_dir: PathBuf,
+        staging_dir: &TempDir,
         verify_checksums: bool,
         http_client: HttpClient,
     ) -> Self {
         Self {
             reporter,
-            cache_dir,
+            staging_dir: staging_dir
+                .path()
+                .join(<&'static str>::from(BinaryProvider::GitlabReleases)),
             verify_checksums,
             http_client,
         }
@@ -119,6 +122,7 @@ impl GitlabProvider {
                 filename,
                 binary_basename,
                 format,
+                target,
             } in &filename_candidates
             {
                 asset_candidates.push(GitlabReleaseAssetCandidate {
@@ -126,6 +130,7 @@ impl GitlabProvider {
                     archive_format: *format,
                     asset_filename: filename.clone(),
                     binary_basename_hint: binary_basename.clone(),
+                    target: target.clone(),
                 });
             }
         }
@@ -256,11 +261,9 @@ impl Provider for GitlabProvider {
         let expected_binary_names =
             super::expected_binary_names(&binary_name, Some(&candidate.binary_basename_hint), crate_name);
 
-        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
+        let work_dir = super::recreate_staging_work_dir(&self.staging_dir, &krate.resolved)?;
 
-        let archive_path = temp_dir
-            .path()
-            .join(candidate.archive_format.canonical_filename());
+        let archive_path = work_dir.join(candidate.archive_format.canonical_filename());
         match self.try_download_to_file(&candidate.url, &archive_path) {
             Ok(true) => {}
             Ok(false) => {
@@ -277,7 +280,7 @@ impl Provider for GitlabProvider {
 
         if self.verify_checksums {
             let checksum_url = format!("{}.sha256", candidate.url);
-            let checksum_path = temp_dir.path().join("checksum.sha256");
+            let checksum_path = work_dir.join("checksum.sha256");
             let checksum_found =
                 self.try_download_to_file(&checksum_url, &checksum_path)
                     .map_err(|source| {
@@ -304,7 +307,7 @@ impl Provider for GitlabProvider {
             }
         }
 
-        let extract_dir = temp_dir.path().join("extracted");
+        let extract_dir = work_dir.join("extracted");
         let binary_path = super::extract_binary_by_candidate_names(
             &archive_path,
             candidate.archive_format,
@@ -315,40 +318,12 @@ impl Provider for GitlabProvider {
             super::provider_asset_preparation_failed(BinaryProvider::GitlabReleases, &candidate.url, source)
         })?;
 
-        let final_dir = self
-            .cache_dir
-            .join("binaries")
-            .join("gitlab")
-            .join(&krate.resolved.name)
-            .join(krate.resolved.version.to_string())
-            .join(target.as_str());
-
-        std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
-            path: final_dir.clone(),
-        })?;
-
-        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
-        std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
-            path: final_path.clone(),
-        })?;
-
-        #[cfg(unix)]
-        {
-            let mut perms = std::fs::metadata(&final_path)
-                .with_context(|_| error::IoSnafu {
-                    path: final_path.clone(),
-                })?
-                .permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
-                path: final_path.clone(),
-            })?;
-        }
-
+        let staged_path = super::stage_extracted_binary(&work_dir, &binary_name, target, &binary_path)?;
         Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::GitlabReleases,
-            path: final_path,
+            path: staged_path,
+            target: candidate.target.to_string(),
         }))
     }
 }
@@ -365,7 +340,7 @@ mod tests {
     use super::*;
     use crate::{
         config::HttpConfig, crate_resolver::ResolvedSource, cratespec::Forge, error::Error,
-        messages::MessageReporter,
+        messages::MessageReporter, testdata::target_triple,
     };
 
     fn fast_retry_config() -> HttpConfig {
@@ -377,22 +352,13 @@ mod tests {
         }
     }
 
-    fn test_provider() -> (GitlabProvider, tempfile::TempDir) {
+    fn test_provider() -> (GitlabProvider, TempDir) {
         let temp_dir = tempfile::tempdir().unwrap();
         let http_client = HttpClient::new(&fast_retry_config()).unwrap();
         (
-            GitlabProvider::new(
-                MessageReporter::null(),
-                temp_dir.path().to_path_buf(),
-                false,
-                http_client,
-            ),
+            GitlabProvider::new(MessageReporter::null(), &temp_dir, false, http_client),
             temp_dir,
         )
-    }
-
-    fn target_triple(target: &'static str) -> TargetTriple {
-        TargetTriple::from_static(target).unwrap()
     }
 
     #[test]

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -123,7 +123,12 @@ pub(super) fn generate_candidate_filenames(
     target: &TargetTriple,
 ) -> Vec<CandidateFilename> {
     let formats = ArchiveFormat::all_formats();
-    let platforms = target.release_asset_platform_aliases();
+    // Get for the target the platform strings to try, corresponding to all targets, pseudo-targets,
+    // and alternative shorter forms of the target triple that are known to be used in release asset
+    // filenames. The host tokens are tried first and ABI-compatible fallback tokens (for example a
+    // `x86_64-unknown-linux-musl` asset for a `x86_64-unknown-linux-gnu` host, or a
+    // `universal-apple-darwin` asset on macOS) are tried afterwards.
+    let platforms = target.compatible_asset_platform_aliases();
 
     // Crate name first, then binary-name fallbacks. On Windows, also try `{name}.exe` as the name
     // component for projects that bake the extension into the asset name (e.g.
@@ -361,6 +366,57 @@ mod tests {
         assert!(
             names.iter().any(|n| n.starts_with("mytool.exe")),
             "expected a mytool.exe-prefixed candidate on Windows"
+        );
+    }
+
+    /// On a `x86_64-unknown-linux-gnu` host, ripgrep's `x86_64-unknown-linux-musl` asset is
+    /// generated as an ABI-compatible fallback, and the exact-host gnu asset is still tried first.
+    #[test]
+    fn gnu_host_generates_musl_fallback_after_exact_host() {
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", &target);
+        let names = filenames(&candidates);
+
+        let gnu = names
+            .iter()
+            .position(|n| *n == "ripgrep-15.1.0-x86_64-unknown-linux-gnu.tar.gz")
+            .expect("expected an exact-host gnu candidate");
+        let musl = names
+            .iter()
+            .position(|n| *n == "ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz")
+            .expect("expected a musl fallback candidate");
+
+        assert!(
+            gnu < musl,
+            "the exact-host gnu candidate must precede the musl fallback"
+        );
+    }
+
+    /// On a `x86_64-pc-windows-msvc` host, eza's `x86_64-pc-windows-gnu` asset (baked-in `.exe`
+    /// name component) is generated as an ABI-compatible fallback.
+    #[test]
+    fn windows_msvc_host_generates_gnu_exe_fallback() {
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let candidates = generate_candidate_filenames("eza", &[], "0.23.1", &target);
+        let names = filenames(&candidates);
+
+        assert!(
+            names.iter().any(|n| *n == "eza.exe_x86_64-pc-windows-gnu.tar.gz"),
+            "expected an eza.exe_x86_64-pc-windows-gnu.tar.gz fallback candidate"
+        );
+    }
+
+    /// On a macOS host, a `universal-apple-darwin` asset is generated as a fallback (a universal
+    /// fat binary always runs regardless of the host architecture).
+    #[test]
+    fn macos_host_generates_universal_fallback() {
+        let target = target_triple("aarch64-apple-darwin");
+        let candidates = generate_candidate_filenames("mytool", &[], "1.0.0", &target);
+        let names = filenames(&candidates);
+
+        assert!(
+            names.iter().any(|n| n.contains("universal-apple-darwin")),
+            "expected a universal-apple-darwin fallback candidate"
         );
     }
 }

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -18,6 +18,7 @@ pub(super) use self::{
 };
 use crate::{
     Result, bin_resolver::ConclusiveResolution, config::BinaryProvider, downloader::DownloadedCrate, error,
+    target::TargetTriple,
 };
 
 /// Trait for providers that can resolve pre-built binaries.
@@ -38,7 +39,7 @@ pub(super) trait Provider {
     /// providers to fallible things like network I/O and parsing of data, in which case those
     /// providers should return `Err` to indicate that they could not determine a conclusive
     /// outcome.
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution>;
+    fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution>;
 
     /// The kind of this provider, used for progress reporting.
     fn kind(&self) -> BinaryProvider;
@@ -119,10 +120,10 @@ pub(super) fn generate_candidate_filenames(
     crate_name: &str,
     extra_binary_names: &[&str],
     version: &str,
-    platform: &str,
+    target: &TargetTriple,
 ) -> Vec<CandidateFilename> {
     let formats = ArchiveFormat::all_formats();
-    let platforms = platform_aliases(platform);
+    let platforms = target.release_asset_platform_aliases();
 
     // Crate name first, then binary-name fallbacks. On Windows, also try `{name}.exe` as the name
     // component for projects that bake the extension into the asset name (e.g.
@@ -130,7 +131,7 @@ pub(super) fn generate_candidate_filenames(
     let mut names: Vec<String> = Vec::new();
     names.push(crate_name.to_string());
     names.extend(extra_binary_names.iter().map(|&n| n.to_string()));
-    if platform.contains("windows") {
+    if target.is_windows() {
         names.push(format!("{}.exe", crate_name));
         names.extend(extra_binary_names.iter().map(|n| format!("{}.exe", n)));
     }
@@ -139,7 +140,14 @@ pub(super) fn generate_candidate_filenames(
     for name in &names {
         for platform_token in &platforms {
             for &(format, suffix) in formats {
-                push_candidate_patterns(&mut candidates, name, version, platform_token, format, suffix);
+                push_candidate_patterns(
+                    &mut candidates,
+                    name,
+                    version,
+                    platform_token.as_ref(),
+                    format,
+                    suffix,
+                );
             }
         }
     }
@@ -150,41 +158,6 @@ pub(super) fn generate_candidate_filenames(
     candidates.retain(|c| seen.insert(c.filename.clone()));
 
     candidates
-}
-
-/// Build the list of platform tokens to try for asset matching: the full target triple first (the
-/// most specific, lowest-false-positive form), then the shorter `{os}-{arch}` and `{arch}-{os}`
-/// forms many projects use in their asset names.
-///
-/// The os component is mapped from the triple: `*apple*`/`*darwin*` -> `darwin`, `*windows*` ->
-/// `windows`, `*linux*` -> `linux`. The arch is the triple's first component, used verbatim (so
-/// `x86_64`, `aarch64`, `armv7` all match as-is); no arch synonyms are invented, to avoid
-/// over-generating candidates that could match the wrong asset.
-fn platform_aliases(platform: &str) -> Vec<String> {
-    let mut aliases = vec![platform.to_string()];
-
-    let arch = platform.split('-').next().unwrap_or("");
-    let os = if platform.contains("windows") {
-        Some("windows")
-    } else if platform.contains("apple") || platform.contains("darwin") {
-        Some("darwin")
-    } else if platform.contains("linux") {
-        Some("linux")
-    } else {
-        None
-    };
-
-    if let Some(os) = os {
-        if !arch.is_empty() {
-            for alias in [format!("{}-{}", os, arch), format!("{}-{}", arch, os)] {
-                if !aliases.contains(&alias) {
-                    aliases.push(alias);
-                }
-            }
-        }
-    }
-
-    aliases
 }
 
 fn push_candidate_patterns(
@@ -255,13 +228,17 @@ mod tests {
         candidates.iter().map(|c| c.filename.as_str()).collect()
     }
 
+    fn target_triple(target: &'static str) -> TargetTriple {
+        TargetTriple::from_static(target).unwrap()
+    }
+
     /// The taplo case: the crate is `taplo-cli`, but its GitHub assets are named after the `taplo`
     /// binary, use a short `{os}-{arch}` platform token, and a bare `.gz` suffix. All three must
     /// combine into a single candidate carrying the naked [`ArchiveFormat::Gz`] format.
     #[test]
     fn binary_name_short_platform_and_naked_gz_combine() {
-        let candidates =
-            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", &target);
 
         let target = candidates
             .iter()
@@ -275,8 +252,8 @@ mod tests {
     /// regression).
     #[test]
     fn crate_name_full_triple_is_first_candidate() {
-        let candidates =
-            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", &target);
         assert_eq!(
             candidates[0].filename,
             "taplo-cli-x86_64-unknown-linux-gnu-v0.10.0.tar"
@@ -286,8 +263,8 @@ mod tests {
     /// Every crate-name candidate is ordered before any binary-name candidate.
     #[test]
     fn crate_name_candidates_precede_binary_name_candidates() {
-        let candidates =
-            generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", "x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", &target);
         let names = filenames(&candidates);
         let last_crate = names.iter().rposition(|n| n.starts_with("taplo-cli")).unwrap();
         let first_binary = names
@@ -303,7 +280,8 @@ mod tests {
     /// Filenames are unique even when a binary name coincides with the crate name.
     #[test]
     fn candidates_are_deduplicated() {
-        let candidates = generate_candidate_filenames("foo", &["foo"], "1.0.0", "x86_64-unknown-linux-gnu");
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("foo", &["foo"], "1.0.0", &target);
         let count = candidates.len();
         let mut names = filenames(&candidates);
         names.sort_unstable();
@@ -313,8 +291,8 @@ mod tests {
 
     #[test]
     fn matched_candidate_carries_binary_basename() {
-        let candidates =
-            generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", "x86_64-unknown-linux-musl");
+        let target = target_triple("x86_64-unknown-linux-musl");
+        let candidates = generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", &target);
         let candidate = candidates
             .iter()
             .find(|candidate| candidate.filename == "ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz")
@@ -349,7 +327,8 @@ mod tests {
         ];
 
         for (platform, asset_name, format) in cases {
-            let candidates = generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", platform);
+            let target = target_triple(platform);
+            let candidates = generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", &target);
             let candidate = candidates
                 .iter()
                 .find(|candidate| candidate.filename == asset_name)
@@ -376,34 +355,12 @@ mod tests {
     /// `eza.exe_x86_64-pc-windows-gnu.tar.gz`).
     #[test]
     fn windows_adds_exe_name_variant() {
-        let candidates = generate_candidate_filenames("mytool", &[], "1.0.0", "x86_64-pc-windows-msvc");
+        let target = target_triple("x86_64-pc-windows-msvc");
+        let candidates = generate_candidate_filenames("mytool", &[], "1.0.0", &target);
         let names = filenames(&candidates);
         assert!(
             names.iter().any(|n| n.starts_with("mytool.exe")),
             "expected a mytool.exe-prefixed candidate on Windows"
         );
-    }
-
-    #[test]
-    fn platform_aliases_full_triple_first_then_short_forms() {
-        let aliases = platform_aliases("x86_64-unknown-linux-gnu");
-        assert_eq!(aliases[0], "x86_64-unknown-linux-gnu");
-        assert!(aliases.contains(&"linux-x86_64".to_string()));
-        assert!(aliases.contains(&"x86_64-linux".to_string()));
-    }
-
-    /// macOS triples use `apple`, but most asset names use `darwin`; the alias must bridge that.
-    #[test]
-    fn platform_aliases_maps_apple_to_darwin() {
-        let aliases = platform_aliases("aarch64-apple-darwin");
-        assert!(aliases.contains(&"darwin-aarch64".to_string()));
-        assert!(aliases.contains(&"aarch64-darwin".to_string()));
-    }
-
-    #[test]
-    fn platform_aliases_windows() {
-        let aliases = platform_aliases("x86_64-pc-windows-msvc");
-        assert!(aliases.contains(&"windows-x86_64".to_string()));
-        assert!(aliases.contains(&"x86_64-windows".to_string()));
     }
 }

--- a/cgx-core/src/bin_resolver/providers/mod.rs
+++ b/cgx-core/src/bin_resolver/providers/mod.rs
@@ -5,9 +5,12 @@ mod github;
 mod gitlab;
 mod quickinstall;
 
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
-use snafu::IntoError;
+use snafu::{IntoError, ResultExt};
 
 pub(super) use self::{
     archive::{ArchiveFormat, extract_binary_at_archive_relative_path, extract_binary_by_candidate_names},
@@ -17,8 +20,8 @@ pub(super) use self::{
     quickinstall::QuickinstallProvider,
 };
 use crate::{
-    Result, bin_resolver::ConclusiveResolution, config::BinaryProvider, downloader::DownloadedCrate, error,
-    target::TargetTriple,
+    Result, bin_resolver::ConclusiveResolution, config::BinaryProvider, crate_resolver::ResolvedCrate,
+    downloader::DownloadedCrate, error, target::TargetTriple,
 };
 
 /// Trait for providers that can resolve pre-built binaries.
@@ -43,6 +46,42 @@ pub(super) trait Provider {
 
     /// The kind of this provider, used for progress reporting.
     fn kind(&self) -> BinaryProvider;
+}
+
+/// Create the per-resolution working directory for `krate` under a provider's staging directory.
+///
+/// Any leftover directory from an earlier attempt (eg a retried inconclusive resolution) is
+/// removed first, so stale downloads or extracted files don't contaminate a fresh resolution.
+pub(super) fn recreate_staging_work_dir(staging_dir: &Path, krate: &ResolvedCrate) -> Result<PathBuf> {
+    let work_dir = staging_dir.join(format!("{}-{}", krate.name, krate.version));
+    if work_dir.exists() {
+        std::fs::remove_dir_all(&work_dir).with_context(|_| error::IoSnafu {
+            path: work_dir.clone(),
+        })?;
+    }
+    std::fs::create_dir_all(&work_dir).with_context(|_| error::IoSnafu {
+        path: work_dir.clone(),
+    })?;
+    Ok(work_dir)
+}
+
+/// Move a freshly extracted binary to the top of its staging work dir under the canonical
+/// filename `<binary_name><host binary-ext>`, returning the staged path.
+///
+/// Release archives do not reliably name their member after the crate's default binary, so this
+/// is where the binary gets the name it will keep in `bin_dir` after relocation.
+pub(super) fn stage_extracted_binary(
+    work_dir: &Path,
+    binary_name: &str,
+    host_target: &TargetTriple,
+    extracted_binary_path: &Path,
+) -> Result<PathBuf> {
+    let staged_path = work_dir.join(format!("{}{}", binary_name, host_target.binary_ext()));
+    std::fs::rename(extracted_binary_path, &staged_path).with_context(|_| error::RenameFileSnafu {
+        src: extracted_binary_path.to_path_buf(),
+        dst: staged_path.clone(),
+    })?;
+    Ok(staged_path)
 }
 
 /// Wrap a downloaded asset preparation failure with the provider and asset URL that caused it.
@@ -101,6 +140,14 @@ pub(super) struct CandidateFilename {
 
     /// File format inferred from the filename suffix.
     pub format: ArchiveFormat,
+
+    /// The compatible target whose platform token produced this candidate, so a match can record
+    /// which target the downloaded binary is actually for. A token shared between siblings (eg
+    /// `linux-x86_64`) is attributed to the most-preferred target that produces it, which is
+    /// potentially misleading as we don't actually KNOW in that case what the target of the binary
+    /// is.  As long as it's compatible though, it will work, and the target is only used for
+    /// reporting and cache key purposes.
+    pub target: TargetTriple,
 }
 
 /// Generate candidate filenames that might be used for a release asset for a given crate, version,
@@ -123,16 +170,18 @@ pub(super) fn generate_candidate_filenames(
     target: &TargetTriple,
 ) -> Vec<CandidateFilename> {
     let formats = ArchiveFormat::all_formats();
-    // Get for the target the platform strings to try, corresponding to all targets, pseudo-targets,
-    // and alternative shorter forms of the target triple that are known to be used in release asset
-    // filenames. The host tokens are tried first and ABI-compatible fallback tokens (for example a
+    // The platform tokens to try, grouped per compatible target in target-preference order: the
+    // exact host's group first, then each ABI-compatible fallback's group (for example a
     // `x86_64-unknown-linux-musl` asset for a `x86_64-unknown-linux-gnu` host, or a
-    // `universal-apple-darwin` asset on macOS) are tried afterwards.
-    let platforms = target.compatible_asset_platform_aliases();
+    // `universal-apple-darwin` asset on macOS). Iterating group-major below makes target
+    // preference dominate name preference: every candidate for the exact host outranks every
+    // candidate for any fallback target.
+    let platform_groups = target.compatible_asset_platform_alias_groups();
 
     // Crate name first, then binary-name fallbacks. On Windows, also try `{name}.exe` as the name
     // component for projects that bake the extension into the asset name (e.g.
-    // `eza.exe_x86_64-pc-windows-gnu.tar.gz`); these come last as the least-likely form.
+    // `eza.exe_x86_64-pc-windows-gnu.tar.gz`); these come last within each target group as the
+    // least-likely form.
     let mut names: Vec<String> = Vec::new();
     names.push(crate_name.to_string());
     names.extend(extra_binary_names.iter().map(|&n| n.to_string()));
@@ -142,17 +191,20 @@ pub(super) fn generate_candidate_filenames(
     }
 
     let mut candidates = Vec::new();
-    for name in &names {
-        for platform_token in &platforms {
-            for &(format, suffix) in formats {
-                push_candidate_patterns(
-                    &mut candidates,
-                    name,
-                    version,
-                    platform_token.as_ref(),
-                    format,
-                    suffix,
-                );
+    for (group_target, platform_tokens) in &platform_groups {
+        for name in &names {
+            for platform_token in platform_tokens {
+                for &(format, suffix) in formats {
+                    push_candidate_patterns(
+                        &mut candidates,
+                        name,
+                        version,
+                        platform_token.as_ref(),
+                        format,
+                        suffix,
+                        group_target,
+                    );
+                }
             }
         }
     }
@@ -172,69 +224,35 @@ fn push_candidate_patterns(
     platform: &str,
     format: ArchiveFormat,
     suffix: &str,
+    target: &TargetTriple,
 ) {
-    candidates.push(CandidateFilename {
-        filename: format!("{}-{}-v{}{}", name, platform, version, suffix),
+    let patterns = [
+        format!("{}-{}-v{}{}", name, platform, version, suffix),
+        format!("{}-{}-{}{}", name, platform, version, suffix),
+        format!("{}-v{}-{}{}", name, version, platform, suffix),
+        format!("{}-{}-{}{}", name, version, platform, suffix),
+        format!("{}_{}_v{}{}", name, platform, version, suffix),
+        format!("{}_{}_{}{}", name, platform, version, suffix),
+        format!("{}_v{}_{}{}", name, version, platform, suffix),
+        format!("{}_{}_{}{}", name, version, platform, suffix),
+        format!("{}-{}{}", name, platform, suffix),
+        format!("{}_{}{}", name, platform, suffix),
+    ];
+    candidates.extend(patterns.into_iter().map(|filename| CandidateFilename {
+        filename,
         binary_basename: name.to_string(),
         format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}-{}-{}{}", name, platform, version, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}-v{}-{}{}", name, version, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}-{}-{}{}", name, version, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}_{}_v{}{}", name, platform, version, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}_{}_{}{}", name, platform, version, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}_v{}_{}{}", name, version, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}_{}_{}{}", name, version, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}-{}{}", name, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
-    candidates.push(CandidateFilename {
-        filename: format!("{}_{}{}", name, platform, suffix),
-        binary_basename: name.to_string(),
-        format,
-    });
+        target: target.clone(),
+    }));
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testdata::target_triple;
 
     fn filenames(candidates: &[CandidateFilename]) -> Vec<&str> {
         candidates.iter().map(|c| c.filename.as_str()).collect()
-    }
-
-    fn target_triple(target: &'static str) -> TargetTriple {
-        TargetTriple::from_static(target).unwrap()
     }
 
     /// The taplo case: the crate is `taplo-cli`, but its GitHub assets are named after the `taplo`
@@ -265,20 +283,29 @@ mod tests {
         );
     }
 
-    /// Every crate-name candidate is ordered before any binary-name candidate.
+    /// Within a single target's group, every crate-name candidate is ordered before any
+    /// binary-name candidate. Across groups target preference dominates instead — see
+    /// `exact_host_candidates_precede_fallback_target_candidates`.
     #[test]
-    fn crate_name_candidates_precede_binary_name_candidates() {
+    fn crate_name_candidates_precede_binary_name_candidates_within_target_group() {
         let target = target_triple("x86_64-unknown-linux-gnu");
         let candidates = generate_candidate_filenames("taplo-cli", &["taplo"], "0.10.0", &target);
-        let names = filenames(&candidates);
-        let last_crate = names.iter().rposition(|n| n.starts_with("taplo-cli")).unwrap();
-        let first_binary = names
+        let host_names: Vec<&str> = candidates
+            .iter()
+            .filter(|c| c.target == target)
+            .map(|c| c.filename.as_str())
+            .collect();
+        let last_crate = host_names
+            .iter()
+            .rposition(|n| n.starts_with("taplo-cli"))
+            .unwrap();
+        let first_binary = host_names
             .iter()
             .position(|n| n.starts_with("taplo-") && !n.starts_with("taplo-cli"))
             .unwrap();
         assert!(
             last_crate < first_binary,
-            "all taplo-cli candidates should precede the taplo (binary) candidates"
+            "within the host group, all taplo-cli candidates should precede the taplo (binary) candidates"
         );
     }
 
@@ -417,6 +444,45 @@ mod tests {
         assert!(
             names.iter().any(|n| n.contains("universal-apple-darwin")),
             "expected a universal-apple-darwin fallback candidate"
+        );
+    }
+
+    /// Target preference must dominate name preference: a binary-name candidate for the exact host
+    /// target must outrank a crate-name candidate for an ABI-compatible fallback target, otherwise
+    /// a fallback asset is selected even when an exact-host asset exists in the same release.
+    #[test]
+    fn exact_host_candidates_precede_fallback_target_candidates() {
+        let target = target_triple("x86_64-unknown-linux-gnu");
+        let candidates = generate_candidate_filenames("ripgrep", &["rg"], "15.1.0", &target);
+        let names = filenames(&candidates);
+
+        let host_binary_name = names
+            .iter()
+            .position(|n| *n == "rg-15.1.0-x86_64-unknown-linux-gnu.tar.gz")
+            .expect("expected an exact-host binary-name candidate");
+        let fallback_crate_name = names
+            .iter()
+            .position(|n| *n == "ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz")
+            .expect("expected a musl fallback crate-name candidate");
+
+        assert!(
+            host_binary_name < fallback_crate_name,
+            "exact-host candidate (index {host_binary_name}) must precede fallback-target candidate (index \
+             {fallback_crate_name})"
+        );
+    }
+
+    /// `arm64` is a far more common asset-name spelling than `aarch64` for Apple Silicon releases;
+    /// candidates must include it or assets like `foo-arm64-darwin.tar.gz` are invisible.
+    #[test]
+    fn aarch64_target_generates_arm64_spelling_candidates() {
+        let target = target_triple("aarch64-apple-darwin");
+        let candidates = generate_candidate_filenames("foo", &[], "1.0.0", &target);
+        let names = filenames(&candidates);
+
+        assert!(
+            names.iter().any(|n| *n == "foo-arm64-darwin.tar.gz"),
+            "expected a foo-arm64-darwin.tar.gz candidate"
         );
     }
 }

--- a/cgx-core/src/bin_resolver/providers/quickinstall.rs
+++ b/cgx-core/src/bin_resolver/providers/quickinstall.rs
@@ -49,28 +49,37 @@ impl Provider for QuickinstallProvider {
     }
 
     fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
-        let url = Self::construct_url(&krate.resolved, target);
-
-        self.reporter
-            .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Quickinstall));
-
-        let temp_dir = tempfile::tempdir().with_context(|_| error::TempDirCreationSnafu {
-            parent: self.cache_dir.clone(),
-        })?;
+        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
 
         let archive_path = temp_dir.path().join(ArchiveFormat::TarGz.canonical_filename());
-        match self.http_client.try_download_to_file(&url, &archive_path) {
-            Ok(true) => {}
-            Ok(false) => {
-                self.reporter.report(|| {
-                    PrebuiltBinaryMessage::provider_has_no_binary(
-                        BinaryProvider::Quickinstall,
-                        "binary not found",
-                    )
-                });
-                return Ok(ConclusiveResolution::Nonexistent);
+
+        // Try the exact host target first, then each ABI-compatible fallback target; the first one
+        // that quickinstall actually publishes wins.
+        let mut resolved_url = None;
+        for candidate_target in target.compatible_targets() {
+            let url = Self::construct_url(&krate.resolved, &candidate_target);
+
+            self.reporter
+                .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Quickinstall));
+
+            match self.http_client.try_download_to_file(&url, &archive_path) {
+                Ok(true) => {
+                    resolved_url = Some(url);
+                    break;
+                }
+                Ok(false) => {}
+                Err(e) => return Err(e),
             }
-            Err(e) => return Err(e),
+        }
+
+        let Some(url) = resolved_url else {
+            self.reporter.report(|| {
+                PrebuiltBinaryMessage::provider_has_no_binary(
+                    BinaryProvider::Quickinstall,
+                    "binary not found",
+                )
+            });
+            return Ok(ConclusiveResolution::Nonexistent);
         };
 
         // TODO(#80): verify .sig (minisign) signatures when support is added

--- a/cgx-core/src/bin_resolver/providers/quickinstall.rs
+++ b/cgx-core/src/bin_resolver/providers/quickinstall.rs
@@ -14,6 +14,7 @@ use crate::{
     error,
     http::HttpClient,
     messages::PrebuiltBinaryMessage,
+    target::TargetTriple,
 };
 
 pub(in crate::bin_resolver) struct QuickinstallProvider {
@@ -35,10 +36,10 @@ impl QuickinstallProvider {
         }
     }
 
-    fn construct_url(krate: &ResolvedCrate, platform: &str) -> String {
+    fn construct_url(krate: &ResolvedCrate, target: &TargetTriple) -> String {
         let base = "https://github.com/cargo-bins/cargo-quickinstall/releases/download";
         let tag = format!("{}-{}", krate.name, krate.version);
-        format!("{base}/{tag}/{tag}-{platform}.tar.gz")
+        format!("{base}/{tag}/{tag}-{}.tar.gz", target.as_str())
     }
 }
 
@@ -47,8 +48,8 @@ impl Provider for QuickinstallProvider {
         BinaryProvider::Quickinstall
     }
 
-    fn try_resolve(&self, krate: &DownloadedCrate, platform: &str) -> Result<ConclusiveResolution> {
-        let url = Self::construct_url(&krate.resolved, platform);
+    fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
+        let url = Self::construct_url(&krate.resolved, target);
 
         self.reporter
             .report(|| PrebuiltBinaryMessage::downloading_binary(&url, BinaryProvider::Quickinstall));
@@ -92,13 +93,13 @@ impl Provider for QuickinstallProvider {
             .join("quickinstall")
             .join(&krate.resolved.name)
             .join(krate.resolved.version.to_string())
-            .join(platform);
+            .join(target.as_str());
 
         std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
             path: final_dir.clone(),
         })?;
 
-        let final_path = final_dir.join(format!("{}{}", binary_name, std::env::consts::EXE_SUFFIX));
+        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
         std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
             path: final_path.clone(),
         })?;

--- a/cgx-core/src/bin_resolver/providers/quickinstall.rs
+++ b/cgx-core/src/bin_resolver/providers/quickinstall.rs
@@ -1,8 +1,6 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
-use snafu::ResultExt;
+use tempfile::TempDir;
 
 use super::{ArchiveFormat, Provider};
 use crate::{
@@ -11,7 +9,6 @@ use crate::{
     config::BinaryProvider,
     crate_resolver::ResolvedCrate,
     downloader::DownloadedCrate,
-    error,
     http::HttpClient,
     messages::PrebuiltBinaryMessage,
     target::TargetTriple,
@@ -19,19 +16,21 @@ use crate::{
 
 pub(in crate::bin_resolver) struct QuickinstallProvider {
     reporter: crate::messages::MessageReporter,
-    cache_dir: PathBuf,
+    staging_dir: PathBuf,
     http_client: HttpClient,
 }
 
 impl QuickinstallProvider {
     pub(in crate::bin_resolver) fn new(
         reporter: crate::messages::MessageReporter,
-        cache_dir: PathBuf,
+        staging_dir: &TempDir,
         http_client: HttpClient,
     ) -> Self {
         Self {
             reporter,
-            cache_dir,
+            staging_dir: staging_dir
+                .path()
+                .join(<&'static str>::from(BinaryProvider::Quickinstall)),
             http_client,
         }
     }
@@ -49,14 +48,22 @@ impl Provider for QuickinstallProvider {
     }
 
     fn try_resolve(&self, krate: &DownloadedCrate, target: &TargetTriple) -> Result<ConclusiveResolution> {
-        let temp_dir = tempfile::tempdir().context(error::TempDirCreationSnafu)?;
+        let work_dir = super::recreate_staging_work_dir(&self.staging_dir, &krate.resolved)?;
 
-        let archive_path = temp_dir.path().join(ArchiveFormat::TarGz.canonical_filename());
+        let archive_path = work_dir.join(ArchiveFormat::TarGz.canonical_filename());
 
         // Try the exact host target first, then each ABI-compatible fallback target; the first one
         // that quickinstall actually publishes wins.
-        let mut resolved_url = None;
+        let mut resolved = None;
         for candidate_target in target.compatible_targets() {
+            // Quickinstall names its release assets after exact rustc target triples, so probing
+            // an asset-name pseudo-target (eg `universal-apple-darwin`) is pointless. The host
+            // itself is exempt: even when its triple is unparsable it is still a real rustc
+            // triple that quickinstall may publish.
+            if candidate_target.triple().is_none() && candidate_target != *target {
+                continue;
+            }
+
             let url = Self::construct_url(&krate.resolved, &candidate_target);
 
             self.reporter
@@ -64,7 +71,7 @@ impl Provider for QuickinstallProvider {
 
             match self.http_client.try_download_to_file(&url, &archive_path) {
                 Ok(true) => {
-                    resolved_url = Some(url);
+                    resolved = Some((url, candidate_target));
                     break;
                 }
                 Ok(false) => {}
@@ -72,7 +79,7 @@ impl Provider for QuickinstallProvider {
             }
         }
 
-        let Some(url) = resolved_url else {
+        let Some((url, matched_target)) = resolved else {
             self.reporter.report(|| {
                 PrebuiltBinaryMessage::provider_has_no_binary(
                     BinaryProvider::Quickinstall,
@@ -85,7 +92,7 @@ impl Provider for QuickinstallProvider {
         // TODO(#80): verify .sig (minisign) signatures when support is added
 
         let binary_name = krate.default_binary_name()?;
-        let extract_dir = temp_dir.path().join("extracted");
+        let extract_dir = work_dir.join("extracted");
         let binary_path = super::extract_binary_by_candidate_names(
             &archive_path,
             ArchiveFormat::TarGz,
@@ -96,40 +103,12 @@ impl Provider for QuickinstallProvider {
             super::provider_asset_preparation_failed(BinaryProvider::Quickinstall, &url, source)
         })?;
 
-        let final_dir = self
-            .cache_dir
-            .join("binaries")
-            .join("quickinstall")
-            .join(&krate.resolved.name)
-            .join(krate.resolved.version.to_string())
-            .join(target.as_str());
-
-        std::fs::create_dir_all(&final_dir).with_context(|_| error::IoSnafu {
-            path: final_dir.clone(),
-        })?;
-
-        let final_path = final_dir.join(format!("{}{}", binary_name, target.binary_ext()));
-        std::fs::copy(&binary_path, &final_path).with_context(|_| error::IoSnafu {
-            path: final_path.clone(),
-        })?;
-
-        #[cfg(unix)]
-        {
-            let mut perms = std::fs::metadata(&final_path)
-                .with_context(|_| error::IoSnafu {
-                    path: final_path.clone(),
-                })?
-                .permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&final_path, perms).with_context(|_| error::IoSnafu {
-                path: final_path.clone(),
-            })?;
-        }
-
+        let staged_path = super::stage_extracted_binary(&work_dir, &binary_name, target, &binary_path)?;
         Ok(ConclusiveResolution::Found(ResolvedBinary {
             krate: krate.resolved.clone(),
             provider: BinaryProvider::Quickinstall,
-            path: final_path,
+            path: staged_path,
+            target: matched_target.to_string(),
         }))
     }
 }

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -219,11 +219,10 @@ impl BuildOptions {
     /// which the CLI front-end has already produced from the raw arguments (tokenizing
     /// features, folding `--debug`, resolving `--bin`/`--example`).
     pub fn load(config: &Config, overrides: &BuildOverrides) -> Result<Self> {
-        let target = overrides
-            .target
-            .clone()
-            .map(TargetTriple::from_owned)
-            .transpose()?;
+        // The target string is deliberately NOT validated here: cargo accepts targets (and even
+        // target-spec JSON paths) that we cannot parse, so whatever the user passed is carried
+        // through verbatim.
+        let target = overrides.target.clone().map(TargetTriple::from_owned);
 
         Ok(BuildOptions {
             // These come from the config settings, `Config` will already apply any CLI overrides
@@ -1974,6 +1973,21 @@ mod tests {
                 assert_eq!(
                     options.target.as_ref().map(TargetTriple::as_str),
                     Some("x86_64-unknown-linux-gnu")
+                );
+            }
+
+            /// Any target rustc accepts must be forwarded to cargo verbatim, including triples
+            /// that `target-lexicon` cannot parse (`arm64ec-pc-windows-msvc` is a real rustc
+            /// target); cgx itself must not reject them.
+            #[test]
+            fn target_unparsable_by_target_lexicon() {
+                let config = Config::default();
+                let cli = Cli::parse_from_test_args(["--target", "arm64ec-pc-windows-msvc", "tool"]);
+                let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
+
+                assert_eq!(
+                    options.target.as_ref().map(TargetTriple::as_str),
+                    Some("arm64ec-pc-windows-msvc")
                 );
             }
 

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -637,7 +637,7 @@ impl RealCrateBuilder {
         let temp_dir = tempfile::Builder::new()
             .prefix(&format!("cgx-build-{}", &krate.resolved.name))
             .tempdir_in(&self.config.build_dir)
-            .with_context(|_| error::TempDirCreationSnafu {
+            .with_context(|_| error::TempDirInCreationSnafu {
                 parent: self.config.build_dir.clone(),
             })?;
 

--- a/cgx-core/src/builder.rs
+++ b/cgx-core/src/builder.rs
@@ -12,6 +12,7 @@ use crate::{
     cratespec::CrateSpec,
     downloader::DownloadedCrate,
     error,
+    target::TargetTriple,
 };
 
 /// Which executable within a crate to build.
@@ -94,44 +95,44 @@ pub struct BuildOverrides {
 #[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BuildOptions {
     /// Features to activate (corresponds to `--features`).
-    pub features: Vec<String>,
+    pub(crate) features: Vec<String>,
 
     /// Activate all available features (corresponds to `--all-features`).
-    pub all_features: bool,
+    pub(crate) all_features: bool,
 
     /// Do not activate the `default` feature (corresponds to `--no-default-features`).
-    pub no_default_features: bool,
+    pub(crate) no_default_features: bool,
 
     /// Build profile to use (corresponds to `--profile`).
     ///
     /// When `None`, the default release profile is used.
     /// Use `Some("dev")` for debug builds.
-    pub profile: Option<String>,
+    pub(crate) profile: Option<String>,
 
     /// Target triple for cross-compilation (corresponds to `--target`).
-    pub target: Option<String>,
+    pub(crate) target: Option<TargetTriple>,
 
     /// Require that `Cargo.lock` remains unchanged (corresponds to `--locked`).
-    pub locked: bool,
+    pub(crate) locked: bool,
 
     /// Run without accessing the network (corresponds to `--offline`).
-    pub offline: bool,
+    pub(crate) offline: bool,
 
     /// Number of parallel jobs for compilation (corresponds to `-j`/`--jobs`).
     ///
     /// When `None`, cargo uses its default (number of CPUs).
-    pub jobs: Option<usize>,
+    pub(crate) jobs: Option<usize>,
 
     /// Ignore `rust-version` specification in packages (corresponds to `--ignore-rust-version`).
-    pub ignore_rust_version: bool,
+    pub(crate) ignore_rust_version: bool,
 
     /// Which executable within the crate to build.
-    pub build_target: BuildTarget,
+    pub(crate) build_target: BuildTarget,
 
     /// Rust toolchain override to use for this build (e.g., "nightly", "1.70.0", "stable").
     ///
     /// When set, Cargo is run through `rustup run <toolchain>`.
-    pub toolchain: Option<String>,
+    pub(crate) toolchain: Option<String>,
 }
 
 impl Default for BuildOptions {
@@ -153,6 +154,61 @@ impl Default for BuildOptions {
 }
 
 impl BuildOptions {
+    /// Features to activate.
+    pub fn features(&self) -> &[String] {
+        &self.features
+    }
+
+    /// Whether all available features are activated.
+    pub fn all_features(&self) -> bool {
+        self.all_features
+    }
+
+    /// Whether the default feature is disabled.
+    pub fn no_default_features(&self) -> bool {
+        self.no_default_features
+    }
+
+    /// The build profile to use.
+    pub fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
+    }
+
+    /// The explicit target triple for cross-compilation, if one was requested.
+    pub fn target(&self) -> Option<&str> {
+        self.target.as_ref().map(TargetTriple::as_str)
+    }
+
+    /// Whether `Cargo.lock` must remain unchanged.
+    pub fn locked(&self) -> bool {
+        self.locked
+    }
+
+    /// Whether Cargo should run without accessing the network.
+    pub fn offline(&self) -> bool {
+        self.offline
+    }
+
+    /// The requested number of parallel jobs for compilation.
+    pub fn jobs(&self) -> Option<usize> {
+        self.jobs
+    }
+
+    /// Whether to ignore package `rust-version` declarations.
+    pub fn ignore_rust_version(&self) -> bool {
+        self.ignore_rust_version
+    }
+
+    /// Which executable within the crate to build.
+    pub fn build_target(&self) -> &BuildTarget {
+        &self.build_target
+    }
+
+    /// The Rust toolchain override to use for this build.
+    pub fn toolchain(&self) -> Option<&str> {
+        self.toolchain.as_deref()
+    }
+
     /// Merge build options from config and already-translated CLI overrides, with proper
     /// precedence.
     ///
@@ -163,6 +219,12 @@ impl BuildOptions {
     /// which the CLI front-end has already produced from the raw arguments (tokenizing
     /// features, folding `--debug`, resolving `--bin`/`--example`).
     pub fn load(config: &Config, overrides: &BuildOverrides) -> Result<Self> {
+        let target = overrides
+            .target
+            .clone()
+            .map(TargetTriple::from_owned)
+            .transpose()?;
+
         Ok(BuildOptions {
             // These come from the config settings, `Config` will already apply any CLI overrides
             locked: config.locked,
@@ -176,7 +238,7 @@ impl BuildOptions {
             all_features: overrides.all_features,
             no_default_features: overrides.no_default_features,
             profile: overrides.profile.clone(),
-            target: overrides.target.clone(),
+            target,
             jobs: overrides.jobs,
             ignore_rust_version: overrides.ignore_rust_version,
             build_target: overrides.target_selection.clone(),
@@ -228,14 +290,11 @@ impl BuildOptions {
 
     /// The resolved Rust target triple this build targets: the explicit `--target`, or cgx's own
     /// host triple ([`build_context::TARGET`]) when none was given.
-    ///
-    /// This matches how cgx resolves the platform everywhere else (pre-built binary lookup, cargo
-    /// metadata filtering, and the build cache), so it reliably names the triple the binary is for
-    /// even on a default build where cargo writes to `target/debug` rather than a triple subdir.
-    pub(crate) fn target_platform(&self) -> String {
-        self.target
-            .clone()
-            .unwrap_or_else(|| build_context::TARGET.to_string())
+    pub(crate) fn target_platform(&self) -> &TargetTriple {
+        match &self.target {
+            Some(target) => target,
+            None => TargetTriple::host(),
+        }
     }
 }
 
@@ -1223,7 +1282,7 @@ mod tests {
             );
             let options2 = BuildOptions {
                 profile: Some("dev".to_string()),
-                target: Some(build_context::TARGET.to_string()),
+                target: Some(TargetTriple::host().clone()),
                 ..Default::default()
             };
             let (binary2, _target) = builder.build(&krate2, &options2).unwrap();
@@ -1912,7 +1971,10 @@ mod tests {
                 let cli = Cli::parse_from_test_args(["--target", "x86_64-unknown-linux-gnu", "tool"]);
                 let options = BuildOptions::load(&config, &cli.crate_args().to_build_overrides()).unwrap();
 
-                assert_eq!(options.target, Some("x86_64-unknown-linux-gnu".to_string()));
+                assert_eq!(
+                    options.target.as_ref().map(TargetTriple::as_str),
+                    Some("x86_64-unknown-linux-gnu")
+                );
             }
 
             /// Test that `--jobs` flag is passed through.

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -233,7 +233,7 @@ impl Cache {
         })?;
 
         // Create a temp directory in the same parent directory for atomic rename
-        let temp_dir = tempfile::tempdir_in(parent).with_context(|_| error::TempDirCreationSnafu {
+        let temp_dir = tempfile::tempdir_in(parent).with_context(|_| error::TempDirInCreationSnafu {
             parent: parent.to_path_buf(),
         })?;
 

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -62,12 +62,19 @@ type CrateResolveCacheEntry = CacheEntry<ResolvedCrate>;
 
 /// Manages the various caches that cgx uses to operate.
 ///
-/// The root of the caches is controlled by [`Config::cache_dir`].  Below that are multiple
-/// subdirectories for caching various things:
+/// Most caches root at [`Config::cache_dir`], with a subdirectory per concern:
 /// - Results of crate spec resolution
+/// - Binary-resolution outcomes for prebuilt binaries
 /// - Downloaded/extracted crate source code packages
 /// - Git database (bare repos)
 /// - Git checkouts at specific commits
+///
+/// The binaries themselves are the exception: they live under [`Config::bin_dir`], rooted per
+/// crate at [`Cache::crate_bin_root`], keeping executables separate from the disposable download
+/// and metadata caches.  You might argue that that's not a cache at all and that this logic
+/// doesn't belong in a type called `Cache`.  I might argue that you're being unnecessarily
+/// pedantic and that the bin dir is absolutely a cache, in that if you delete it we have to do
+/// more work again to get the binaries back.
 ///
 /// More may be added over time.
 #[derive(Clone, Debug)]
@@ -233,9 +240,12 @@ impl Cache {
         })?;
 
         // Create a temp directory in the same parent directory for atomic rename
-        let temp_dir = tempfile::tempdir_in(parent).with_context(|_| error::TempDirInCreationSnafu {
-            parent: parent.to_path_buf(),
-        })?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix(&format!("cgx-download-{}-temp", &resolved.name))
+            .tempdir_in(parent)
+            .with_context(|_| error::TempDirInCreationSnafu {
+                parent: parent.to_path_buf(),
+            })?;
 
         // Call the downloader with the temp path
         downloader(temp_dir.path())?;
@@ -326,7 +336,10 @@ impl Cache {
     ///
     /// Returns `Ok(None)` when there is no cache entry for the crate, or `Ok(Some(entry))` carrying
     /// the cached resolution outcome.
-    pub(crate) fn get_cached_binary(&self, krate: &ResolvedCrate) -> Result<Option<BinaryCacheEntry>> {
+    pub(crate) fn get_cached_binary_resolution(
+        &self,
+        krate: &ResolvedCrate,
+    ) -> Result<Option<BinaryCacheEntry>> {
         self.inner
             .reporter
             .report(|| PrebuiltBinaryMessage::cache_lookup(krate));
@@ -342,7 +355,11 @@ impl Cache {
     }
 
     /// Store a binary-resolution cache entry for the given [`ResolvedCrate`].
-    pub(crate) fn put_cached_binary(&self, krate: &ResolvedCrate, entry: BinaryCacheEntry) -> Result<()> {
+    pub(crate) fn put_cached_binary_resolution(
+        &self,
+        krate: &ResolvedCrate,
+        entry: BinaryCacheEntry,
+    ) -> Result<()> {
         let cache_file = self.binary_cache_path(krate)?;
 
         if let Some(parent) = cache_file.parent() {
@@ -547,6 +564,20 @@ impl Cache {
         Ok(path)
     }
 
+    /// Get the root directory under [`Config::bin_dir`] holding all binaries for one resolved
+    /// crate: `<bin_dir>/<name>-<version>/<source-hash>/`.
+    ///
+    /// Callers are expected to append their own leaf directory to this path.  A given bin root can
+    /// contain either binaries built from source or prebuilt binaries obtained from various
+    /// sources; each caller is responsible for avoiding collisions with all other callers.
+    pub(crate) fn crate_bin_root(&self, krate: &ResolvedCrate) -> PathBuf {
+        self.inner
+            .config
+            .bin_dir
+            .join(format!("{}-{}", krate.name, krate.version))
+            .join(krate.source.source_hash())
+    }
+
     /// Get the cache path for a git database (bare repo) for a URL.
     pub(crate) fn git_db_path(&self, url: &str) -> PathBuf {
         let ident = Self::compute_git_ident(url);
@@ -662,17 +693,10 @@ impl Cache {
             .reporter
             .report(|| BuildCacheMessage::cache_lookup(krate, options));
 
-        let source_hash = Self::compute_source_hash(&krate.source);
         let build_hash = Self::compute_build_hash(options);
         let binary_name = Self::expected_binary_name(&krate.name, &options.build_target);
 
-        let cache_dir = self
-            .inner
-            .config
-            .bin_dir
-            .join(format!("{}-{}", krate.name, krate.version))
-            .join(source_hash)
-            .join(build_hash);
+        let cache_dir = self.crate_bin_root(krate).join(build_hash);
 
         let cache_path = cache_dir.join(&binary_name);
         let sbom_path = cache_dir.join("sbom.cyclonedx.json");
@@ -722,25 +746,6 @@ impl Cache {
             .report(|| BuildCacheMessage::cache_stored(&cache_path, &sbom_path));
 
         Ok(cache_path)
-    }
-
-    /// Compute a hash of the resolved source to distinguish different crate origins.
-    ///
-    /// Different sources (crates.io vs git vs forge) will produce different hashes
-    /// even for the same crate name and version.
-    ///
-    /// Uses SHA-256 over the source's JSON serialization, so the resulting build-cache paths are
-    /// stable across toolchains and platforms (presuming, of course, that the JSON serialized
-    /// representation of the source is itself stable across toolchains and platforms, which we
-    /// hope that it is).
-    fn compute_source_hash(source: &ResolvedSource) -> String {
-        // It makes absolutely no sense to try to cache a local dir source!  Higher-level code
-        // should have already bypassed the cache for this source.
-        if matches!(source, ResolvedSource::LocalDir { .. }) {
-            panic!("BUG: Should not compute a build-cache hash for LocalDir sources");
-        }
-
-        source.source_hash()
     }
 
     /// Compute a hash of build options that affect the output binary.
@@ -829,12 +834,8 @@ mod tests {
     use super::*;
     use crate::{
         bin_resolver::{BinaryCacheEntry, ConclusiveResolution, ResolvedBinary},
-        target::TargetTriple,
+        testdata::target_triple,
     };
-
-    fn target(target: &'static str) -> TargetTriple {
-        TargetTriple::from_static(target).unwrap()
-    }
 
     fn test_cache() -> (Cache, TempDir) {
         test_cache_with_timeout(Duration::from_secs(3600))
@@ -935,6 +936,7 @@ mod tests {
                             },
                             provider: BinaryProvider::GithubReleases,
                             path: PathBuf::from("/cache/bin/eza"),
+                            target: "x86_64-pc-windows-gnu".to_string(),
                         }),
                         enabled_providers: vec![
                             BinaryProvider::Binstall,
@@ -970,6 +972,7 @@ mod tests {
   },
   "provider": "github-releases",
   "path": "/cache/bin/eza",
+  "target": "x86_64-pc-windows-gnu",
   "enabled_providers": [
     "binstall",
     "github-releases",
@@ -1278,7 +1281,8 @@ mod tests {
                     source: ResolvedSource::CratesIo,
                 };
                 assert_eq!(
-                    Cache::compute_binary_cache_hash(&krate, &target("x86_64-unknown-linux-gnu")).unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target_triple("x86_64-unknown-linux-gnu"))
+                        .unwrap(),
                     "e73c84363ece02d92a3dfe4ff390dcbe0dbe3381f050280505a1adb3916fad78"
                 );
             }
@@ -1291,8 +1295,9 @@ mod tests {
                     source: ResolvedSource::CratesIo,
                 };
                 assert_ne!(
-                    Cache::compute_binary_cache_hash(&krate, &target("x86_64-unknown-linux-gnu")).unwrap(),
-                    Cache::compute_binary_cache_hash(&krate, &target("aarch64-apple-darwin")).unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target_triple("x86_64-unknown-linux-gnu"))
+                        .unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target_triple("aarch64-apple-darwin")).unwrap(),
                 );
             }
         }
@@ -1306,7 +1311,7 @@ mod tests {
             #[test]
             fn source_hash_crates_io() {
                 assert_eq!(
-                    Cache::compute_source_hash(&ResolvedSource::CratesIo),
+                    ResolvedSource::CratesIo.source_hash(),
                     "797cfdcfdf4d45ed0d3963577b0e549fe0c37295320d320d7173bfcf7bc42842"
                 );
             }
@@ -1326,7 +1331,7 @@ mod tests {
                     all_features: false,
                     no_default_features: true,
                     profile: Some("release".to_string()),
-                    target: Some(target("x86_64-unknown-linux-gnu")),
+                    target: Some(target_triple("x86_64-unknown-linux-gnu")),
                     build_target: BuildTarget::Bin("mybin".to_string()),
                     toolchain: Some("stable".to_string()),
                     locked: true,
@@ -1939,11 +1944,11 @@ mod tests {
         #[test]
         fn different_target_produces_different_hash() {
             let options1 = BuildOptions {
-                target: Some(target("x86_64-unknown-linux-gnu")),
+                target: Some(target_triple("x86_64-unknown-linux-gnu")),
                 ..Default::default()
             };
             let options2 = BuildOptions {
-                target: Some(target("aarch64-unknown-linux-gnu")),
+                target: Some(target_triple("aarch64-unknown-linux-gnu")),
                 ..Default::default()
             };
 
@@ -2095,54 +2100,60 @@ mod tests {
 
         #[test]
         fn source_hash_distinguishes_crates_io() {
-            let hash = Cache::compute_source_hash(&ResolvedSource::CratesIo);
+            let hash = ResolvedSource::CratesIo.source_hash();
             assert_eq!(hash.len(), 64, "SHA-256 hash should be 64 hex chars");
         }
 
         #[test]
         fn source_hash_distinguishes_git() {
-            let hash1 = Cache::compute_source_hash(&ResolvedSource::Git {
+            let hash1 = ResolvedSource::Git {
                 repo: "https://github.com/rust-lang/cargo".to_string(),
                 commit: "abc123".to_string(),
-            });
-            let hash2 = Cache::compute_source_hash(&ResolvedSource::Git {
+            }
+            .source_hash();
+            let hash2 = ResolvedSource::Git {
                 repo: "https://github.com/rust-lang/cargo".to_string(),
                 commit: "def456".to_string(),
-            });
+            }
+            .source_hash();
 
             assert_ne!(hash1, hash2, "Different commits should produce different hashes");
         }
 
         #[test]
         fn source_hash_distinguishes_forge() {
-            let hash1 = Cache::compute_source_hash(&ResolvedSource::Forge {
+            let hash1 = ResolvedSource::Forge {
                 forge: Forge::GitHub {
                     custom_url: None,
                     owner: "rust-lang".to_string(),
                     repo: "cargo".to_string(),
                 },
                 commit: "abc123".to_string(),
-            });
-            let hash2 = Cache::compute_source_hash(&ResolvedSource::Forge {
+            }
+            .source_hash();
+            let hash2 = ResolvedSource::Forge {
                 forge: Forge::GitHub {
                     custom_url: None,
                     owner: "rust-lang".to_string(),
                     repo: "cargo".to_string(),
                 },
                 commit: "def456".to_string(),
-            });
+            }
+            .source_hash();
 
             assert_ne!(hash1, hash2, "Different commits should produce different hashes");
         }
 
         #[test]
         fn source_hash_distinguishes_registry() {
-            let hash1 = Cache::compute_source_hash(&ResolvedSource::Registry {
+            let hash1 = ResolvedSource::Registry {
                 source: RegistrySource::Named("my-registry".to_string()),
-            });
-            let hash2 = Cache::compute_source_hash(&ResolvedSource::Registry {
+            }
+            .source_hash();
+            let hash2 = ResolvedSource::Registry {
                 source: RegistrySource::Named("other-registry".to_string()),
-            });
+            }
+            .source_hash();
 
             assert_ne!(
                 hash1, hash2,
@@ -2215,10 +2226,10 @@ mod tests {
             let krate = test_resolved();
             let providers = vec![BinaryProvider::Binstall, BinaryProvider::GithubReleases];
 
-            assert_matches!(cache.get_cached_binary(&krate), Ok(None));
+            assert_matches!(cache.get_cached_binary_resolution(&krate), Ok(None));
 
             cache
-                .put_cached_binary(
+                .put_cached_binary_resolution(
                     &krate,
                     BinaryCacheEntry {
                         outcome: ConclusiveResolution::Nonexistent,
@@ -2227,7 +2238,7 @@ mod tests {
                 )
                 .unwrap();
 
-            let entry = cache.get_cached_binary(&krate).unwrap().unwrap();
+            let entry = cache.get_cached_binary_resolution(&krate).unwrap().unwrap();
             assert_eq!(entry.outcome, ConclusiveResolution::Nonexistent);
             assert_eq!(entry.enabled_providers, providers);
         }
@@ -2238,7 +2249,7 @@ mod tests {
             let krate = test_resolved();
 
             cache
-                .put_cached_binary(
+                .put_cached_binary_resolution(
                     &krate,
                     BinaryCacheEntry {
                         outcome: ConclusiveResolution::Nonexistent,
@@ -2252,12 +2263,13 @@ mod tests {
                     krate: test_resolved(),
                     provider: BinaryProvider::GithubReleases,
                     path: PathBuf::from("/cache/bin/serde"),
+                    target: build_context::TARGET.to_string(),
                 }),
                 enabled_providers: vec![BinaryProvider::GithubReleases],
             };
-            cache.put_cached_binary(&krate, found.clone()).unwrap();
+            cache.put_cached_binary_resolution(&krate, found.clone()).unwrap();
 
-            let entry = cache.get_cached_binary(&krate).unwrap().unwrap();
+            let entry = cache.get_cached_binary_resolution(&krate).unwrap().unwrap();
             assert_eq!(entry, found);
         }
     }

--- a/cgx-core/src/cache.rs
+++ b/cgx-core/src/cache.rs
@@ -21,6 +21,7 @@ use crate::{
     downloader::DownloadedCrate,
     error,
     messages::{BuildCacheMessage, CrateResolutionMessage, PrebuiltBinaryMessage, SourceMessage},
+    target::TargetTriple,
 };
 
 /// A cache entry wrapping a value with timestamp metadata.
@@ -414,7 +415,7 @@ impl Cache {
     /// This ensures that binaries are cached per-platform, which is essential since pre-built
     /// binaries are platform-specific.
     fn binary_cache_path(&self, krate: &ResolvedCrate) -> Result<PathBuf> {
-        let hash = Self::compute_binary_cache_hash(krate, build_context::TARGET)?;
+        let hash = Self::compute_binary_cache_hash(krate, TargetTriple::host())?;
         Ok(self
             .inner
             .config
@@ -431,22 +432,22 @@ impl Cache {
     /// - Resolved source (crates.io vs git vs forge, etc.)
     /// - The target platform triple
     ///
-    /// `platform` is a parameter so the hash is distinct and testable for a fixed platform. This
+    /// `target` is a parameter so the hash is distinct and testable for a fixed platform. This
     /// ensures the same crate on different platforms gets different cache entries.
-    fn compute_binary_cache_hash(krate: &ResolvedCrate, platform: &str) -> Result<String> {
+    fn compute_binary_cache_hash(krate: &ResolvedCrate, target: &TargetTriple) -> Result<String> {
         #[derive(Serialize)]
         struct BinaryCacheKey<'a> {
             name: &'a str,
             version: &'a semver::Version,
             source: &'a ResolvedSource,
-            platform: &'a str,
+            platform: &'a TargetTriple,
         }
 
         let key = BinaryCacheKey {
             name: &krate.name,
             version: &krate.version,
             source: &krate.source,
-            platform,
+            platform: target,
         };
 
         let json = serde_json::to_string(&key).context(error::JsonSnafu)?;
@@ -770,7 +771,7 @@ impl Cache {
             all_features: bool,
             no_default_features: bool,
             profile: &'a Option<String>,
-            target: &'a Option<String>,
+            target: &'a Option<TargetTriple>,
             build_target: &'a BuildTarget,
             toolchain: &'a Option<String>,
             locked: bool,
@@ -826,7 +827,14 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::bin_resolver::{BinaryCacheEntry, ConclusiveResolution, ResolvedBinary};
+    use crate::{
+        bin_resolver::{BinaryCacheEntry, ConclusiveResolution, ResolvedBinary},
+        target::TargetTriple,
+    };
+
+    fn target(target: &'static str) -> TargetTriple {
+        TargetTriple::from_static(target).unwrap()
+    }
 
     fn test_cache() -> (Cache, TempDir) {
         test_cache_with_timeout(Duration::from_secs(3600))
@@ -1262,8 +1270,6 @@ mod tests {
         mod binary_cache_hash {
             use super::*;
 
-            const PLATFORM: &str = "x86_64-unknown-linux-gnu";
-
             #[test]
             fn crates_io() {
                 let krate = ResolvedCrate {
@@ -1272,7 +1278,7 @@ mod tests {
                     source: ResolvedSource::CratesIo,
                 };
                 assert_eq!(
-                    Cache::compute_binary_cache_hash(&krate, PLATFORM).unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target("x86_64-unknown-linux-gnu")).unwrap(),
                     "e73c84363ece02d92a3dfe4ff390dcbe0dbe3381f050280505a1adb3916fad78"
                 );
             }
@@ -1285,8 +1291,8 @@ mod tests {
                     source: ResolvedSource::CratesIo,
                 };
                 assert_ne!(
-                    Cache::compute_binary_cache_hash(&krate, "x86_64-unknown-linux-gnu").unwrap(),
-                    Cache::compute_binary_cache_hash(&krate, "aarch64-apple-darwin").unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target("x86_64-unknown-linux-gnu")).unwrap(),
+                    Cache::compute_binary_cache_hash(&krate, &target("aarch64-apple-darwin")).unwrap(),
                 );
             }
         }
@@ -1320,7 +1326,7 @@ mod tests {
                     all_features: false,
                     no_default_features: true,
                     profile: Some("release".to_string()),
-                    target: Some("x86_64-unknown-linux-gnu".to_string()),
+                    target: Some(target("x86_64-unknown-linux-gnu")),
                     build_target: BuildTarget::Bin("mybin".to_string()),
                     toolchain: Some("stable".to_string()),
                     locked: true,
@@ -1933,11 +1939,11 @@ mod tests {
         #[test]
         fn different_target_produces_different_hash() {
             let options1 = BuildOptions {
-                target: Some("x86_64-unknown-linux-gnu".to_string()),
+                target: Some(target("x86_64-unknown-linux-gnu")),
                 ..Default::default()
             };
             let options2 = BuildOptions {
-                target: Some("aarch64-unknown-linux-gnu".to_string()),
+                target: Some(target("aarch64-unknown-linux-gnu")),
                 ..Default::default()
             };
 

--- a/cgx-core/src/cargo.rs
+++ b/cgx-core/src/cargo.rs
@@ -15,6 +15,7 @@ use crate::{
     config::{Config, Verbosity},
     error,
     messages::{BuildMessage, MessageReporter},
+    target::TargetTriple,
 };
 
 /// Options for controlling cargo metadata invocation.
@@ -27,7 +28,7 @@ pub(crate) struct CargoMetadataOptions {
 
     /// Only include dependencies for the specified target platform.
     /// Corresponds to `--filter-platform TARGET` flag.
-    pub filter_platform: Option<String>,
+    pub filter_platform: Option<TargetTriple>,
 
     /// Space or comma separated list of features to activate.
     /// Corresponds to `--features` flag.
@@ -193,15 +194,15 @@ impl RealCargoRunner {
         // deps for all platforms mixed together. Default to current platform if not specified.
         let platform: Option<&str> = if options.no_deps {
             // When not resolving deps, platform filtering doesn't matter
-            options.filter_platform.as_deref()
+            options.filter_platform.as_ref().map(TargetTriple::as_str)
         } else {
             // When resolving deps, MUST filter by platform
             // Default to current platform if not specified
             Some(
                 options
                     .filter_platform
-                    .as_deref()
-                    .unwrap_or(build_context::TARGET),
+                    .as_ref()
+                    .map_or_else(|| TargetTriple::host().as_str(), TargetTriple::as_str),
             )
         };
 
@@ -335,7 +336,7 @@ impl CargoRunner for RealCargoRunner {
 
         // Target triple for cross-compilation
         if let Some(target) = &options.target {
-            cmd.args(["--target", target]);
+            cmd.args(["--target", target.as_str()]);
         }
 
         // Build target (bin/example)

--- a/cgx-core/src/cli.rs
+++ b/cgx-core/src/cli.rs
@@ -1847,7 +1847,10 @@ mod tests {
         fn test_target() {
             let opts =
                 parse_build_options_from_args(&["--target", "x86_64-unknown-linux-musl", "ripgrep"]).unwrap();
-            assert_eq!(opts.target, Some("x86_64-unknown-linux-musl".to_string()));
+            assert_eq!(
+                opts.target.as_ref().map(|target| target.as_str()),
+                Some("x86_64-unknown-linux-musl")
+            );
         }
 
         #[test]

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -139,9 +139,6 @@ pub enum Error {
     #[snafu(display("Failed to create temporary directory in {}: {}", parent.display(), source))]
     TempDirInCreation { parent: PathBuf, source: std::io::Error },
 
-    #[snafu(display("Failed to create temporary directory: {}", source))]
-    TempDirCreation { source: std::io::Error },
-
     #[snafu(display("Failed to execute command: {}", source))]
     CommandExecution { source: std::io::Error },
 
@@ -308,9 +305,6 @@ pub enum Error {
         template: String,
         source: leon::RenderError,
     },
-
-    #[snafu(display("Invalid target triple '{target}': {message}"))]
-    InvalidTargetTriple { target: String, message: String },
 
     #[snafu(display("Failed to build HTTP client: {message}"))]
     HttpClientBuild { message: String },

--- a/cgx-core/src/error.rs
+++ b/cgx-core/src/error.rs
@@ -137,7 +137,10 @@ pub enum Error {
     },
 
     #[snafu(display("Failed to create temporary directory in {}: {}", parent.display(), source))]
-    TempDirCreation { parent: PathBuf, source: std::io::Error },
+    TempDirInCreation { parent: PathBuf, source: std::io::Error },
+
+    #[snafu(display("Failed to create temporary directory: {}", source))]
+    TempDirCreation { source: std::io::Error },
 
     #[snafu(display("Failed to execute command: {}", source))]
     CommandExecution { source: std::io::Error },

--- a/cgx-core/src/lib.rs
+++ b/cgx-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod messages;
 pub(crate) mod registry;
 pub mod runner;
 pub(crate) mod sbom;
+pub(crate) mod target;
 #[cfg(test)]
 pub(crate) mod testdata;
 

--- a/cgx-core/src/lib.rs
+++ b/cgx-core/src/lib.rs
@@ -77,7 +77,7 @@ impl Cgx {
             cache.clone(),
             reporter.clone(),
             http_client.clone(),
-        ));
+        )?);
 
         let downloader = Arc::new(downloader::create_downloader(
             config.clone(),
@@ -129,8 +129,7 @@ impl Cgx {
                     &downloaded_crate.resolved,
                     &downloaded_crate.crate_path,
                     &build_options,
-                    provider,
-                    &resolved_binary.path,
+                    &resolved_binary,
                 )
             });
             return Ok(resolved_binary.path);

--- a/cgx-core/src/messages/cgx.rs
+++ b/cgx-core/src/messages/cgx.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::Message;
 use crate::{
+    bin_resolver::ResolvedBinary,
     builder::{BuildOptions, BuildTarget},
     config::BinaryProvider,
     crate_resolver::ResolvedCrate,
@@ -44,6 +45,10 @@ pub enum CgxMessage {
         /// The build options cgx chose for this invocation.
         options: BuildOptions,
         /// The Rust target triple this binary is for (the explicit `--target`, or the host triple).
+        ///
+        /// The reported target platform pertains to the resolved binary itself, not from the build
+        /// options: the binary may be for an ABI-compatible fallback of the host (a musl binary on
+        /// a glibc host, an msvc PE on a windows-gnu host, etc)
         target_platform: String,
         /// Whether the binary was built from source or downloaded pre-built, and where it is.
         provenance: Provenance,
@@ -108,17 +113,16 @@ impl CgxMessage {
         resolved: &ResolvedCrate,
         crate_path: &Path,
         options: &BuildOptions,
-        provider: BinaryProvider,
-        binary_path: &Path,
+        binary: &ResolvedBinary,
     ) -> Self {
         Self::CrateProvenance {
             resolved: resolved.clone(),
             crate_path: crate_path.to_path_buf(),
-            target_platform: options.target_platform().to_string(),
+            target_platform: binary.target.clone(),
             options: options.clone(),
             provenance: Provenance::Prebuilt {
-                provider,
-                binary_path: binary_path.to_path_buf(),
+                provider: binary.provider,
+                binary_path: binary.path.clone(),
             },
         }
     }

--- a/cgx-core/src/messages/cgx.rs
+++ b/cgx-core/src/messages/cgx.rs
@@ -78,7 +78,7 @@ impl CgxMessage {
         Self::CratePlan {
             resolved: resolved.clone(),
             crate_path: crate_path.to_path_buf(),
-            target_platform: options.target_platform(),
+            target_platform: options.target_platform().to_string(),
             options: options.clone(),
         }
     }
@@ -94,7 +94,7 @@ impl CgxMessage {
         Self::CrateProvenance {
             resolved: resolved.clone(),
             crate_path: crate_path.to_path_buf(),
-            target_platform: options.target_platform(),
+            target_platform: options.target_platform().to_string(),
             options: options.clone(),
             provenance: Provenance::BuiltFromSource {
                 binary_path: binary_path.to_path_buf(),
@@ -114,7 +114,7 @@ impl CgxMessage {
         Self::CrateProvenance {
             resolved: resolved.clone(),
             crate_path: crate_path.to_path_buf(),
-            target_platform: options.target_platform(),
+            target_platform: options.target_platform().to_string(),
             options: options.clone(),
             provenance: Provenance::Prebuilt {
                 provider,

--- a/cgx-core/src/messages/mod.rs
+++ b/cgx-core/src/messages/mod.rs
@@ -28,6 +28,11 @@ pub use crate::git::GitSelector;
 /// Messages are serialized as tagged JSON with a "type" field indicating the subsystem.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "the target refactor increases the largest variant by only about 40 bytes, just enough to \
+              cross the lint threshold"
+)]
 pub enum Message {
     CrateResolution(CrateResolutionMessage),
     PrebuiltBinary(PrebuiltBinaryMessage),

--- a/cgx-core/src/messages/prebuilt_binary.rs
+++ b/cgx-core/src/messages/prebuilt_binary.rs
@@ -41,6 +41,9 @@ pub enum PrebuiltBinaryMessage {
         krate: ResolvedCrate,
         reason: ProviderChangeReason,
     },
+    /// A cached positive prebuilt binary resolution existed but the binary it points to is no
+    /// longer on disk, so the entry was discarded and the crate will be re-resolved.
+    CacheInvalidatedByMissingBinary { krate: ResolvedCrate, path: PathBuf },
     /// Checking a specific binary provider for prebuilt binaries
     CheckingProvider {
         krate: ResolvedCrate,
@@ -110,6 +113,13 @@ impl PrebuiltBinaryMessage {
         Self::CacheInvalidatedByProviderChange {
             krate: krate.clone(),
             reason,
+        }
+    }
+
+    pub fn cache_invalidated_by_missing_binary(krate: &ResolvedCrate, path: &std::path::Path) -> Self {
+        Self::CacheInvalidatedByMissingBinary {
+            krate: krate.clone(),
+            path: path.to_path_buf(),
         }
     }
 

--- a/cgx-core/src/sbom.rs
+++ b/cgx-core/src/sbom.rs
@@ -241,7 +241,7 @@ fn build_main_component(resolved: &ResolvedCrate, options: &BuildOptions) -> Res
         properties.push(
             PropertyBuilder::default()
                 .name("build:target")
-                .value(target.clone())
+                .value(target.to_string())
                 .build()
                 .map_err(|e| {
                     crate::error::SbomBuilderSnafu {
@@ -461,8 +461,13 @@ pub(crate) mod tests {
     use crate::{
         cargo::{CargoMetadataOptions, CargoRunner},
         crate_resolver::ResolvedSource,
+        target::TargetTriple,
         testdata::CrateTestCase,
     };
+
+    fn target(target: &'static str) -> TargetTriple {
+        TargetTriple::from_static(target).unwrap()
+    }
 
     /// Get a [`CargoRunner`] for testing.
     ///
@@ -939,7 +944,7 @@ pub(crate) mod tests {
         let options = BuildOptions {
             profile: Some("release".to_string()),
             all_features: true,
-            target: Some("x86_64-unknown-linux-musl".to_string()),
+            target: Some(target("x86_64-unknown-linux-musl")),
             toolchain: Some("stable".to_string()),
             ..Default::default()
         };

--- a/cgx-core/src/sbom.rs
+++ b/cgx-core/src/sbom.rs
@@ -461,13 +461,8 @@ pub(crate) mod tests {
     use crate::{
         cargo::{CargoMetadataOptions, CargoRunner},
         crate_resolver::ResolvedSource,
-        target::TargetTriple,
-        testdata::CrateTestCase,
+        testdata::{CrateTestCase, target_triple},
     };
-
-    fn target(target: &'static str) -> TargetTriple {
-        TargetTriple::from_static(target).unwrap()
-    }
 
     /// Get a [`CargoRunner`] for testing.
     ///
@@ -944,7 +939,7 @@ pub(crate) mod tests {
         let options = BuildOptions {
             profile: Some("release".to_string()),
             all_features: true,
-            target: Some(target("x86_64-unknown-linux-musl")),
+            target: Some(target_triple("x86_64-unknown-linux-musl")),
             toolchain: Some("stable".to_string()),
             ..Default::default()
         };

--- a/cgx-core/src/target.rs
+++ b/cgx-core/src/target.rs
@@ -1,0 +1,320 @@
+use std::{
+    borrow::Cow,
+    fmt,
+    hash::{Hash, Hasher},
+    str::FromStr,
+    sync::OnceLock,
+};
+
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Visitor},
+};
+use target_lexicon::{Architecture, Environment, OperatingSystem, Triple, Vendor};
+
+use crate::{Result, error};
+
+/// Strongly typed representation of a Rust target triple string, with parsed components and
+/// convenience methods.
+///
+/// This spares us the ugly and error-prone stringly-typed handling of targets, and gives us a
+/// single place to implement logic around target-specific behavior in a form that we can more
+/// easily unit test.
+#[derive(Clone, Debug)]
+pub(crate) struct TargetTriple {
+    raw: Cow<'static, str>,
+    triple: Triple,
+}
+
+impl TargetTriple {
+    pub(crate) fn from_static(target: &'static str) -> Result<Self> {
+        Self::parse(Cow::Borrowed(target))
+    }
+
+    pub(crate) fn from_owned(target: String) -> Result<Self> {
+        Self::parse(Cow::Owned(target))
+    }
+
+    pub(crate) fn host() -> &'static Self {
+        static HOST: OnceLock<TargetTriple> = OnceLock::new();
+        HOST.get_or_init(|| {
+            Self::from_static(build_context::TARGET)
+                .expect("build_context::TARGET must be a valid target triple")
+        })
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub(crate) fn as_cow(&self) -> Cow<'_, str> {
+        Cow::Borrowed(self.as_str())
+    }
+
+    pub(crate) fn triple(&self) -> &Triple {
+        &self.triple
+    }
+
+    pub(crate) fn architecture(&self) -> Architecture {
+        self.triple().architecture
+    }
+
+    pub(crate) fn operating_system(&self) -> OperatingSystem {
+        self.triple().operating_system
+    }
+
+    pub(crate) fn environment(&self) -> Environment {
+        self.triple().environment
+    }
+
+    pub(crate) fn vendor(&self) -> &Vendor {
+        &self.triple().vendor
+    }
+
+    pub(crate) fn is_windows(&self) -> bool {
+        self.operating_system() == OperatingSystem::Windows
+    }
+
+    /// Returns true if the target is macOS or another Apple platform (e.g., iOS, tvOS, watchOS).
+    ///
+    /// There are many different target OS values for the various Apple platforms, but for our
+    /// purposes they are all "macos-like".
+    pub(crate) fn is_macos_like(&self) -> bool {
+        self.operating_system().is_like_darwin()
+    }
+
+    pub(crate) fn binary_ext(&self) -> &'static str {
+        if self.is_windows() { ".exe" } else { "" }
+    }
+
+    /// Platform tokens to try when matching release asset filenames.
+    ///
+    /// Release assets are not named consistently across projects. Some use the exact Rust target
+    /// triple (`x86_64-unknown-linux-gnu`), while others use shorter `{os}-{arch}` or `{arch}-{os}`
+    /// forms (`linux-x86_64`, `x86_64-linux`). This returns the full triple first because it is the
+    /// most specific token, then appends those common short forms for Linux, Windows, and
+    /// Darwin-like Apple targets. Other targets get only their exact triple, since each of the
+    /// shorter variants were based on actual observed release asset naming conventions that may
+    /// not generalize to other platforms.
+    pub(crate) fn release_asset_platform_aliases(&self) -> Vec<Cow<'_, str>> {
+        // Keep the original, full triple first. It is the most specific so, if present, it should
+        // be used.
+        let mut aliases = vec![self.as_cow()];
+
+        // Convert the OS into a colloquial OS name most commonly used when naming release assets.
+        let os = if self.is_windows() {
+            "windows"
+        } else if self.is_macos_like() {
+            "darwin"
+        } else if self.operating_system() == OperatingSystem::Linux {
+            "linux"
+        } else {
+            // We don't know this OS so we can't generate any aliases for it. Just return the full triple.
+            return aliases;
+        };
+
+        let arch = self.architecture().into_str();
+
+        // Short aliases can collide with the full triple for unusual targets, so preserve priority
+        // order while dropping duplicates.
+        for alias in [format!("{}-{}", os, arch), format!("{}-{}", arch, os)] {
+            if !aliases.iter().any(|existing| existing.as_ref() == alias) {
+                aliases.push(Cow::Owned(alias));
+            }
+        }
+
+        aliases
+    }
+
+    fn parse(raw: Cow<'static, str>) -> Result<Self> {
+        let triple = Triple::from_str(raw.as_ref()).map_err(|source| {
+            error::InvalidTargetTripleSnafu {
+                target: raw.to_string(),
+                message: source.to_string(),
+            }
+            .build()
+        })?;
+        Ok(Self { raw, triple })
+    }
+}
+
+impl AsRef<str> for TargetTriple {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for TargetTriple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl PartialEq for TargetTriple {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl Eq for TargetTriple {}
+
+impl Hash for TargetTriple {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+// serde for the target triple is literally just preserving the string representation that it was
+// created from.
+
+impl Serialize for TargetTriple {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetTriple {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TargetTripleVisitor;
+
+        impl Visitor<'_> for TargetTripleVisitor {
+            type Value = TargetTriple;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a Rust target triple string")
+            }
+
+            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                TargetTriple::from_owned(value.to_string()).map_err(E::custom)
+            }
+
+            fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                TargetTriple::from_owned(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_string(TargetTripleVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use target_lexicon::{Architecture, Environment, OperatingSystem, Vendor};
+
+    use super::*;
+    use crate::error::Error;
+
+    #[test]
+    fn parses_valid_target() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(target.as_str(), "x86_64-unknown-linux-gnu");
+    }
+
+    #[test]
+    fn invalid_parse_reports_invalid_target_triple() {
+        assert_matches!(
+            TargetTriple::from_static("not-a-real-target"),
+            Err(Error::InvalidTargetTriple { .. })
+        );
+    }
+
+    #[test]
+    fn host_target_parses() {
+        assert_eq!(TargetTriple::host().as_str(), build_context::TARGET);
+    }
+
+    #[test]
+    fn exposes_original_string_forms() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(target.to_string(), "x86_64-unknown-linux-gnu");
+        assert_eq!(target.as_str(), "x86_64-unknown-linux-gnu");
+        assert_matches!(target.as_cow(), Cow::Borrowed("x86_64-unknown-linux-gnu"));
+    }
+
+    #[test]
+    fn exposes_typed_components() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(target.triple().architecture, Architecture::X86_64);
+        assert_eq!(target.architecture(), Architecture::X86_64);
+        assert_eq!(target.operating_system(), OperatingSystem::Linux);
+        assert_eq!(target.environment(), Environment::Gnu);
+        assert_eq!(target.vendor(), &Vendor::Unknown);
+    }
+
+    #[test]
+    fn windows_binary_extension() {
+        let windows = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
+        let linux = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(windows.binary_ext(), ".exe");
+        assert_eq!(linux.binary_ext(), "");
+    }
+
+    #[test]
+    fn linux_release_asset_aliases() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(
+            target.release_asset_platform_aliases(),
+            vec![
+                Cow::Borrowed("x86_64-unknown-linux-gnu"),
+                Cow::Owned("linux-x86_64".to_string()),
+                Cow::Owned("x86_64-linux".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn macos_release_asset_aliases_use_darwin() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+
+        assert_eq!(
+            target.release_asset_platform_aliases(),
+            vec![
+                Cow::Borrowed("aarch64-apple-darwin"),
+                Cow::Owned("darwin-aarch64".to_string()),
+                Cow::Owned("aarch64-darwin".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_release_asset_aliases() {
+        let target = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
+
+        assert_eq!(
+            target.release_asset_platform_aliases(),
+            vec![
+                Cow::Borrowed("x86_64-pc-windows-msvc"),
+                Cow::Owned("windows-x86_64".to_string()),
+                Cow::Owned("x86_64-windows".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn serializes_and_deserializes_as_string() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let json = serde_json::to_string(&target).unwrap();
+        let round_trip: TargetTriple = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(json, r#""x86_64-unknown-linux-gnu""#);
+        assert_eq!(round_trip, target);
+    }
+}

--- a/cgx-core/src/target.rs
+++ b/cgx-core/src/target.rs
@@ -11,9 +11,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{self, Visitor},
 };
-use target_lexicon::{Architecture, Environment, OperatingSystem, Triple, Vendor};
-
-use crate::{Result, error};
+use target_lexicon::{Aarch64Architecture, Architecture, Environment, OperatingSystem, Triple, Vendor};
 
 /// Strongly typed representation of a Rust target triple string, with parsed components and
 /// convenience methods.
@@ -21,26 +19,41 @@ use crate::{Result, error};
 /// This spares us the ugly and error-prone stringly-typed handling of targets, and gives us a
 /// single place to implement logic around target-specific behavior in a form that we can more
 /// easily unit test.
+///
+/// Having said all of that, there is sadly still a bit of stringly-typedness left, because not all
+/// Rust targets are parsable as LLVM target triples.  For example, `arm64ec-pc-windows-msvc` is a
+/// valid Rust target triple but not a valid LLVM triple. We also have to represent pseudo-targets
+/// like Mac's `universal-apple-darwin` which isn't any kind of target triple at all. So this also
+/// carries around the raw target string, and must fall back to some stringly heuristics in cases
+/// where a parsed `Triple` isn't available.
 #[derive(Clone, Debug)]
 pub(crate) struct TargetTriple {
     raw: Cow<'static, str>,
-    triple: Triple,
+    /// The parsed components, or `None` when `raw` is not parseable as an LLVM triple.
+    triple: Option<Triple>,
 }
 
 impl TargetTriple {
-    pub(crate) fn from_static(target: &'static str) -> Result<Self> {
-        Self::parse(Cow::Borrowed(target))
+    pub(crate) fn from_static(target: &'static str) -> Self {
+        Self::new(Cow::Borrowed(target))
     }
 
-    pub(crate) fn from_owned(target: String) -> Result<Self> {
-        Self::parse(Cow::Owned(target))
+    pub(crate) fn from_owned(target: String) -> Self {
+        Self::new(Cow::Owned(target))
     }
 
     pub(crate) fn host() -> &'static Self {
         static HOST: OnceLock<TargetTriple> = OnceLock::new();
         HOST.get_or_init(|| {
-            Self::from_static(build_context::TARGET)
-                .expect("build_context::TARGET must be a valid target triple")
+            let host = Self::from_static(build_context::TARGET);
+            if host.triple.is_none() {
+                tracing::warn!(
+                    "Host target triple '{}' is not recognized; pre-built binary discovery will only match \
+                     assets that name this exact triple",
+                    build_context::TARGET
+                );
+            }
+            host
         })
     }
 
@@ -52,36 +65,47 @@ impl TargetTriple {
         Cow::Borrowed(self.as_str())
     }
 
-    pub(crate) fn triple(&self) -> &Triple {
-        &self.triple
+    pub(crate) fn triple(&self) -> Option<&Triple> {
+        self.triple.as_ref()
     }
 
-    pub(crate) fn architecture(&self) -> Architecture {
-        self.triple().architecture
+    pub(crate) fn architecture(&self) -> Option<Architecture> {
+        self.triple().map(|triple| triple.architecture)
     }
 
-    pub(crate) fn operating_system(&self) -> OperatingSystem {
-        self.triple().operating_system
+    pub(crate) fn operating_system(&self) -> Option<OperatingSystem> {
+        self.triple().map(|triple| triple.operating_system)
     }
 
-    pub(crate) fn environment(&self) -> Environment {
-        self.triple().environment
+    pub(crate) fn environment(&self) -> Option<Environment> {
+        self.triple().map(|triple| triple.environment)
     }
 
-    pub(crate) fn vendor(&self) -> &Vendor {
-        &self.triple().vendor
+    pub(crate) fn vendor(&self) -> Option<&Vendor> {
+        self.triple().map(|triple| &triple.vendor)
     }
 
+    /// Whether this target is a Windows target.
+    ///
+    /// For an opaque target that could not be parsed into a `Target`, this falls back to a
+    /// substring heuristic on the raw string.
     pub(crate) fn is_windows(&self) -> bool {
-        self.operating_system() == OperatingSystem::Windows
+        match &self.triple {
+            Some(triple) => triple.operating_system == OperatingSystem::Windows,
+            None => self.raw.contains("-windows"),
+        }
     }
 
     /// Returns true if the target is macOS or another Apple platform (e.g., iOS, tvOS, watchOS).
     ///
     /// There are many different target OS values for the various Apple platforms, but for our
-    /// purposes they are all "macos-like".
+    /// purposes they are all "macos-like". For an opaque target this falls back to a substring
+    /// heuristic, mirroring [`Self::is_windows`].
     pub(crate) fn is_macos_like(&self) -> bool {
-        self.operating_system().is_like_darwin()
+        match &self.triple {
+            Some(triple) => triple.operating_system.is_like_darwin(),
+            None => self.raw.contains("-darwin"),
+        }
     }
 
     pub(crate) fn binary_ext(&self) -> &'static str {
@@ -93,53 +117,76 @@ impl TargetTriple {
     /// Release assets are not named consistently across projects. Some use the exact Rust target
     /// triple (eg, `x86_64-unknown-linux-gnu`), while others use shorter `{os}-{arch}` or
     /// `{arch}-{os}` forms (`linux-x86_64`, `x86_64-linux`). This method returns the full
-    /// triple first because it is the most specific token, then appends those common short
-    /// forms for whatever target this is. Targets outside of the known windows/mac/linux set
-    /// get only their exact triple, since each of the shorter variants were based on actual
-    /// observed release asset naming conventions that may not generalize to more exotic
-    /// targets.
+    /// triple first because it is the most specific token, then any alternate full
+    /// triples, then those common short forms for whatever target this is. Targets outside of the
+    /// known windows/mac/linux set get only their exact triple, since without a successfully
+    /// parsed `Target` we don't know enough about the components of the target to generate any
+    /// other permutations/short forms of it.
     pub(crate) fn release_asset_platform_aliases(&self) -> Vec<Cow<'static, str>> {
         // Keep the original, full triple first. It is the most specific so, if present, it should
         // be used.
         let mut aliases = vec![self.raw.clone()];
 
-        // Convert the OS into a colloquial OS name most commonly used when naming release assets.
-        let os = if self.is_windows() {
-            "windows"
-        } else if self.is_macos_like() {
-            "darwin"
-        } else if self.operating_system() == OperatingSystem::Linux {
-            "linux"
-        } else {
-            // We don't know this OS so we can't generate any aliases for it. Just return the full triple.
+        // An opaque target has no known components to build short forms from, so its exact string
+        // is the only usable token.
+        let Some(triple) = &self.triple else {
             return aliases;
         };
 
-        let arch = self.architecture().into_str();
-
-        // Short aliases can collide with the full triple for unusual targets, so preserve priority
-        // order while dropping duplicates.
-        for alias in [format!("{}-{}", os, arch), format!("{}-{}", arch, os)] {
+        let push_unique = |aliases: &mut Vec<Cow<'static, str>>, alias: String| {
             if !aliases.iter().any(|existing| existing.as_ref() == alias) {
                 aliases.push(Cow::Owned(alias));
+            }
+        };
+
+        // `arm64` is a far more common release-asset spelling than the canonical `aarch64`, so
+        // aarch64 targets match under both strings..
+        let arch = triple.architecture.into_str();
+        let mut arch_versions = vec![arch.clone()];
+        if triple.architecture == Architecture::Aarch64(Aarch64Architecture::Aarch64) {
+            arch_versions.push(Cow::Borrowed("arm64"));
+
+            // Alternate-form full triples (eg `arm64-apple-darwin`) directly after the raw triple:
+            // still fully specific, just a different arch version. The canonical version reproduces
+            // the raw triple and is dropped as a duplicate.
+            let arm64_triple = self.raw.replace("aarch64-", "arm64-");
+            push_unique(&mut aliases, arm64_triple);
+        }
+
+        // Convert the OS into a colloquial OS name most commonly used when naming release assets.
+        let os = if triple.operating_system == OperatingSystem::Windows {
+            "windows"
+        } else if triple.operating_system.is_like_darwin() {
+            "darwin"
+        } else if triple.operating_system == OperatingSystem::Linux {
+            "linux"
+        } else {
+            // We don't know this OS so we can't generate any short aliases for it.
+            return aliases;
+        };
+
+        // For a known target triple, add common short forms that encode just the OS and the
+        // architecture name.
+        for arch_version in &arch_versions {
+            for alias in [
+                format!("{}-{}", os, arch_version),
+                format!("{}-{}", arch_version, os),
+            ] {
+                push_unique(&mut aliases, alias);
             }
         }
 
         aliases
     }
 
-    /// The ABI-compatible fallback targets for this host: every real target *other than* `self`
-    /// whose binaries this host can also execute, most preferred first.
+    /// The ABI-compatible fallback targets for this host: every target *other than* `self` whose
+    /// binaries this host can also execute, most preferred first. On macOS this includes the
+    /// `universal`/`universal2` fat-binary pseudo-targets.
     ///
-    /// This deliberately excludes `self`; callers that want the complete "targets to try" list with
-    /// the exact host first should use [`Self::compatible_targets`]. Returns empty when the host
-    /// has no compatible siblings (eg, a musl Linux host, an Apple Silicon host without Rosetta, or
-    /// an OS we have no fallback rules for).
-    pub(crate) fn compatible_fallback_targets(&self) -> Vec<TargetTriple> {
-        self.compatible_fallback_targets_with(HostCapabilities::detect())
-    }
-
-    /// Host-independent core of [`Self::compatible_fallback_targets`].
+    /// This deliberately excludes `self`; callers that want the complete list with the exact host
+    /// first should use [`Self::compatible_targets`]. Returns empty when the host has no
+    /// compatible siblings (eg, a musl Linux host, an OS we have no fallback rules for, or an
+    /// opaque target whose components are unknown).
     ///
     /// `caps` is the runtime-probed host state, which is used on certain platforms where the
     /// targets available for fallback also depend on whether or not the host is configured to
@@ -147,13 +194,24 @@ impl TargetTriple {
     fn compatible_fallback_targets_with(&self, caps: HostCapabilities) -> Vec<TargetTriple> {
         let mut fallbacks = Vec::new();
 
-        if self.is_macos_like() {
+        // An opaque target has unknown components, so no ABI-compatibility rule can apply.
+        let Some(triple) = &self.triple else {
+            return fallbacks;
+        };
+
+        if triple.operating_system.is_like_darwin() {
+            // A universal (fat) binary carries a slice for every macOS architecture, so it runs
+            // natively on any Mac — Intel or Apple Silicon. These are Apple `lipo` asset naming
+            // conventions, not real triples, so they are carried as opaque targets.
+            fallbacks.push(Self::from_static("universal-apple-darwin"));
+            fallbacks.push(Self::from_static("universal2-apple-darwin"));
+
             // An Apple Silicon host can also run an `x86_64-apple-darwin` binary, but only through
             // Rosetta 2 — so it is a fallback only when the probe found Rosetta.
-            if matches!(self.architecture(), Architecture::Aarch64(_)) && caps.x86_64_macos_runnable {
-                fallbacks.push(self.with_architecture(Architecture::X86_64));
+            if matches!(triple.architecture, Architecture::Aarch64(_)) && caps.x86_64_macos_runnable {
+                fallbacks.push(Self::sibling_with_architecture(triple, Architecture::X86_64));
             }
-        } else if self.operating_system() == OperatingSystem::Windows {
+        } else if triple.operating_system == OperatingSystem::Windows {
             // Every Windows ABI is interchangeable at runtime for the same architecture (see
             // `windows_fallback_environments`), so each sibling ABI is a valid fallback.
             //
@@ -161,76 +219,73 @@ impl TargetTriple {
             // Windows on ARM64 becomes a relevant target, and I can get my hands on a Windows
             // ARM64 machine to test on, add some logic here to detect that and add the x86_64
             // sibling as a fallback for ARM64 hosts.
-            for &environment in Self::windows_fallback_environments(self.environment()) {
-                fallbacks.push(self.with_environment(environment));
+            for &environment in Self::windows_fallback_environments(triple.environment) {
+                fallbacks.push(Self::sibling_with_environment(triple, environment));
             }
-        } else if self.operating_system() == OperatingSystem::Linux && self.environment() == Environment::Gnu
+        } else if triple.operating_system == OperatingSystem::Linux && triple.environment == Environment::Gnu
         {
             // A glibc host can also run a musl binary (musl release binaries are statically linked).
             // The reverse does NOT hold — a musl-only host generally cannot run a glibc-linked binary
             // — so a musl host is intentionally left with no fallback.
-            fallbacks.push(self.with_environment(Environment::Musl));
+            fallbacks.push(Self::sibling_with_environment(triple, Environment::Musl));
         }
 
         fallbacks
     }
 
-    /// Every real target whose binaries this host can execute, `self` first (the exact host always
-    /// wins), then [`Self::compatible_fallback_targets`]. This is the ordered list the binary
-    /// providers should iterate when probing for a downloadable asset.
+    /// List every target whose binaries this host can execute, `self` first (the exact host always
+    /// wins), then its ABI-compatible fallbacks in preference order.
+    ///
+    /// This is the ordered list the binary providers should iterate when probing for a
+    /// downloadable asset.
     pub(crate) fn compatible_targets(&self) -> Vec<TargetTriple> {
+        self.compatible_targets_with(HostCapabilities::detect())
+    }
+
+    /// Host-independent core of [`Self::compatible_targets`]; see
+    /// [`Self::compatible_fallback_targets_with`] for why `caps` is injected.
+    fn compatible_targets_with(&self, caps: HostCapabilities) -> Vec<TargetTriple> {
         std::iter::once(self.clone())
-            .chain(self.compatible_fallback_targets())
+            .chain(self.compatible_fallback_targets_with(caps))
             .collect()
     }
 
-    /// Release-asset platform strings across the host and all its compatible fallbacks, most
-    /// preferred first. This is what the GitHub and GitLab providers match candidate asset
-    /// filenames against.
-    pub(crate) fn compatible_asset_platform_aliases(&self) -> Vec<Cow<'static, str>> {
-        self.compatible_asset_platform_aliases_with(HostCapabilities::detect())
+    /// Release-asset platform strings grouped per compatible target, in target-preference order:
+    /// the exact host's group first, then each ABI-compatible fallback's group.
+    pub(crate) fn compatible_asset_platform_alias_groups(
+        &self,
+    ) -> Vec<(TargetTriple, Vec<Cow<'static, str>>)> {
+        self.compatible_asset_platform_alias_groups_with(HostCapabilities::detect())
     }
 
-    /// Host-independent core of [`Self::compatible_asset_platform_aliases`]; see
+    /// Host-independent core of [`Self::compatible_asset_platform_alias_groups`]; see
     /// [`Self::compatible_fallback_targets_with`] for why `caps` is injected.
-    fn compatible_asset_platform_aliases_with(&self, caps: HostCapabilities) -> Vec<Cow<'static, str>> {
-        // Build the token list in strict priority order, then drop duplicates. Priority is:
-        //   1. the exact host's asset tokens (full triple + `{os}-{arch}` / `{arch}-{os}` forms),
-        //   2. the host's native fat-binary pseudo-targets (`universal*`) — these run natively, so they
-        //      must outrank any cross-architecture fallback yet never the exact host, then (Mac-only)
-        //   3. each ABI-compatible fallback target's asset tokens, in fallback-preference order.
-        let mut aliases: Vec<Cow<'static, str>> = Vec::new();
-        aliases.extend(self.release_asset_platform_aliases());
-        aliases.extend(
-            self.pseudo_target_asset_names()
-                .iter()
-                .copied()
-                .map(Cow::Borrowed),
-        );
-        for fallback in self.compatible_fallback_targets_with(caps) {
-            aliases.extend(fallback.release_asset_platform_aliases());
-        }
+    fn compatible_asset_platform_alias_groups_with(
+        &self,
+        caps: HostCapabilities,
+    ) -> Vec<(TargetTriple, Vec<Cow<'static, str>>)> {
+        // Within a group the strings are that target's [`Self::release_asset_platform_aliases`].
+        // Across groups a string is kept only in the first (most preferred) group that produces it,
+        // so an ambiguous short form shared by multiple targets (eg, a gnu host and its musl fallback both
+        // emit `linux-x86_64`) is attributed to the primary target.
+        //
+        // Basically, take all compatible targets, and for each target make the various platform
+        // alias strings for that target, and return a deduped list of all of those platform alias
+        // strings.
 
-        // Same-arch siblings share their short forms — a gnu host and its musl fallback both emit
-        // `linux-x86_64` — so the concatenation contains duplicates. Keep the first occurrence of
-        // each token, which preserves the priority order established above.
         let mut seen = HashSet::new();
-        aliases.retain(|alias| seen.insert(alias.clone()));
-        aliases
-    }
-
-    /// Asset-name platform strings for this OS's native fat-binary pseudo-targets, or an empty
-    /// slice when it has none. On macOS a `universal`/`universal2` archive carries a slice for
-    /// every architecture and so always runs natively; these tokens let providers match such an
-    /// asset. They are asset names only, never real target triples (they do not parse as
-    /// [`Triple`]s — their "arch" is an Apple `lipo` fat-binary naming convention, not a real
-    /// architecture).
-    fn pseudo_target_asset_names(&self) -> &'static [&'static str] {
-        if self.is_macos_like() {
-            &["universal-apple-darwin", "universal2-apple-darwin"]
-        } else {
-            &[]
+        let mut groups = Vec::new();
+        for candidate in self.compatible_targets_with(caps) {
+            let tokens: Vec<Cow<'static, str>> = candidate
+                .release_asset_platform_aliases()
+                .into_iter()
+                .filter(|token| seen.insert(token.clone()))
+                .collect();
+            if !tokens.is_empty() {
+                groups.push((candidate, tokens));
+            }
         }
+        groups
     }
 
     /// The Windows ABI environments to fall back to after the host's own, in preference order.
@@ -253,35 +308,29 @@ impl TargetTriple {
     fn from_triple(triple: Triple) -> Self {
         Self {
             raw: Cow::Owned(triple.to_string()),
-            triple,
+            triple: Some(triple),
         }
     }
 
-    /// The sibling target that differs from this one only in its environment (ABI), for example
+    /// The sibling target that differs from `triple` only in its environment (ABI), for example
     /// turning a `-gnu` host into its `-musl` sibling.
-    fn with_environment(&self, environment: Environment) -> TargetTriple {
-        let mut triple = self.triple.clone();
-        triple.environment = environment;
-        Self::from_triple(triple)
+    fn sibling_with_environment(triple: &Triple, environment: Environment) -> TargetTriple {
+        let mut sibling = triple.clone();
+        sibling.environment = environment;
+        Self::from_triple(sibling)
     }
 
-    /// The sibling target that differs from this one only in its architecture, for example turning
+    /// The sibling target that differs from `triple` only in its architecture, for example turning
     /// an `aarch64-apple-darwin` host into `x86_64-apple-darwin`.
-    fn with_architecture(&self, architecture: Architecture) -> TargetTriple {
-        let mut triple = self.triple.clone();
-        triple.architecture = architecture;
-        Self::from_triple(triple)
+    fn sibling_with_architecture(triple: &Triple, architecture: Architecture) -> TargetTriple {
+        let mut sibling = triple.clone();
+        sibling.architecture = architecture;
+        Self::from_triple(sibling)
     }
 
-    fn parse(raw: Cow<'static, str>) -> Result<Self> {
-        let triple = Triple::from_str(raw.as_ref()).map_err(|source| {
-            error::InvalidTargetTripleSnafu {
-                target: raw.to_string(),
-                message: source.to_string(),
-            }
-            .build()
-        })?;
-        Ok(Self { raw, triple })
+    fn new(raw: Cow<'static, str>) -> Self {
+        let triple = Triple::from_str(raw.as_ref()).ok();
+        Self { raw, triple }
     }
 }
 
@@ -303,7 +352,7 @@ impl HostCapabilities {
         *CAPABILITIES.get_or_init(|| {
             let host = TargetTriple::host();
             let x86_64_macos_runnable = host.is_macos_like()
-                && matches!(host.architecture(), Architecture::Aarch64(_))
+                && matches!(host.architecture(), Some(Architecture::Aarch64(_)))
                 && Self::probe_x86_64_macos_runnable();
             HostCapabilities {
                 x86_64_macos_runnable,
@@ -363,7 +412,7 @@ impl Hash for TargetTriple {
 // created from.
 
 impl Serialize for TargetTriple {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -372,7 +421,7 @@ impl Serialize for TargetTriple {
 }
 
 impl<'de> Deserialize<'de> for TargetTriple {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -385,18 +434,18 @@ impl<'de> Deserialize<'de> for TargetTriple {
                 formatter.write_str("a Rust target triple string")
             }
 
-            fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                TargetTriple::from_owned(value.to_string()).map_err(E::custom)
+                Ok(TargetTriple::from_owned(value.to_string()))
             }
 
-            fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E>
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
             where
                 E: de::Error,
             {
-                TargetTriple::from_owned(value).map_err(E::custom)
+                Ok(TargetTriple::from_owned(value))
             }
         }
 
@@ -410,21 +459,37 @@ mod tests {
     use target_lexicon::{Architecture, Environment, OperatingSystem, Vendor};
 
     use super::*;
-    use crate::error::Error;
 
     #[test]
     fn parses_valid_target() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(target.as_str(), "x86_64-unknown-linux-gnu");
+        assert!(target.triple().is_some());
     }
 
+    /// A string target-lexicon cannot parse is carried opaquely: the raw string is preserved
+    /// verbatim, component accessors report nothing, and the target participates in discovery with
+    /// only its exact token and no ABI-compatible fallbacks.
     #[test]
-    fn invalid_parse_reports_invalid_target_triple() {
-        assert_matches!(
-            TargetTriple::from_static("not-a-real-target"),
-            Err(Error::InvalidTargetTriple { .. })
+    fn unparsable_target_is_carried_opaquely() {
+        // A real rustc target that target-lexicon cannot parse (unknown architecture).
+        let target = TargetTriple::from_static("arm64ec-pc-windows-msvc");
+
+        assert_eq!(target.as_str(), "arm64ec-pc-windows-msvc");
+        assert!(target.triple().is_none());
+        assert_eq!(target.architecture(), None);
+        assert_eq!(target.operating_system(), None);
+        assert_eq!(target.environment(), None);
+        assert_eq!(target.vendor(), None);
+        assert_eq!(
+            target.release_asset_platform_aliases(),
+            vec![Cow::Borrowed("arm64ec-pc-windows-msvc")]
         );
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+        // The `-windows` heuristic still classifies it for cosmetic purposes.
+        assert!(target.is_windows());
+        assert_eq!(target.binary_ext(), ".exe");
     }
 
     #[test]
@@ -434,7 +499,7 @@ mod tests {
 
     #[test]
     fn exposes_original_string_forms() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(target.to_string(), "x86_64-unknown-linux-gnu");
         assert_eq!(target.as_str(), "x86_64-unknown-linux-gnu");
@@ -443,19 +508,19 @@ mod tests {
 
     #[test]
     fn exposes_typed_components() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
-        assert_eq!(target.triple().architecture, Architecture::X86_64);
-        assert_eq!(target.architecture(), Architecture::X86_64);
-        assert_eq!(target.operating_system(), OperatingSystem::Linux);
-        assert_eq!(target.environment(), Environment::Gnu);
-        assert_eq!(target.vendor(), &Vendor::Unknown);
+        assert_eq!(target.triple().unwrap().architecture, Architecture::X86_64);
+        assert_eq!(target.architecture(), Some(Architecture::X86_64));
+        assert_eq!(target.operating_system(), Some(OperatingSystem::Linux));
+        assert_eq!(target.environment(), Some(Environment::Gnu));
+        assert_eq!(target.vendor(), Some(&Vendor::Unknown));
     }
 
     #[test]
     fn windows_binary_extension() {
-        let windows = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
-        let linux = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let windows = TargetTriple::from_static("x86_64-pc-windows-msvc");
+        let linux = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(windows.binary_ext(), ".exe");
         assert_eq!(linux.binary_ext(), "");
@@ -463,7 +528,7 @@ mod tests {
 
     #[test]
     fn linux_release_asset_aliases() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(
             target.release_asset_platform_aliases(),
@@ -475,23 +540,28 @@ mod tests {
         );
     }
 
+    /// macOS triples use `apple`, but most asset names use `darwin`; aarch64 targets additionally
+    /// match under the more common `arm64` spelling, full-triple and short forms alike.
     #[test]
-    fn macos_release_asset_aliases_use_darwin() {
-        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+    fn macos_release_asset_aliases_use_darwin_and_arm64() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
 
         assert_eq!(
             target.release_asset_platform_aliases(),
-            vec![
-                Cow::Borrowed("aarch64-apple-darwin"),
-                Cow::Owned("darwin-aarch64".to_string()),
-                Cow::Owned("aarch64-darwin".to_string()),
-            ]
+            cows(&[
+                "aarch64-apple-darwin",
+                "arm64-apple-darwin",
+                "darwin-aarch64",
+                "aarch64-darwin",
+                "darwin-arm64",
+                "arm64-darwin",
+            ])
         );
     }
 
     #[test]
     fn windows_release_asset_aliases() {
-        let target = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
+        let target = TargetTriple::from_static("x86_64-pc-windows-msvc");
 
         assert_eq!(
             target.release_asset_platform_aliases(),
@@ -514,9 +584,15 @@ mod tests {
     }
 
     fn targets(items: &[&'static str]) -> Vec<TargetTriple> {
-        items
-            .iter()
-            .map(|item| TargetTriple::from_static(item).unwrap())
+        items.iter().map(|item| TargetTriple::from_static(item)).collect()
+    }
+
+    /// Flatten the grouped alias tokens into one preference-ordered list.
+    fn flat_aliases(target: &TargetTriple, caps: HostCapabilities) -> Vec<Cow<'static, str>> {
+        target
+            .compatible_asset_platform_alias_groups_with(caps)
+            .into_iter()
+            .flat_map(|(_, tokens)| tokens)
             .collect()
     }
 
@@ -525,7 +601,7 @@ mod tests {
     /// `aarch64-apple-darwin` arm consults runtime-probed capabilities.
     #[test]
     fn compatible_targets_list_host_first_then_fallbacks() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(
             target.compatible_targets(),
@@ -535,7 +611,7 @@ mod tests {
 
     #[test]
     fn linux_gnu_falls_back_to_musl() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
         assert_eq!(
             target.compatible_fallback_targets_with(caps(false)),
@@ -545,7 +621,7 @@ mod tests {
 
     #[test]
     fn linux_aarch64_gnu_falls_back_to_musl() {
-        let target = TargetTriple::from_static("aarch64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("aarch64-unknown-linux-gnu");
 
         assert_eq!(
             target.compatible_fallback_targets_with(caps(false)),
@@ -557,14 +633,14 @@ mod tests {
     /// glibc-linked binary. This asymmetry is load-bearing.
     #[test]
     fn linux_musl_has_no_fallback() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-musl").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-musl");
 
         assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
     }
 
     #[test]
     fn windows_msvc_falls_back_to_gnu_then_gnullvm() {
-        let target = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
+        let target = TargetTriple::from_static("x86_64-pc-windows-msvc");
 
         assert_eq!(
             target.compatible_fallback_targets_with(caps(false)),
@@ -574,7 +650,7 @@ mod tests {
 
     #[test]
     fn windows_gnu_falls_back_to_gnullvm_then_msvc() {
-        let target = TargetTriple::from_static("x86_64-pc-windows-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-pc-windows-gnu");
 
         assert_eq!(
             target.compatible_fallback_targets_with(caps(false)),
@@ -582,71 +658,89 @@ mod tests {
         );
     }
 
+    /// Without Rosetta an Apple Silicon host cannot run x86_64 binaries, but universal fat
+    /// binaries always run natively, so they remain the only fallbacks.
     #[test]
-    fn apple_silicon_without_rosetta_has_no_fallback() {
-        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+    fn apple_silicon_without_rosetta_falls_back_to_universal_only() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
 
-        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(false)),
+            targets(&["universal-apple-darwin", "universal2-apple-darwin"])
+        );
     }
 
     #[test]
-    fn apple_silicon_with_rosetta_falls_back_to_x86_64() {
-        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+    fn apple_silicon_with_rosetta_falls_back_to_universal_then_x86_64() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
 
         assert_eq!(
             target.compatible_fallback_targets_with(caps(true)),
-            targets(&["x86_64-apple-darwin"])
+            targets(&[
+                "universal-apple-darwin",
+                "universal2-apple-darwin",
+                "x86_64-apple-darwin"
+            ])
         );
     }
 
     /// An Intel Mac host is already `x86_64-apple-darwin`, so the capability bit is irrelevant and
-    /// no cross-architecture sibling is added regardless of its value.
+    /// no cross-architecture sibling is added regardless of its value; only the universal fat
+    /// binaries are compatible fallbacks.
     #[test]
-    fn intel_mac_has_no_fallback_regardless_of_capability_bit() {
-        let target = TargetTriple::from_static("x86_64-apple-darwin").unwrap();
+    fn intel_mac_falls_back_to_universal_regardless_of_capability_bit() {
+        let target = TargetTriple::from_static("x86_64-apple-darwin");
 
-        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
-        assert_eq!(target.compatible_fallback_targets_with(caps(true)), targets(&[]));
+        let expected = targets(&["universal-apple-darwin", "universal2-apple-darwin"]);
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), expected);
+        assert_eq!(target.compatible_fallback_targets_with(caps(true)), expected);
     }
 
     /// An OS with no known ABI-compatible siblings gets no fallbacks — only its exact host triple,
     /// which `compatible_fallback_targets` excludes.
     #[test]
     fn unhandled_os_has_no_fallback() {
-        let target = TargetTriple::from_static("x86_64-unknown-freebsd").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-freebsd");
 
         assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
     }
 
-    /// The musl sibling's short `{os}-{arch}` forms coincide with the gnu host's, so they dedup
-    /// away; only the musl full triple is added.
+    /// The musl sibling's short `{os}-{arch}` forms coincide with the gnu host's, so they are
+    /// attributed to the host group; the musl group keeps only its full triple.
     #[test]
-    fn linux_gnu_asset_aliases_add_only_musl_full_triple() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+    fn linux_gnu_alias_groups_attribute_shared_tokens_to_host() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
 
+        let groups = target.compatible_asset_platform_alias_groups_with(caps(false));
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].0, target);
         assert_eq!(
-            target.compatible_asset_platform_aliases_with(caps(false)),
-            cows(&[
-                "x86_64-unknown-linux-gnu",
-                "linux-x86_64",
-                "x86_64-linux",
-                "x86_64-unknown-linux-musl",
-            ])
+            groups[0].1,
+            cows(&["x86_64-unknown-linux-gnu", "linux-x86_64", "x86_64-linux"])
         );
+        assert_eq!(
+            groups[1].0,
+            TargetTriple::from_static("x86_64-unknown-linux-musl")
+        );
+        assert_eq!(groups[1].1, cows(&["x86_64-unknown-linux-musl"]));
     }
 
     /// The Rosetta cross-architecture sibling contributes its own short forms (`darwin-x86_64` /
     /// `x86_64-darwin`), while the universal pseudo-targets contribute only themselves.
     #[test]
     fn apple_silicon_with_rosetta_asset_aliases_include_x86_64_short_forms() {
-        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
 
         assert_eq!(
-            target.compatible_asset_platform_aliases_with(caps(true)),
+            flat_aliases(&target, caps(true)),
             cows(&[
                 "aarch64-apple-darwin",
+                "arm64-apple-darwin",
                 "darwin-aarch64",
                 "aarch64-darwin",
+                "darwin-arm64",
+                "arm64-darwin",
                 "universal-apple-darwin",
                 "universal2-apple-darwin",
                 "x86_64-apple-darwin",
@@ -656,39 +750,73 @@ mod tests {
         );
     }
 
+    /// On Apple Silicon with Rosetta, the common `arm64` asset spelling must be generated, and
+    /// every native (aarch64/arm64) token must precede every emulated x86_64 token — otherwise a
+    /// release shipping `foo-arm64-darwin.tar.gz` plus `foo-x86_64-darwin.tar.gz` matches only the
+    /// Intel asset and cgx silently runs it under Rosetta instead of natively.
+    #[test]
+    fn apple_silicon_arm64_spellings_present_and_precede_x86_64() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
+        let aliases = flat_aliases(&target, caps(true));
+
+        for expected in ["darwin-arm64", "arm64-darwin", "arm64-apple-darwin"] {
+            assert!(
+                aliases.iter().any(|alias| alias.as_ref() == expected),
+                "expected {expected:?} among aliases {aliases:?}"
+            );
+        }
+
+        let last_native = aliases
+            .iter()
+            .rposition(|alias| alias.contains("aarch64") || alias.contains("arm64"))
+            .expect("expected native-architecture aliases");
+        let first_x86_64 = aliases
+            .iter()
+            .position(|alias| alias.contains("x86_64"))
+            .expect("expected x86_64 fallback aliases under Rosetta");
+        assert!(
+            last_native < first_x86_64,
+            "all native tokens must precede all x86_64 tokens: {aliases:?}"
+        );
+    }
+
     #[test]
     fn apple_silicon_without_rosetta_asset_aliases_omit_x86_64_short_forms() {
-        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+        let target = TargetTriple::from_static("aarch64-apple-darwin");
 
         assert_eq!(
-            target.compatible_asset_platform_aliases_with(caps(false)),
+            flat_aliases(&target, caps(false)),
             cows(&[
                 "aarch64-apple-darwin",
+                "arm64-apple-darwin",
                 "darwin-aarch64",
                 "aarch64-darwin",
+                "darwin-arm64",
+                "arm64-darwin",
                 "universal-apple-darwin",
                 "universal2-apple-darwin",
             ])
         );
     }
 
-    /// The universal pseudo-targets are asset-name tokens, not real triples, so they must not parse
-    /// back into a [`TargetTriple`].
+    /// The universal pseudo-targets are asset-name tokens, not real triples: they are carried as
+    /// opaque [`TargetTriple`]s whose only asset token is their exact name, and they never gain
+    /// fallbacks of their own even though the `-darwin` heuristic classifies them as macOS-like.
     #[test]
-    fn universal_pseudo_targets_do_not_parse() {
-        assert_matches!(
-            TargetTriple::from_owned("universal-apple-darwin".to_string()),
-            Err(Error::InvalidTargetTriple { .. })
-        );
-        assert_matches!(
-            TargetTriple::from_owned("universal2-apple-darwin".to_string()),
-            Err(Error::InvalidTargetTriple { .. })
-        );
+    fn universal_pseudo_targets_are_opaque() {
+        for pseudo in ["universal-apple-darwin", "universal2-apple-darwin"] {
+            let target = TargetTriple::from_owned(pseudo.to_string());
+
+            assert!(target.triple().is_none(), "{pseudo} must not parse as a triple");
+            assert!(target.is_macos_like());
+            assert_eq!(target.release_asset_platform_aliases(), cows(&[pseudo]));
+            assert_eq!(target.compatible_fallback_targets_with(caps(true)), targets(&[]));
+        }
     }
 
     #[test]
     fn serializes_and_deserializes_as_string() {
-        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu");
         let json = serde_json::to_string(&target).unwrap();
         let round_trip: TargetTriple = serde_json::from_str(&json).unwrap();
 

--- a/cgx-core/src/target.rs
+++ b/cgx-core/src/target.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    collections::HashSet,
     fmt,
     hash::{Hash, Hasher},
     str::FromStr,
@@ -87,19 +88,20 @@ impl TargetTriple {
         if self.is_windows() { ".exe" } else { "" }
     }
 
-    /// Platform tokens to try when matching release asset filenames.
+    /// Platform strings to try when matching release asset filenames.
     ///
     /// Release assets are not named consistently across projects. Some use the exact Rust target
-    /// triple (`x86_64-unknown-linux-gnu`), while others use shorter `{os}-{arch}` or `{arch}-{os}`
-    /// forms (`linux-x86_64`, `x86_64-linux`). This returns the full triple first because it is the
-    /// most specific token, then appends those common short forms for Linux, Windows, and
-    /// Darwin-like Apple targets. Other targets get only their exact triple, since each of the
-    /// shorter variants were based on actual observed release asset naming conventions that may
-    /// not generalize to other platforms.
-    pub(crate) fn release_asset_platform_aliases(&self) -> Vec<Cow<'_, str>> {
+    /// triple (eg, `x86_64-unknown-linux-gnu`), while others use shorter `{os}-{arch}` or
+    /// `{arch}-{os}` forms (`linux-x86_64`, `x86_64-linux`). This method returns the full
+    /// triple first because it is the most specific token, then appends those common short
+    /// forms for whatever target this is. Targets outside of the known windows/mac/linux set
+    /// get only their exact triple, since each of the shorter variants were based on actual
+    /// observed release asset naming conventions that may not generalize to more exotic
+    /// targets.
+    pub(crate) fn release_asset_platform_aliases(&self) -> Vec<Cow<'static, str>> {
         // Keep the original, full triple first. It is the most specific so, if present, it should
         // be used.
-        let mut aliases = vec![self.as_cow()];
+        let mut aliases = vec![self.raw.clone()];
 
         // Convert the OS into a colloquial OS name most commonly used when naming release assets.
         let os = if self.is_windows() {
@@ -126,6 +128,151 @@ impl TargetTriple {
         aliases
     }
 
+    /// The ABI-compatible fallback targets for this host: every real target *other than* `self`
+    /// whose binaries this host can also execute, most preferred first.
+    ///
+    /// This deliberately excludes `self`; callers that want the complete "targets to try" list with
+    /// the exact host first should use [`Self::compatible_targets`]. Returns empty when the host
+    /// has no compatible siblings (eg, a musl Linux host, an Apple Silicon host without Rosetta, or
+    /// an OS we have no fallback rules for).
+    pub(crate) fn compatible_fallback_targets(&self) -> Vec<TargetTriple> {
+        self.compatible_fallback_targets_with(HostCapabilities::detect())
+    }
+
+    /// Host-independent core of [`Self::compatible_fallback_targets`].
+    ///
+    /// `caps` is the runtime-probed host state, which is used on certain platforms where the
+    /// targets available for fallback also depend on whether or not the host is configured to
+    /// emulate other architedtures.
+    fn compatible_fallback_targets_with(&self, caps: HostCapabilities) -> Vec<TargetTriple> {
+        let mut fallbacks = Vec::new();
+
+        if self.is_macos_like() {
+            // An Apple Silicon host can also run an `x86_64-apple-darwin` binary, but only through
+            // Rosetta 2 — so it is a fallback only when the probe found Rosetta.
+            if matches!(self.architecture(), Architecture::Aarch64(_)) && caps.x86_64_macos_runnable {
+                fallbacks.push(self.with_architecture(Architecture::X86_64));
+            }
+        } else if self.operating_system() == OperatingSystem::Windows {
+            // Every Windows ABI is interchangeable at runtime for the same architecture (see
+            // `windows_fallback_environments`), so each sibling ABI is a valid fallback.
+            //
+            // TODO: Windows on ARM64 can supposedly run x86_64 binaries through emulation.  If
+            // Windows on ARM64 becomes a relevant target, and I can get my hands on a Windows
+            // ARM64 machine to test on, add some logic here to detect that and add the x86_64
+            // sibling as a fallback for ARM64 hosts.
+            for &environment in Self::windows_fallback_environments(self.environment()) {
+                fallbacks.push(self.with_environment(environment));
+            }
+        } else if self.operating_system() == OperatingSystem::Linux && self.environment() == Environment::Gnu
+        {
+            // A glibc host can also run a musl binary (musl release binaries are statically linked).
+            // The reverse does NOT hold — a musl-only host generally cannot run a glibc-linked binary
+            // — so a musl host is intentionally left with no fallback.
+            fallbacks.push(self.with_environment(Environment::Musl));
+        }
+
+        fallbacks
+    }
+
+    /// Every real target whose binaries this host can execute, `self` first (the exact host always
+    /// wins), then [`Self::compatible_fallback_targets`]. This is the ordered list the binary
+    /// providers should iterate when probing for a downloadable asset.
+    pub(crate) fn compatible_targets(&self) -> Vec<TargetTriple> {
+        std::iter::once(self.clone())
+            .chain(self.compatible_fallback_targets())
+            .collect()
+    }
+
+    /// Release-asset platform strings across the host and all its compatible fallbacks, most
+    /// preferred first. This is what the GitHub and GitLab providers match candidate asset
+    /// filenames against.
+    pub(crate) fn compatible_asset_platform_aliases(&self) -> Vec<Cow<'static, str>> {
+        self.compatible_asset_platform_aliases_with(HostCapabilities::detect())
+    }
+
+    /// Host-independent core of [`Self::compatible_asset_platform_aliases`]; see
+    /// [`Self::compatible_fallback_targets_with`] for why `caps` is injected.
+    fn compatible_asset_platform_aliases_with(&self, caps: HostCapabilities) -> Vec<Cow<'static, str>> {
+        // Build the token list in strict priority order, then drop duplicates. Priority is:
+        //   1. the exact host's asset tokens (full triple + `{os}-{arch}` / `{arch}-{os}` forms),
+        //   2. the host's native fat-binary pseudo-targets (`universal*`) — these run natively, so they
+        //      must outrank any cross-architecture fallback yet never the exact host, then (Mac-only)
+        //   3. each ABI-compatible fallback target's asset tokens, in fallback-preference order.
+        let mut aliases: Vec<Cow<'static, str>> = Vec::new();
+        aliases.extend(self.release_asset_platform_aliases());
+        aliases.extend(
+            self.pseudo_target_asset_names()
+                .iter()
+                .copied()
+                .map(Cow::Borrowed),
+        );
+        for fallback in self.compatible_fallback_targets_with(caps) {
+            aliases.extend(fallback.release_asset_platform_aliases());
+        }
+
+        // Same-arch siblings share their short forms — a gnu host and its musl fallback both emit
+        // `linux-x86_64` — so the concatenation contains duplicates. Keep the first occurrence of
+        // each token, which preserves the priority order established above.
+        let mut seen = HashSet::new();
+        aliases.retain(|alias| seen.insert(alias.clone()));
+        aliases
+    }
+
+    /// Asset-name platform strings for this OS's native fat-binary pseudo-targets, or an empty
+    /// slice when it has none. On macOS a `universal`/`universal2` archive carries a slice for
+    /// every architecture and so always runs natively; these tokens let providers match such an
+    /// asset. They are asset names only, never real target triples (they do not parse as
+    /// [`Triple`]s — their "arch" is an Apple `lipo` fat-binary naming convention, not a real
+    /// architecture).
+    fn pseudo_target_asset_names(&self) -> &'static [&'static str] {
+        if self.is_macos_like() {
+            &["universal-apple-darwin", "universal2-apple-darwin"]
+        } else {
+            &[]
+        }
+    }
+
+    /// The Windows ABI environments to fall back to after the host's own, in preference order.
+    ///
+    /// Every Windows target compiles to a standalone PE linked against the system UCRT, so a binary
+    /// built for a sibling ABI runs on the host; we just prefer the closest ABI first. The host's
+    /// own ABI is omitted because the sole caller wants only the *additional* targets — the host is
+    /// already covered by `self`.
+    fn windows_fallback_environments(host: Environment) -> &'static [Environment] {
+        match host {
+            Environment::Msvc => &[Environment::Gnu, Environment::GnuLlvm],
+            Environment::Gnu => &[Environment::GnuLlvm, Environment::Msvc],
+            Environment::GnuLlvm => &[Environment::Gnu, Environment::Msvc],
+            _ => &[],
+        }
+    }
+
+    /// Build a [`TargetTriple`] from an already-parsed [`Triple`], re-deriving its canonical
+    /// string.
+    fn from_triple(triple: Triple) -> Self {
+        Self {
+            raw: Cow::Owned(triple.to_string()),
+            triple,
+        }
+    }
+
+    /// The sibling target that differs from this one only in its environment (ABI), for example
+    /// turning a `-gnu` host into its `-musl` sibling.
+    fn with_environment(&self, environment: Environment) -> TargetTriple {
+        let mut triple = self.triple.clone();
+        triple.environment = environment;
+        Self::from_triple(triple)
+    }
+
+    /// The sibling target that differs from this one only in its architecture, for example turning
+    /// an `aarch64-apple-darwin` host into `x86_64-apple-darwin`.
+    fn with_architecture(&self, architecture: Architecture) -> TargetTriple {
+        let mut triple = self.triple.clone();
+        triple.architecture = architecture;
+        Self::from_triple(triple)
+    }
+
     fn parse(raw: Cow<'static, str>) -> Result<Self> {
         let triple = Triple::from_str(raw.as_ref()).map_err(|source| {
             error::InvalidTargetTripleSnafu {
@@ -135,6 +282,54 @@ impl TargetTriple {
             .build()
         })?;
         Ok(Self { raw, triple })
+    }
+}
+
+/// Runtime-probed facts about the host that the ABI-compatibility logic needs but cannot derive
+/// from the target triple alone.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct HostCapabilities {
+    /// Whether an `x86_64-apple-darwin` binary runs on this host. This is native on Intel Macs and
+    /// available on Apple Silicon only when Rosetta 2 is installed. It is consulted only when the
+    /// host is `aarch64-apple-darwin`.
+    pub(crate) x86_64_macos_runnable: bool,
+}
+
+impl HostCapabilities {
+    /// The real capabilities of the current host, probed once and memoized for the process
+    /// lifetime.
+    fn detect() -> Self {
+        static CAPABILITIES: OnceLock<HostCapabilities> = OnceLock::new();
+        *CAPABILITIES.get_or_init(|| {
+            let host = TargetTriple::host();
+            let x86_64_macos_runnable = host.is_macos_like()
+                && matches!(host.architecture(), Architecture::Aarch64(_))
+                && Self::probe_x86_64_macos_runnable();
+            HostCapabilities {
+                x86_64_macos_runnable,
+            }
+        })
+    }
+
+    /// Probe whether an `x86_64` macOS binary can execute on this host by running a universal
+    /// system binary forced through its `x86_64` slice. Success means the `x86_64` slice ran,
+    /// which on Apple Silicon requires Rosetta 2.
+    #[cfg(target_os = "macos")]
+    fn probe_x86_64_macos_runnable() -> bool {
+        std::process::Command::new("arch")
+            .args(["-arch", "x86_64", "/usr/bin/true"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    }
+
+    /// On non-macOS hosts an `x86_64-apple-darwin` binary can never run, and the field is never
+    /// consulted anyway.
+    #[cfg(not(target_os = "macos"))]
+    fn probe_x86_64_macos_runnable() -> bool {
+        false
     }
 }
 
@@ -305,6 +500,189 @@ mod tests {
                 Cow::Owned("windows-x86_64".to_string()),
                 Cow::Owned("x86_64-windows".to_string()),
             ]
+        );
+    }
+
+    fn caps(x86_64_macos_runnable: bool) -> HostCapabilities {
+        HostCapabilities {
+            x86_64_macos_runnable,
+        }
+    }
+
+    fn cows(items: &[&'static str]) -> Vec<Cow<'static, str>> {
+        items.iter().copied().map(Cow::Borrowed).collect()
+    }
+
+    fn targets(items: &[&'static str]) -> Vec<TargetTriple> {
+        items
+            .iter()
+            .map(|item| TargetTriple::from_static(item).unwrap())
+            .collect()
+    }
+
+    /// The full "targets to try" list puts the exact host first, then its fallbacks. Uses a Linux
+    /// host so the result does not depend on the machine running the test — only the
+    /// `aarch64-apple-darwin` arm consults runtime-probed capabilities.
+    #[test]
+    fn compatible_targets_list_host_first_then_fallbacks() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(
+            target.compatible_targets(),
+            targets(&["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"])
+        );
+    }
+
+    #[test]
+    fn linux_gnu_falls_back_to_musl() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(false)),
+            targets(&["x86_64-unknown-linux-musl"])
+        );
+    }
+
+    #[test]
+    fn linux_aarch64_gnu_falls_back_to_musl() {
+        let target = TargetTriple::from_static("aarch64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(false)),
+            targets(&["aarch64-unknown-linux-musl"])
+        );
+    }
+
+    /// A musl host must NOT be offered a gnu fallback: a musl-only host generally cannot run a
+    /// glibc-linked binary. This asymmetry is load-bearing.
+    #[test]
+    fn linux_musl_has_no_fallback() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-musl").unwrap();
+
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+    }
+
+    #[test]
+    fn windows_msvc_falls_back_to_gnu_then_gnullvm() {
+        let target = TargetTriple::from_static("x86_64-pc-windows-msvc").unwrap();
+
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(false)),
+            targets(&["x86_64-pc-windows-gnu", "x86_64-pc-windows-gnullvm"])
+        );
+    }
+
+    #[test]
+    fn windows_gnu_falls_back_to_gnullvm_then_msvc() {
+        let target = TargetTriple::from_static("x86_64-pc-windows-gnu").unwrap();
+
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(false)),
+            targets(&["x86_64-pc-windows-gnullvm", "x86_64-pc-windows-msvc"])
+        );
+    }
+
+    #[test]
+    fn apple_silicon_without_rosetta_has_no_fallback() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+    }
+
+    #[test]
+    fn apple_silicon_with_rosetta_falls_back_to_x86_64() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+
+        assert_eq!(
+            target.compatible_fallback_targets_with(caps(true)),
+            targets(&["x86_64-apple-darwin"])
+        );
+    }
+
+    /// An Intel Mac host is already `x86_64-apple-darwin`, so the capability bit is irrelevant and
+    /// no cross-architecture sibling is added regardless of its value.
+    #[test]
+    fn intel_mac_has_no_fallback_regardless_of_capability_bit() {
+        let target = TargetTriple::from_static("x86_64-apple-darwin").unwrap();
+
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+        assert_eq!(target.compatible_fallback_targets_with(caps(true)), targets(&[]));
+    }
+
+    /// An OS with no known ABI-compatible siblings gets no fallbacks — only its exact host triple,
+    /// which `compatible_fallback_targets` excludes.
+    #[test]
+    fn unhandled_os_has_no_fallback() {
+        let target = TargetTriple::from_static("x86_64-unknown-freebsd").unwrap();
+
+        assert_eq!(target.compatible_fallback_targets_with(caps(false)), targets(&[]));
+    }
+
+    /// The musl sibling's short `{os}-{arch}` forms coincide with the gnu host's, so they dedup
+    /// away; only the musl full triple is added.
+    #[test]
+    fn linux_gnu_asset_aliases_add_only_musl_full_triple() {
+        let target = TargetTriple::from_static("x86_64-unknown-linux-gnu").unwrap();
+
+        assert_eq!(
+            target.compatible_asset_platform_aliases_with(caps(false)),
+            cows(&[
+                "x86_64-unknown-linux-gnu",
+                "linux-x86_64",
+                "x86_64-linux",
+                "x86_64-unknown-linux-musl",
+            ])
+        );
+    }
+
+    /// The Rosetta cross-architecture sibling contributes its own short forms (`darwin-x86_64` /
+    /// `x86_64-darwin`), while the universal pseudo-targets contribute only themselves.
+    #[test]
+    fn apple_silicon_with_rosetta_asset_aliases_include_x86_64_short_forms() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+
+        assert_eq!(
+            target.compatible_asset_platform_aliases_with(caps(true)),
+            cows(&[
+                "aarch64-apple-darwin",
+                "darwin-aarch64",
+                "aarch64-darwin",
+                "universal-apple-darwin",
+                "universal2-apple-darwin",
+                "x86_64-apple-darwin",
+                "darwin-x86_64",
+                "x86_64-darwin",
+            ])
+        );
+    }
+
+    #[test]
+    fn apple_silicon_without_rosetta_asset_aliases_omit_x86_64_short_forms() {
+        let target = TargetTriple::from_static("aarch64-apple-darwin").unwrap();
+
+        assert_eq!(
+            target.compatible_asset_platform_aliases_with(caps(false)),
+            cows(&[
+                "aarch64-apple-darwin",
+                "darwin-aarch64",
+                "aarch64-darwin",
+                "universal-apple-darwin",
+                "universal2-apple-darwin",
+            ])
+        );
+    }
+
+    /// The universal pseudo-targets are asset-name tokens, not real triples, so they must not parse
+    /// back into a [`TargetTriple`].
+    #[test]
+    fn universal_pseudo_targets_do_not_parse() {
+        assert_matches!(
+            TargetTriple::from_owned("universal-apple-darwin".to_string()),
+            Err(Error::InvalidTargetTriple { .. })
+        );
+        assert_matches!(
+            TargetTriple::from_owned("universal2-apple-darwin".to_string()),
+            Err(Error::InvalidTargetTriple { .. })
         );
     }
 

--- a/cgx-core/src/testdata.rs
+++ b/cgx-core/src/testdata.rs
@@ -7,6 +7,13 @@ use std::path::{Path, PathBuf};
 
 use tempfile::TempDir;
 
+use crate::target::TargetTriple;
+
+/// Construct a [`TargetTriple`] from a literal, for tests anywhere in the crate that need one.
+pub(crate) fn target_triple(target: &'static str) -> TargetTriple {
+    TargetTriple::from_static(target)
+}
+
 pub(crate) struct CrateTestCase {
     /// The name of the test case, which is also the name of the directory under `testdata`.
     pub name: &'static str,

--- a/cgx/tests/integration/config.rs
+++ b/cgx/tests/integration/config.rs
@@ -291,7 +291,7 @@ eza = { version = "=0.23.1", features = ["vendored-openssl"] }
     let features = messages
         .iter()
         .find_map(|message| match message {
-            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features.clone()),
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features().to_vec()),
             _ => None,
         })
         .expect("expected a CratePlan message");
@@ -329,7 +329,7 @@ eza = { version = "=0.23.1", features = ["a-config-only-feature"] }
     let features = messages
         .iter()
         .find_map(|message| match message {
-            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features.clone()),
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.features().to_vec()),
             _ => None,
         })
         .expect("expected a CratePlan message");
@@ -362,7 +362,7 @@ eza = { version = "=0.23.1", default-features = false }
     let no_default_features = messages
         .iter()
         .find_map(|message| match message {
-            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.no_default_features),
+            Message::Cgx(CgxMessage::CratePlan { options, .. }) => Some(options.no_default_features()),
             _ => None,
         })
         .expect("expected a CratePlan message");
@@ -405,8 +405,8 @@ eza = { version = "=0.23.1", default-features = false }
         })
         .expect("expected a CratePlan message");
 
-    assert!(options.no_default_features);
-    assert_eq!(options.features, vec!["vendored-openssl"]);
+    assert!(options.no_default_features());
+    assert_eq!(options.features(), ["vendored-openssl"]);
 }
 
 #[test]

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -597,11 +597,13 @@ mod github_releases {
     /// Test that `--prebuilt-binary-sources github-releases` resolves via the GitHub provider only.
     ///
     /// eza version 0.23.1 published GitHub release assets for Linux GNU, x86_64 Linux musl, and
-    /// `x86_64-pc-windows-gnu` only (no macOS, no windows-msvc, no aarch64 Linux musl).
+    /// `x86_64-pc-windows-gnu` only (no macOS, no windows-msvc, no aarch64 Linux musl). The
+    /// `x86_64-pc-windows-msvc` host is included below to prove the ABI-compatible fallback: with
+    /// no msvc asset, an msvc host resolves and runs eza's `x86_64-pc-windows-gnu` PE.
     #[test]
     #[cfg(any(
         all(target_os = "linux", not(all(target_arch = "aarch64", target_env = "musl"))),
-        all(target_os = "windows", target_env = "gnu")
+        all(target_os = "windows", target_arch = "x86_64")
     ))]
     fn github_provider_resolves_binary() {
         let mut cgx = Cgx::with_test_fs();
@@ -800,18 +802,19 @@ mod github_releases {
     /// Test that ripgrep's GitHub release archive resolves when the host target is one ripgrep
     /// publishes for 15.1.0. This exercises archives whose executable (`rg`) is inside a single
     /// top-level directory named after the crate/release (`ripgrep-...`).
+    ///
+    /// ripgrep 15.1.0 publishes no `x86_64-unknown-linux-gnu` asset, only
+    /// `x86_64-unknown-linux-musl`. `x86_64-unknown-linux-gnu` is included below to prove the
+    /// ABI-compatible fallback: a glibc host resolves and runs the musl static binary.
     #[test]
     #[cfg(any(
         all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")),
-        all(
-            target_os = "windows",
-            any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")
-        ),
+        all(target_os = "windows", any(target_arch = "x86_64", target_arch = "aarch64")),
         all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
         all(
             target_os = "linux",
             target_env = "gnu",
-            any(target_arch = "x86", target_arch = "aarch64", target_arch = "s390x")
+            any(target_arch = "x86_64", target_arch = "aarch64")
         )
     ))]
     fn github_provider_resolves_ripgrep_15_1_0() {
@@ -845,6 +848,193 @@ mod github_releases {
                 .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
             "Should not have BuildMessage::Started when using prebuilt binary"
         );
+    }
+
+    /// Test that `just@1.42.4` resolves via an ABI-compatible fallback target.
+    ///
+    /// just 1.42.4 publishes no `-gnu` Linux asset and no `-windows-gnu` asset: for Linux it ships
+    /// only `*-unknown-linux-musl`, and for Windows only `*-pc-windows-msvc`. So a glibc Linux host
+    /// resolves the musl static binary and an `x86_64-pc-windows-gnu` host resolves the msvc PE,
+    /// both ABI-compatible siblings of the host target. The resolved binary is executed to prove it
+    /// actually runs on the host.
+    #[test]
+    #[cfg(any(
+        all(
+            target_os = "linux",
+            target_env = "gnu",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ),
+        all(target_os = "windows", target_env = "gnu", target_arch = "x86_64")
+    ))]
+    fn github_provider_resolves_just_via_abi_fallback() {
+        let mut cgx = Cgx::with_test_fs();
+
+        let (assert, messages) = cgx
+            .cmd
+            .with_json_messages()
+            .arg("--prebuilt-binary")
+            .arg("always")
+            .arg("--prebuilt-binary-sources")
+            .arg("github-releases")
+            .arg("just@=1.42.4")
+            .arg("--version")
+            .assert_with_messages();
+
+        assert.success().stdout(predicates::str::contains("just 1.42.4"));
+
+        let binary = messages
+            .iter()
+            .find_map(|m| match m {
+                Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { binary }) => Some(binary),
+                _ => None,
+            })
+            .expect("Expected PrebuiltBinaryMessage::Resolved");
+        assert_eq!(binary.provider, BinaryProvider::GithubReleases);
+
+        assert!(
+            !messages
+                .iter()
+                .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+            "Should not have BuildMessage::Started when using prebuilt binary"
+        );
+    }
+
+    /// Test the Apple Silicon Rosetta 2 fallback: on `aarch64-apple-darwin`, an
+    /// `x86_64-apple-darwin` binary is an ABI-compatible fallback only when Rosetta 2 is installed.
+    ///
+    /// ripgrep 13.0.0 publishes only `x86_64-apple-darwin` for macOS (no `aarch64-apple-darwin`, no
+    /// `universal`), so it is resolvable on Apple Silicon exactly when Rosetta is available. This
+    /// test is self-adapting: it probes the ground-truth Rosetta state itself (independently of
+    /// cgx's own probe) and asserts cgx agrees. The nightly full-platform workflow installs Rosetta
+    /// and re-runs the prebuilt tests to exercise the positive branch; per-PR runners typically
+    /// lack Rosetta and exercise the negative branch. Unit tests cover both branches
+    /// deterministically.
+    #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn github_provider_resolves_ripgrep_13_via_rosetta_when_available() {
+        // Ground truth, independent of cgx's own probe: can this host run an x86_64 macOS binary?
+        let rosetta_available = std::process::Command::new("arch")
+            .args(["-arch", "x86_64", "/usr/bin/true"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success());
+
+        if rosetta_available {
+            let mut cgx = Cgx::with_test_fs();
+            let (assert, messages) = cgx
+                .cmd
+                .with_json_messages()
+                .arg("--prebuilt-binary")
+                .arg("always")
+                .arg("--prebuilt-binary-sources")
+                .arg("github-releases")
+                .arg("ripgrep@=13.0.0")
+                .arg("--version")
+                .assert_with_messages();
+
+            assert
+                .success()
+                .stdout(predicates::str::contains("ripgrep 13.0.0"));
+
+            let binary = messages
+                .iter()
+                .find_map(|m| match m {
+                    Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { binary }) => Some(binary),
+                    _ => None,
+                })
+                .expect("Expected PrebuiltBinaryMessage::Resolved when Rosetta is available");
+            assert_eq!(binary.provider, BinaryProvider::GithubReleases);
+
+            // The resolved asset must be the x86_64 (Rosetta) fallback, not an aarch64 asset.
+            assert!(
+                messages.iter().any(|m| matches!(
+                    m,
+                    Message::PrebuiltBinary(PrebuiltBinaryMessage::DownloadingBinary { url, .. })
+                        if url.contains("x86_64-apple-darwin")
+                )),
+                "Expected the downloaded asset URL to contain x86_64-apple-darwin"
+            );
+
+            assert!(
+                !messages
+                    .iter()
+                    .any(|m| matches!(m, Message::Build(BuildMessage::Started { .. }))),
+                "Should not have BuildMessage::Started when using prebuilt binary"
+            );
+        } else {
+            // Without Rosetta, x86_64 macOS binaries are not runnable, so the x86_64 fallback must
+            // NOT be offered and `always` mode must fail with no binary found.
+            let mut cgx = Cgx::with_test_fs();
+            let (assert, messages) = cgx
+                .cmd
+                .with_json_messages()
+                .arg("--prebuilt-binary")
+                .arg("always")
+                .arg("--prebuilt-binary-sources")
+                .arg("github-releases")
+                .arg("--no-exec")
+                .arg("ripgrep@=13.0.0")
+                .assert_with_messages();
+
+            assert.failure();
+
+            assert!(
+                messages.iter().any(|m| matches!(
+                    m,
+                    Message::PrebuiltBinary(PrebuiltBinaryMessage::ProviderHasNoBinary {
+                        provider: BinaryProvider::GithubReleases,
+                        ..
+                    })
+                )),
+                "Expected ProviderHasNoBinary for GithubReleases without Rosetta"
+            );
+
+            assert!(
+                !messages
+                    .iter()
+                    .any(|m| matches!(m, Message::PrebuiltBinary(PrebuiltBinaryMessage::Resolved { .. }))),
+                "Should not resolve an x86_64 macOS binary without Rosetta"
+            );
+        }
+    }
+
+    /// Test the macOS `universal-apple-darwin` fallback path — currently BLOCKED by issue #239.
+    ///
+    /// cargo-nextest 0.9.100 publishes only a `universal-apple-darwin` fat binary for macOS, which
+    /// a universal fallback token would match. But its GitHub release is tagged
+    /// `cargo-nextest-0.9.100`, and the GitHub provider today only tries the `v{version}` and
+    /// `{version}` tag forms, so it never finds the release and resolution fails before any asset
+    /// is matched.
+    ///
+    /// This test asserts the current (incorrect) blocked behavior as a tripwire. Once
+    /// https://github.com/anelson/cgx/issues/239 adds `{crate}-{version}` tag matching, cgx will
+    /// find the `cargo-nextest-0.9.100` release and match its
+    /// `cargo-nextest-0.9.100-universal-apple-darwin.tar.gz` asset via the `universal-apple-darwin`
+    /// compatible-target name. When that lands, this assertion must flip: the command should
+    /// `.success()` with `Resolved { provider: GithubReleases }` and a `DownloadingBinary` URL
+    /// containing `universal-apple-darwin`. (The universal fallback itself is already proven by the
+    /// `target.rs` and `providers` unit tests; #239 only unblocks the end-to-end path.)
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn github_provider_universal_nextest_blocked_by_239() {
+        let mut cgx = Cgx::with_test_fs();
+
+        let (assert, _messages) = cgx
+            .cmd
+            .with_json_messages()
+            .arg("--prebuilt-binary")
+            .arg("always")
+            .arg("--prebuilt-binary-sources")
+            .arg("github-releases")
+            .arg("--no-exec")
+            .arg("cargo-nextest@=0.9.100")
+            .assert_with_messages();
+
+        // BLOCKED by #239: the `cargo-nextest-0.9.100` release tag is not matched, so no binary is
+        // found and `always` mode fails. Flip to `.success()` (see doc comment) once #239 lands.
+        assert.failure();
     }
 }
 
@@ -1079,11 +1269,13 @@ fn default_resolves_via_binstall() {
 ///
 /// eza 0.23.1 published GitHub release assets for Linux GNU, x86_64 Linux musl, and
 /// `x86_64-pc-windows-gnu` only (no macOS, no windows-msvc, no aarch64 Linux musl). On
-/// aarch64 Linux musl, default resolution falls through to Quickinstall.
+/// aarch64 Linux musl, default resolution falls through to Quickinstall. On
+/// `x86_64-pc-windows-msvc` GitHub resolves via the ABI-compatible `x86_64-pc-windows-gnu` fallback
+/// asset.
 #[test]
 #[cfg(any(
     all(target_os = "linux", not(all(target_arch = "aarch64", target_env = "musl"))),
-    all(target_os = "windows", target_env = "gnu")
+    all(target_os = "windows", target_arch = "x86_64")
 ))]
 fn default_resolves_via_github() {
     let mut cgx = Cgx::with_test_fs();

--- a/cgx/tests/integration/prebuilt_binaries.rs
+++ b/cgx/tests/integration/prebuilt_binaries.rs
@@ -891,6 +891,24 @@ mod github_releases {
             .expect("Expected PrebuiltBinaryMessage::Resolved");
         assert_eq!(binary.provider, BinaryProvider::GithubReleases);
 
+        // The provenance report must name the ABI-compatible target that actually matched (just
+        // 1.42.4 ships only musl Linux and msvc Windows assets)
+        #[cfg(target_os = "linux")]
+        let expected_target = format!("{}-unknown-linux-musl", std::env::consts::ARCH);
+        #[cfg(target_os = "windows")]
+        let expected_target = "x86_64-pc-windows-msvc".to_string();
+
+        let target_platform = messages
+            .iter()
+            .find_map(|m| match m {
+                Message::Cgx(cgx::messages::CgxMessage::CrateProvenance { target_platform, .. }) => {
+                    Some(target_platform)
+                }
+                _ => None,
+            })
+            .expect("Expected CgxMessage::CrateProvenance");
+        assert_eq!(target_platform, &expected_target);
+
         assert!(
             !messages
                 .iter()

--- a/deny.toml
+++ b/deny.toml
@@ -75,11 +75,9 @@ skip = [
   # rustls-native-certs. Unavoidable until upstreams converge or we change
   # reqwest's TLS backend.
   { name = "openssl-probe", version = "0.1.6" },
-  # windows-sys 0.59 is pulled by etcetera 0.10 and home 0.5.11, while the rest
-  # of the tree is on 0.61. The releases that move both to windows-sys 0.61
-  # (etcetera 0.11, home 0.5.12) require rustc 1.87/1.88 respectively, above our
-  # 1.85.1 MSRV. Revisit when we raise the MSRV.
-  { name = "windows-sys", version = "0.59" },
+  # leon/miette still use unicode-width 0.1, while clap and test-only httpmock
+  # use unicode-width 0.2. No current update on Rust 1.85.1 converges these.
+  { name = "unicode-width", version = "0.1.14" },
 ]
 skip-tree = [
   # vergen-gix (build dep) uses older gix 0.71


### PR DESCRIPTION
This introduces a new module `target` and a type `TargetTriple`, which represents a possible binary target.  This also exposes helpers to get the alternative targets that a given target is ABI-compatible with, as well as pseudo-targets that Rust doesn't recognize but that appear in artifact names in some cases.

It also modifies all of the `bin_resolver` providers to take advantage of this information when looking for prebuilt binaries.  Now prebuilt binary resolution should be successful for many more cases.

Closes #107 