### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.1] - 2026-08-22
+
+### ⚙️ Miscellaneous Tasks
+
+- Update Cargo.toml dependencies
+- Update Cargo.lock dependencies
 
 ## [0.1.0] - 2026-08-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-cgx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "cgx",
@@ -491,7 +491,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert-json-diff",
  "assert_cmd",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "cgx-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert-json-diff",
  "assert_matches",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ build-context      = "0.1.4"
 bytes              = "1"
 bzip2              = "0.6.1"
 cargo_metadata     = "0.20.0"
-cgx                = { version = "0.1.0", path = "cgx" }
-cgx-core           = { version = "0.1.0", path = "cgx-core" }
+cgx                = { version = "0.1.1", path = "cgx" }
+cgx-core           = { version = "0.1.1", path = "cgx-core" }
 chrono             = { version = "0.4.44", features = ["serde"] }
 clap               = { version = "4.6.1", features = ["derive", "env", "string", "unicode"] }
 ctrlc              = "3.5"

--- a/cargo-cgx/Cargo.toml
+++ b/cargo-cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cargo-cgx"
 readme                 = "README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.1.0"
+version                = "0.1.1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cgx-core/Cargo.toml
+++ b/cgx-core/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx-core"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.1.0"
+version                = "0.1.1"
 
 [package.metadata.cargo-machete]
 ignored = [

--- a/cgx/Cargo.toml
+++ b/cgx/Cargo.toml
@@ -9,7 +9,7 @@ name                   = "cgx"
 readme                 = "../README.md"
 repository.workspace   = true
 rust-version.workspace = true
-version                = "0.1.0"
+version                = "0.1.1"
 
 [badges]
 maintenance = { status = "experimental" }


### PR DESCRIPTION



## 🤖 New release

* `cgx-core`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `cgx`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `cargo-cgx`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `cgx`

<blockquote>

## [0.1.1] - 2026-08-22

### ⚙️ Miscellaneous Tasks

- Update Cargo.toml dependencies
- Update Cargo.lock dependencies
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).