### PR TITLE
ci: Automate updating README when releasing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           if [[ "${{ github.head_ref }}" == release-plz-* ]]; then
             echo "is-release-plz=true" >> $GITHUB_OUTPUT
             echo "is-dependabot=false" >> $GITHUB_OUTPUT
-            echo "Detected release-plz PR - will use cargo check only"
+            echo "Detected release-plz PR - will check compilation and the README release version"
           elif [ "${{ github.actor }}" == "dependabot[bot]" ]; then
             echo "is-release-plz=false" >> $GITHUB_OUTPUT
             echo "is-dependabot=true" >> $GITHUB_OUTPUT
@@ -158,12 +158,11 @@ jobs:
 
   # Stage 1c: Minimal check for release-plz PRs (Linux amd64 only)
   # Release-plz PRs only edit Cargo.toml version numbers, Cargo.lock entries for
-  # those bumps, and CHANGELOG.md. They cannot change source code. A
-  # single `cargo check` is sufficient to catch the one real failure
-  # mode: a lockfile resolution that pulls in some dependency version
-  # that breaks the build, most likely because the new version's MSRV exceeds
-  # our pinned toolchain.  No other checks are needed, as the `master` branch
-  # upon which the release-plz branch is based is assumed to be green.
+  # those bumps, CHANGELOG.md, and the release reference in README.md. They
+  # cannot change source code. A `cargo check` catches lockfile resolution
+  # failures, while cargo-release verifies that the README version matches the
+  # bumped manifest. No other checks are needed, as the `master` branch upon
+  # which the release-plz branch is based is assumed to be green.
   release-plz-check:
     name: Release-plz Check (Linux amd64)
     needs: detect-pr-type
@@ -174,6 +173,11 @@ jobs:
 
       - *install-rust
 
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2.83.2
+        with:
+          tool: cargo-release@1.1.3
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: x86_64-unknown-linux-gnu
@@ -182,6 +186,11 @@ jobs:
 
       - name: Check compilation
         run: cargo check --workspace --all-targets
+
+      - name: Check README release version
+        run: |
+          cargo release replace --package cgx --execute --no-confirm
+          git diff --exit-code -- README.md
 
   # Stage 1: Lint and Format Check on Linux amd64, which is the cheapest and quickest build for us
   lint:
@@ -205,6 +214,11 @@ jobs:
         uses: taiki-e/install-action@v2.85.2
         with:
           tool: just
+
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2.83.2
+        with:
+          tool: cargo-release@1.1.3
 
       - name: Install taplo
         uses: taiki-e/install-action@v2.85.2
@@ -234,6 +248,11 @@ jobs:
 
       - name: Check TOML formatting
         run: taplo fmt --check
+
+      - name: Check README release version
+        run: |
+          cargo release replace --package cgx --execute --no-confirm
+          git diff --exit-code -- README.md
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2.85.2
@@ -440,12 +459,12 @@ jobs:
           IS_RELEASE_PLZ="${{ needs.detect-pr-type.outputs.is-release-plz }}"
 
           if [ "$IS_RELEASE_PLZ" == "true" ]; then
-            echo "Checking release-plz fast-path..."
+            echo "Checking release-plz compilation and README version fast-path..."
             if [ "${{ needs.release-plz-check.result }}" != "success" ]; then
               echo "Release-plz check failed"
               exit 1
             fi
-            echo "Release-plz check passed"
+            echo "Release-plz compilation and README version checks passed"
           elif [ "$IS_DEPENDABOT" == "true" ]; then
             echo "Checking minimal CI for dependabot PR..."
             # For dependabot PRs, only check the minimal jobs

--- a/.github/workflows/full-platform-tests.yml
+++ b/.github/workflows/full-platform-tests.yml
@@ -266,7 +266,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2.83.2
+        with:
+          tool: cargo-release@1.1.3
+
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5.131
         with:
           command: release-pr
@@ -277,3 +283,33 @@ jobs:
           # which would leave the release PR with no CI checks and therefore
           # unmergeable under the required-status branch protection.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Update README release version
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          RELEASE_PLZ_BRANCH: ${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}
+        run: |
+          git fetch origin "$RELEASE_PLZ_BRANCH"
+          remote_head="$(git rev-parse FETCH_HEAD)"
+          git checkout -B "$RELEASE_PLZ_BRANCH" "$remote_head"
+
+          cargo release replace --package cgx --execute --no-confirm
+
+          changes="$(git status --porcelain=v1 --untracked-files=all)"
+          if [ -z "$changes" ]; then
+            echo "README release version already matches the cgx manifest."
+            exit 0
+          fi
+
+          if [ "$changes" != " M README.md" ]; then
+            echo "cargo-release changed unexpected files:"
+            echo "$changes"
+            exit 1
+          fi
+
+          git add -- README.md
+          git commit --amend --no-edit
+          git push \
+            --force-with-lease="refs/heads/$RELEASE_PLZ_BRANCH:$remote_head" \
+            origin \
+            "HEAD:refs/heads/$RELEASE_PLZ_BRANCH"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/anelson/cgx/releas
 The installer will download the appropriate binary for your platform and add it to your PATH.
 
 > **Note:** To install a specific version for CI/reproducible builds, replace `latest` in the URL above with the desired
-> version tag from the [Releases page](https://github.com/anelson/cgx/releases), such as `v0.0.10`.
+> version tag from the [Releases page](https://github.com/anelson/cgx/releases), such as `v0.1.0`.
 
 ### Alternative Installation Methods
 

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,11 @@
+allow-branch = ["*"]
+publish      = false
+push         = false
+tag          = false
+
+[[pre-release-replacements]]
+exactly    = 1
+file       = "../README.md"
+prerelease = true
+replace    = "${prefix}{{version}}${suffix}"
+search     = '(?P<prefix>^> version tag from the \[Releases page\]\(https://github\.com/anelson/cgx/releases\), such as `v)(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)(?:-(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?P<suffix>`\.$)'


### PR DESCRIPTION
I noticed that the README referred to old releases, because there's no automated mechanism to update it when we make a new release.  This is an attempt to incorporate that automation as part of the existing release-plz workflow that updates the changelog and Cargo.toml version numbers.

I haven't tested it yet; it needs to be committed and run in GHA in order to see if it works.

- Added release.toml using cargo-release to synchronize exactly one README installer-version reference with the cgx package version.
- Pinned cargo-release 1.1.3 in CI.
- Added README version validation to regular and release-plz PR checks.
- Updated release-plz PR generation to amend and safely force-push README updates.
- Updated the installer example from v0.0.10 to v0.1.0.
- Verified with just precommit, just xwin-check, and just xmac-check.

Closes #181 